### PR TITLE
feat: `<provider> info` reports cores/memory/storage on all four providers

### DIFF
--- a/.github/workflows/smoke-test.yml
+++ b/.github/workflows/smoke-test.yml
@@ -127,6 +127,18 @@ jobs:
           echo "SSM connectivity: FAIL after 18 attempts (~6 minutes)"
           exit 1
 
+      - name: Test info command
+        run: |
+          OUT=$(uv run remo aws info --name "$INSTANCE_NAME")
+          echo "$OUT"
+          echo "$OUT" | grep -q "Instance ID:" || { echo "FAIL: missing Instance ID"; exit 1; }
+          echo "$OUT" | grep -q "State:"       || { echo "FAIL: missing State"; exit 1; }
+          echo "$OUT" | grep -q "Type:"        || { echo "FAIL: missing Type"; exit 1; }
+          echo "$OUT" | grep -q "Cores:"       || { echo "FAIL: missing Cores"; exit 1; }
+          echo "$OUT" | grep -q "Memory:"      || { echo "FAIL: missing Memory"; exit 1; }
+          echo "$OUT" | grep -q "EBS volume:"  || { echo "FAIL: missing EBS volume"; exit 1; }
+          echo "aws info: PASS"
+
       - name: Teardown
         if: always()
         run: |
@@ -192,6 +204,18 @@ jobs:
               -i ~/.ssh/id_rsa \
               "remo@$HOST" echo "connection-ok" | grep -q "connection-ok"
           echo "SSH connectivity: PASS"
+
+      - name: Test info command
+        run: |
+          OUT=$(uv run remo hetzner info --name "$INSTANCE_NAME")
+          echo "$OUT"
+          echo "$OUT" | grep -q "Server ID:"   || { echo "FAIL: missing Server ID"; exit 1; }
+          echo "$OUT" | grep -q "State:"       || { echo "FAIL: missing State"; exit 1; }
+          echo "$OUT" | grep -q "Type:"        || { echo "FAIL: missing Type"; exit 1; }
+          echo "$OUT" | grep -q "Cores:"       || { echo "FAIL: missing Cores"; exit 1; }
+          echo "$OUT" | grep -q "Memory:"      || { echo "FAIL: missing Memory"; exit 1; }
+          echo "$OUT" | grep -q "Volume:"      || { echo "FAIL: missing Volume"; exit 1; }
+          echo "hetzner info: PASS"
 
       - name: Teardown
         if: always()
@@ -268,6 +292,17 @@ jobs:
               -i ~/.ssh/id_rsa \
               "remo@$HOST" echo "connection-ok" | grep -q "connection-ok"
           echo "Incus connectivity: PASS"
+
+      - name: Test info command
+        run: |
+          OUT=$(sg incus-admin -c "uv run remo incus info --name $CONTAINER_NAME")
+          echo "$OUT"
+          echo "$OUT" | grep -q "State:"     || { echo "FAIL: missing State"; exit 1; }
+          echo "$OUT" | grep -q "IP:"        || { echo "FAIL: missing IP"; exit 1; }
+          echo "$OUT" | grep -q "Cores:"     || { echo "FAIL: missing Cores"; exit 1; }
+          echo "$OUT" | grep -q "Memory:"    || { echo "FAIL: missing Memory"; exit 1; }
+          echo "$OUT" | grep -q "Root size:" || { echo "FAIL: missing Root size"; exit 1; }
+          echo "incus info: PASS"
 
       - name: Verify dev tools
         run: |

--- a/README.md
+++ b/README.md
@@ -148,6 +148,7 @@ remo init                           # Install Ansible collections
 # Hetzner Cloud
 remo hetzner create                 # Provision VM
 remo hetzner list                   # List registered VMs
+remo hetzner info [--name N]        # Show type, cores, memory, volume size
 remo hetzner sync                   # Discover existing VMs
 remo hetzner update                 # Update dev tools
 remo hetzner update --volume-size 100   # Grow persistent volume + FS
