### PR TITLE
chore(devcontainer): bind-mount sibling site and remo-broker repos

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -40,7 +40,9 @@
         "source=${localEnv:HOME}/.config/gh,target=/home/vscode/.config/gh,type=bind,consistency=cached",
         "source=${localEnv:HOME}/.claude,target=/home/vscode/.claude,type=bind,consistency=cached",
 	"source=${localEnv:HOME}/.aws,target=/home/vscode/.aws,type=bind,consistency=cached",
-        "source=${localEnv:HOME}/.ssh,target=/home/vscode/.ssh,type=bind,consistency=cached"
+        "source=${localEnv:HOME}/.ssh,target=/home/vscode/.ssh,type=bind,consistency=cached",
+        "source=${localWorkspaceFolder}/../site,target=/workspaces/site,type=bind,consistency=cached",
+        "source=${localWorkspaceFolder}/../remo-broker,target=/workspaces/remo-broker,type=bind,consistency=cached"
     ],
     "postCreateCommand": "python3 --version && node --version"
 }


### PR DESCRIPTION
## Summary
- Add bind-mounts for `../site` and `../remo-broker` so the sibling repos are
  available inside this project's devcontainer.
- Enables cross-repo work without leaving the container: live edits to the
  Remo site (project page, blog) and the credential-broker Rust daemon.

## Test plan
- [ ] Rebuild the devcontainer; verify `/workspaces/site` and `/workspaces/remo-broker` appear and are writable.
- [ ] Confirm the mounts only take effect if the sibling directories exist on the host; no breakage for users without them (devcontainer should still launch — bind-mount of a missing source typically creates an empty target; if that surprises us, we'll convert to optional mounts in a follow-up).

🤖 Generated with [Claude Code](https://claude.com/claude-code)