@@ -164,11 +165,12 @@ remo aws stop [--yes]               # Stop instance (pause billing)
 remo aws start                      # Start a stopped instance
 remo aws reboot                     # Reboot instance
 remo aws destroy [--yes]            # Tear down (keeps storage)
-remo aws info                       # Show instance info
+remo aws info [--name N]            # Show type, cores, memory, EBS size
 
 # Incus Containers
 remo incus create --name <n> [--host H]  # Create container
 remo incus list                     # List registered containers
+remo incus info --name <n>          # Show cores, memory, root size
 remo incus sync [--host H]          # Discover existing containers
 remo incus update --name <n>        # Update dev tools
 remo incus update --name <n> --volume-size 40 --cores 4 --memory 4096
@@ -178,6 +180,7 @@ remo incus bootstrap                # Initialize Incus on host
 # Proxmox VE LXC Containers
 remo proxmox create --name <n> --host <node>  # Create LXC container
 remo proxmox list                   # List registered containers
+remo proxmox info --name <n>        # Show cores, memory, rootfs size
 remo proxmox sync --host <node>     # Discover existing containers
 remo proxmox update --name <n>      # Update dev tools
 remo proxmox update --name <n> --volume-size 40 --cores 4 --memory 4096

--- a/docs/aws.md
+++ b/docs/aws.md
@@ -71,7 +71,7 @@ remo aws update --skip docker --skip nodejs
 # Grow the persistent EBS volume (and the filesystem) in place
 remo aws update --volume-size 100
 
-# Show instance information
+# Show instance information (type, cores, memory, EBS volume size)
 remo aws info
 
 # Stop instance (pause billing, keep storage)

--- a/docs/hetzner.md
+++ b/docs/hetzner.md
@@ -57,6 +57,9 @@ remo hetzner update --skip docker --skip nodejs
 # Grow the persistent volume (and the filesystem) in place
 remo hetzner update --volume-size 100
 
+# Inspect resources on an existing server (type, cores, memory, volume size)
+remo hetzner info
+
 # Destroy server (keeps persistent volume)
 remo hetzner destroy --yes
 

--- a/docs/incus.md
+++ b/docs/incus.md
@@ -65,6 +65,9 @@ remo incus destroy dev1 --host myserver --user paul --yes --remove-storage
 
 # Bootstrap Incus on a host
 remo incus bootstrap --host myserver --user paul
+
+# Inspect resources on an existing container
+remo incus info --name dev1
 ```
 
 ### Create Options

--- a/docs/proxmox.md
+++ b/docs/proxmox.md
@@ -72,6 +72,9 @@ remo proxmox destroy --name dev1 --yes --purge
 
 # Bootstrap (verify) a Proxmox node
 remo proxmox bootstrap --host prox01 --user root
+
+# Inspect resources on an existing container (cores, memory, rootfs size)
+remo proxmox info --name dev1
 ```
 
 ### Create Options

--- a/src/remo_cli/cli/providers/hetzner.py
+++ b/src/remo_cli/cli/providers/hetzner.py
@@ -108,6 +108,16 @@ def list_cmd() -> None:
 
 
 @hetzner.command()
+@click.option("--name", default="", help="Server name (default: remote-coding-server).")
+def info(name: str) -> None:
+    """Show resource details (type, cores, memory, volume size) for a Hetzner VM."""
+    from remo_cli.providers.hetzner import info as do_info
+
+    rc = do_info(name=name)
+    sys.exit(rc)
+
+
+@hetzner.command()
 def sync() -> None:
     """Discover VMs and update registry."""
     from remo_cli.providers.hetzner import sync as do_sync

--- a/src/remo_cli/cli/providers/incus.py
+++ b/src/remo_cli/cli/providers/incus.py
@@ -160,6 +160,16 @@ def list_cmd() -> None:
 
 
 @incus.command()
+@click.option("--name", default="dev1", help="Container name (default: dev1).")
+@click.option("--host", default="", help="Incus host (default: auto-detect).")
+@click.option("--user", default="", help="SSH user for remote Incus host.")
+def info(name: str, host: str, user: str) -> None:
+    """Show resource details (cores, memory, root size) for an Incus container."""
+    rc = providers_incus.info(name=name, host=host, user=user)
+    sys.exit(rc)
+
+
+@incus.command()
 @click.option("--host", default="localhost", help="Incus host (default: localhost).")
 @click.option("--user", default="", help="SSH user for remote Incus host.")
 def sync(host: str, user: str) -> None:

--- a/src/remo_cli/cli/providers/proxmox.py
+++ b/src/remo_cli/cli/providers/proxmox.py
@@ -166,6 +166,16 @@ def list_cmd() -> None:
 
 
 @proxmox.command()
+@click.option("--name", default="dev1", help="Container hostname.")
+@click.option("--host", default="", help="Proxmox host (default: auto-detect).")
+@click.option("--user", default="", help="SSH user for the Proxmox host.")
+def info(name: str, host: str, user: str) -> None:
+    """Show resource details (cores, memory, rootfs) for a Proxmox container."""
+    rc = providers_proxmox.info(name=name, host=host, user=user)
+    sys.exit(rc)
+
+
+@proxmox.command()
 @click.option("--host", required=True, help="Proxmox host to scan.")
 @click.option("--user", default="", help="SSH user for the Proxmox host.")
 def sync(host: str, user: str) -> None:

--- a/src/remo_cli/providers/aws.py
+++ b/src/remo_cli/providers/aws.py
@@ -955,6 +955,41 @@ def info(name: str = "") -> None:
     tags = {t["Key"]: t["Value"] for t in instance.get("Tags", [])}
     access_mode = tags.get("remo_access_mode", "ssm")
 
+    # Best-effort lookup of vCPU / memory from the instance type spec.
+    cores: str = "?"
+    memory_mib: str = "?"
+    try:
+        session = _boto3_session(region)
+        type_resp = session.client("ec2").describe_instance_types(
+            InstanceTypes=[instance_type]
+        )
+        type_info = (type_resp.get("InstanceTypes") or [{}])[0]
+        vcpu_info = type_info.get("VCpuInfo") or {}
+        memory_info = type_info.get("MemoryInfo") or {}
+        if vcpu_info.get("DefaultVCpus"):
+            cores = str(vcpu_info["DefaultVCpus"])
+        if memory_info.get("SizeInMiB"):
+            memory_mib = str(memory_info["SizeInMiB"])
+    except Exception:
+        # Non-fatal — fall back to '?'.
+        pass
+
+    # Best-effort lookup of the persistent EBS volume size.
+    ebs_size: str = "(none)"
+    try:
+        ebs_name = f"remo-{resource_name}-home"
+        ebs_resp = session.client("ec2").describe_volumes(
+            Filters=[
+                {"Name": "tag:Name", "Values": [ebs_name]},
+                {"Name": "tag:remo", "Values": ["true"]},
+            ],
+        )
+        volumes = ebs_resp.get("Volumes", [])
+        if volumes:
+            ebs_size = f"{volumes[0].get('Size', '?')} GB ({ebs_name})"
+    except Exception:
+        pass
+
     print("")
     print(f"  Name:         remo-{resource_name}")
     print(f"  Instance ID:  {instance_id}")
@@ -965,6 +1000,9 @@ def info(name: str = "") -> None:
     print(f"  Public DNS:   {public_dns}")
     print(f"  Launch Time:  {launch_time}")
     print(f"  Access Mode:  {access_mode}")
+    print(f"  Cores:        {cores}")
+    print(f"  Memory:       {memory_mib} MiB")
+    print(f"  EBS volume:   {ebs_size}")
     print("")
 
     # Register in known_hosts if not already present.

--- a/src/remo_cli/providers/hetzner.py
+++ b/src/remo_cli/providers/hetzner.py
@@ -275,6 +275,76 @@ def list_hosts() -> None:
         print("Create one with: remo hetzner create")
 
 
+def info(name: str = "") -> int:
+    """Print detailed information about a Hetzner Cloud server.
+
+    Queries the Hetzner API for the server (type, status, IP) and its
+    paired ``<name>-home`` volume (size). Requires ``HETZNER_API_TOKEN``.
+    Returns 0 on success or 1 on failure.
+    """
+    token = os.environ.get("HETZNER_API_TOKEN", "")
+    if not token:
+        print_error("HETZNER_API_TOKEN is not set.")
+        return 1
+
+    server_name = name or "remote-coding-server"
+
+    server_url = f"https://api.hetzner.cloud/v1/servers?name={server_name}"
+    server_req = urllib.request.Request(
+        server_url,
+        headers={"Authorization": f"Bearer {token}"},
+    )
+    try:
+        with urllib.request.urlopen(server_req, timeout=15) as resp:
+            server_data = json.loads(resp.read().decode())
+    except urllib.error.URLError as e:
+        print_error(f"Hetzner API request failed: {e}")
+        return 1
+
+    servers = server_data.get("servers", [])
+    if not servers:
+        print_error(f"No Hetzner server found with name '{server_name}'.")
+        return 1
+
+    server = servers[0]
+    server_type = server.get("server_type") or {}
+    public_net = server.get("public_net") or {}
+    ipv4 = (public_net.get("ipv4") or {}).get("ip", "")
+    location = (server.get("datacenter") or {}).get("location", {}).get("name", "")
+
+    volume_name = f"{server_name}-home"
+    volume_url = f"https://api.hetzner.cloud/v1/volumes?name={volume_name}"
+    volume_req = urllib.request.Request(
+        volume_url,
+        headers={"Authorization": f"Bearer {token}"},
+    )
+    volume_size = ""
+    try:
+        with urllib.request.urlopen(volume_req, timeout=15) as resp:
+            volume_data = json.loads(resp.read().decode())
+        volumes = volume_data.get("volumes", [])
+        if volumes:
+            volume_size = f"{volumes[0].get('size', '?')} GB"
+    except urllib.error.URLError:
+        # Volume lookup is best-effort; don't fail the whole info call.
+        pass
+
+    print("")
+    print(f"  Name:          {server.get('name', server_name)}")
+    print(f"  Server ID:     {server.get('id', '?')}")
+    print(f"  State:         {server.get('status', 'unknown')}")
+    print(f"  Type:          {server_type.get('name', '?')}")
+    print(f"  Location:      {location or '?'}")
+    print(f"  Public IPv4:   {ipv4 or '(unavailable)'}")
+    print(f"  Cores:         {server_type.get('cores', '?')}")
+    print(f"  Memory:        {server_type.get('memory', '?')} GB")
+    print(f"  Server disk:   {server_type.get('disk', '?')} GB (ephemeral; tied to instance)")
+    print(f"  Volume:        {volume_size or '(none attached)'} ({volume_name})")
+    print("")
+
+    return 0
+
+
 def sync() -> None:
     """Discover Hetzner VMs with the ``remo`` label and update the registry.
 

--- a/src/remo_cli/providers/incus.py
+++ b/src/remo_cli/providers/incus.py
@@ -398,6 +398,89 @@ def list_hosts() -> None:
         print("Create one with: remo incus create <name>")
 
 
+def info(name: str, host: str = "", user: str = "") -> int:
+    """Print detailed information about an Incus container.
+
+    Runs ``incus list <name> --format=json`` (locally or via SSH on the
+    Incus host) and reports state, IP, CPU limit, memory limit, and root
+    disk size. Returns 0 on success or 1 if the container could not be
+    located.
+    """
+    import json
+
+    validate_name(name, "container name")
+
+    if not host:
+        host, looked_up_user = _lookup_incus_host(name)
+        if not user and looked_up_user:
+            user = looked_up_user
+
+    if not host:
+        host = "localhost"
+
+    incus_cmd = f"incus list '{name}' --format=json"
+    if host == "localhost":
+        result = subprocess.run(
+            ["incus", "list", name, "--format=json"],
+            capture_output=True,
+            text=True,
+        )
+    else:
+        ssh_target = f"{user}@{host}" if user else host
+        result = subprocess.run(
+            ["ssh", "-o", "ConnectTimeout=10", ssh_target, incus_cmd],
+            capture_output=True,
+            text=True,
+        )
+
+    if result.returncode != 0:
+        print_error(
+            f"Failed to query container '{name}' on '{host}': {result.stderr.strip()}"
+        )
+        return 1
+
+    try:
+        containers = json.loads(result.stdout)
+    except json.JSONDecodeError:
+        print_error(f"Could not parse incus output for '{name}'.")
+        return 1
+
+    if not containers:
+        print_error(f"Container '{name}' was not found on Incus host '{host}'.")
+        return 1
+
+    container = containers[0]
+    state = container.get("status", "unknown")
+    expanded_config = container.get("expanded_config") or {}
+    expanded_devices = container.get("expanded_devices") or {}
+
+    cpu_limit = expanded_config.get("limits.cpu", "")
+    memory_limit = expanded_config.get("limits.memory", "")
+    root_device = expanded_devices.get("root") or {}
+    root_size = root_device.get("size", "")
+    root_pool = root_device.get("pool", "")
+
+    container_ip = ""
+    network = (container.get("state") or {}).get("network") or {}
+    eth0 = network.get("eth0") or {}
+    for addr in eth0.get("addresses", []):
+        if addr.get("family") == "inet":
+            container_ip = addr.get("address", "")
+            break
+
+    print("")
+    print(f"  Name:       {name}")
+    print(f"  Incus host: {host}")
+    print(f"  State:      {state}")
+    print(f"  IP:         {container_ip or '(unavailable)'}")
+    print(f"  Cores:      {cpu_limit or '(profile default)'}")
+    print(f"  Memory:     {memory_limit or '(profile default)'}")
+    print(f"  Root size:  {root_size or '(profile default)'}{f' ({root_pool})' if root_pool else ''}")
+    print("")
+
+    return 0
+
+
 def sync(host: str = "localhost", user: str = "") -> None:
     """Discover Incus containers on *host* and register them in known-hosts.
 

--- a/src/remo_cli/providers/proxmox.py
+++ b/src/remo_cli/providers/proxmox.py
@@ -450,6 +450,95 @@ def list_hosts() -> None:
         print("Create one with: remo proxmox create <name> --host <node>")
 
 
+def info(name: str, host: str = "", user: str = "") -> int:
+    """Print detailed information about a Proxmox LXC container.
+
+    Reads ``pct config`` and ``pct status`` over SSH on the Proxmox host,
+    then prints state, network, CPU, memory, and rootfs details. Returns
+    0 on success or 1 if the container could not be located.
+    """
+    validate_name(name, "container name")
+
+    vmid = ""
+    if not host:
+        host, looked_up_user, vmid = _lookup_proxmox_host(name)
+        if not user and looked_up_user:
+            user = looked_up_user
+
+    if not host:
+        print_error(
+            f"Proxmox host for container '{name}' could not be determined.\n"
+            "Use --host (and --user) to specify it explicitly."
+        )
+        return 1
+
+    if not user:
+        user = "root"
+
+    if not vmid:
+        vmid = _resolve_vmid(name, host, user)
+    if not vmid:
+        print_error(f"Container '{name}' was not found on Proxmox host '{host}'.")
+        return 1
+
+    # Single SSH round-trip: combine config + status.
+    cmd = f"pct config {vmid}; echo ---STATUS---; pct status {vmid}"
+    result = _ssh_run(host, user, cmd)
+    if result.returncode != 0:
+        print_error(
+            f"Failed to query container '{name}' on '{host}': {result.stderr.strip()}"
+        )
+        return 1
+
+    config_text, _, status_text = result.stdout.partition("---STATUS---")
+
+    cores = _parse_pct_config_field(config_text, "cores")
+    memory = _parse_pct_config_field(config_text, "memory")
+    swap = _parse_pct_config_field(config_text, "swap")
+    hostname = _parse_pct_config_field(config_text, "hostname") or name
+    rootfs_line = _parse_pct_config_field(config_text, "rootfs")
+    rootfs_size = ""
+    rootfs_storage = ""
+    if rootfs_line:
+        # rootfs format: "vmpool:subvol-100-disk-0,size=20G"
+        rootfs_storage = rootfs_line.split(",", 1)[0]
+        size_match = re.search(r"size=(\S+)", rootfs_line)
+        if size_match:
+            rootfs_size = size_match.group(1)
+
+    state = ""
+    state_match = re.search(r"status:\s*(\S+)", status_text)
+    if state_match:
+        state = state_match.group(1)
+
+    container_ip = _resolve_container_ip(name, host, user, vmid=vmid)
+
+    print("")
+    print(f"  Name:       {hostname}")
+    print(f"  VMID:       {vmid}")
+    print(f"  Node:       {host}")
+    print(f"  State:      {state or 'unknown'}")
+    print(f"  IP:         {container_ip or '(unavailable)'}")
+    print(f"  Cores:      {cores or '?'}")
+    print(f"  Memory:     {memory + ' MiB' if memory else '?'}")
+    if swap:
+        print(f"  Swap:       {swap} MiB")
+    print(f"  Rootfs:     {rootfs_size or '?'}{f' ({rootfs_storage})' if rootfs_storage else ''}")
+    print("")
+
+    return 0
+
+
+def _parse_pct_config_field(config_text: str, field: str) -> str:
+    """Return the value of *field* from the output of ``pct config``.
+
+    Returns an empty string when the field is not present.
+    """
+    pattern = rf"^{re.escape(field)}:\s*(.+)$"
+    match = re.search(pattern, config_text, re.MULTILINE)
+    return match.group(1).strip() if match else ""
+
+
 def sync(host: str, user: str = "") -> None:
     """Discover Proxmox LXC containers on *host* and register them.
 


### PR DESCRIPTION
## Summary
Closes the reporting loop on v0.10.0's resize work. Before/after `update --volume-size` / `--cores` / `--memory`, users want to see the current provisioned values without dropping into `pct config` / `incus config show` / Hetzner console / AWS console.

- **proxmox info**: SSH to the Proxmox host, parse `pct config <vmid>` + `pct status <vmid>` in a single round-trip. Reports cores, memory, swap, rootfs size + storage backend, state, IP.
- **incus info**: run `incus list <name> --format=json` (locally or via SSH). Reports `limits.cpu`, `limits.memory`, root device size + pool, state, IP.
- **hetzner info**: query the Hetzner Cloud API for the server + matching `<name>-home` volume. Reports server type, cores, memory, ephemeral server disk, persistent volume size, state, IPv4.
- **aws info**: extend the existing command with EBS persistent-volume size and instance-type vCPU/memory (best-effort lookups via `describe_instance_types` and `describe_volumes` — fall back to `?` if a permission/lookup fails).

Storage *usage* (df-style used/avail) is intentionally out of scope — adding it would require an SSH round-trip into the AWS/Hetzner instances. Can revisit if it's actually needed.

## Test plan
- [x] Lint, unit tests (379), and per-provider `--help` all clean.
- [x] Verified live on lab1 `dev1`: single SSH call returns state, IP, cores, memory, swap, rootfs size + storage backend.
- [ ] Smoke tests in CI exercise the AWS/Hetzner/Incus paths (will run on this PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)