### PR TITLE
chore: enforce 7-day supply-chain cooldown on dependencies

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -40,7 +40,9 @@
         "source=${localEnv:HOME}/.config/gh,target=/home/vscode/.config/gh,type=bind,consistency=cached",
         "source=${localEnv:HOME}/.claude,target=/home/vscode/.claude,type=bind,consistency=cached",
 	"source=${localEnv:HOME}/.aws,target=/home/vscode/.aws,type=bind,consistency=cached",
-        "source=${localEnv:HOME}/.ssh,target=/home/vscode/.ssh,type=bind,consistency=cached"
+        "source=${localEnv:HOME}/.ssh,target=/home/vscode/.ssh,type=bind,consistency=cached",
+        "source=${localWorkspaceFolder}/../site,target=/workspaces/site,type=bind,consistency=cached",
+        "source=${localWorkspaceFolder}/../remo-broker,target=/workspaces/remo-broker,type=bind,consistency=cached"
     ],
     "postCreateCommand": "python3 --version && node --version"
 }

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,6 +7,10 @@ updates:
       interval: "weekly"
       day: "monday"
     open-pull-requests-limit: 5
+    # Supply-chain cooldown: hold newly published versions for 7 days so a
+    # compromised release can be detected/yanked before it's proposed.
+    cooldown:
+      default-days: 7
     groups:
       # One PR per week with all minor/patch production deps bumped together.
       production-minor-patch:
@@ -29,8 +33,22 @@ updates:
       interval: "weekly"
       day: "monday"
     open-pull-requests-limit: 5
+    cooldown:
+      default-days: 7
     groups:
       actions:
         update-types:
           - "minor"
           - "patch"
+
+  # Docker base images (Dockerfile + notifier/Dockerfile)
+  - package-ecosystem: "docker"
+    directories:
+      - "/"
+      - "/notifier"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    open-pull-requests-limit: 5
+    cooldown:
+      default-days: 7

--- a/.github/workflows/smoke-test.yml
+++ b/.github/workflows/smoke-test.yml
@@ -803,6 +803,51 @@ jobs:
           $SSH_CMD "pkill -f 'python3 -m http.server 9090'" 2>/dev/null || true
           $SSH_CMD "pkill -f 'python3 -m http.server 3000'" 2>/dev/null || true
 
+      - name: Test remo shell -p / --exec / --detach (project-launch passthrough)
+        run: |
+          SSH_CMD="ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null \
+            -o ConnectTimeout=30 -o BatchMode=yes -i ~/.ssh/id_rsa remo@$HOST"
+
+          # Plant a project dir without a .devcontainer so we exercise the
+          # host-side branches of project-launch (no docker dance needed in CI).
+          $SSH_CMD "mkdir -p ~/projects/smoke-proj && \
+            echo 'placeholder' > ~/projects/smoke-proj/README"
+
+          # --- Foreground --exec on a no-devcontainer project (Case 4) ---
+          OUT=$(uv run remo shell -p smoke-proj --exec 'echo hello-$REMO_PROJECT-$REMO_INSTANCE && pwd' 2>&1)
+          echo "$OUT"
+          echo "$OUT" | grep -q "hello-smoke-proj-" || {
+            echo "FAIL: --exec did not run / env vars missing"; exit 1; }
+          echo "$OUT" | grep -q "/projects/smoke-proj" || {
+            echo "FAIL: --exec did not cd into project dir"; exit 1; }
+          echo "remo shell -p --exec (foreground): PASS"
+
+          # --- Detached --exec writes log file and returns immediately ---
+          DETACH_OUT=$(uv run remo shell -p smoke-proj --detach \
+            --exec 'sleep 1 && echo detached-marker-$REMO_PROJECT' 2>&1)
+          echo "$DETACH_OUT"
+          echo "$DETACH_OUT" | grep -q "Launched detached" || {
+            echo "FAIL: detach didn't print launched message"; exit 1; }
+          # Give the background command a moment to finish
+          sleep 3
+          LOG=$($SSH_CMD "cat ~/.local/state/remo/smoke-proj.log")
+          echo "log contents:"; echo "$LOG"
+          echo "$LOG" | grep -q "detached-marker-smoke-proj" || {
+            echo "FAIL: detached command did not run / log missing marker"; exit 1; }
+          echo "remo shell -p --detach --exec: PASS"
+
+          # --- Validation: --exec without -p exits 2 ---
+          if uv run remo shell --exec 'true' 2>/dev/null; then
+            echo "FAIL: --exec without -p should have errored"; exit 1
+          fi
+          echo "validation: --exec without -p errors as expected"
+
+          # --- Validation: --detach without --exec exits 2 ---
+          if uv run remo shell -p smoke-proj --detach 2>/dev/null; then
+            echo "FAIL: --detach without --exec should have errored"; exit 1
+          fi
+          echo "validation: --detach without --exec errors as expected"
+
       - name: Teardown
         if: always()
         run: |

--- a/.gitignore
+++ b/.gitignore
@@ -45,3 +45,4 @@ env/
 .maverick/*
 !.maverick/checkpoints/
 .claude/settings.local.json
+.DS_Store

--- a/.gitignore
+++ b/.gitignore
@@ -31,6 +31,12 @@ build/
 *.egg-info/
 *.egg
 
+# Test / coverage artifacts
+.coverage
+.coverage.*
+.pytest_cache/
+htmlcov/
+
 # Python virtual environment
 venv/
 .venv/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -12,6 +12,8 @@ See `.specify/memory/constitution.md` for project principles and non-negotiable 
 - Python 3.11+ + Click (CLI framework), InquirerPy (interactive picker), boto3 (AWS, optional), hcloud (Hetzner, optional) (003-python-cli-rewrite)
 - Flat file (`~/.config/remo/known_hosts`, colon-delimited) (003-python-cli-rewrite)
 - Cross-provider snapshot model (`models/snapshot.py`) + shared helpers in `core/snapshot.py` (name generator, validator, table formatter, destroy-time cleanup hook). No new runtime deps. (005-provider-snapshots)
+- Python 3.11+ (package `requires-python = ">=3.11"`); service container runs Python 3.13-slim + Service (new `[notifier]` extra): FastAPI ≥0.115, uvicorn[standard] ≥0.32, pydantic ≥2.9, python-telegram-bot ≥21.6, structlog ≥24.4, tomli (py<3.11 only). CLI side: Click ≥8.1 (existing), no new laptop runtime deps. Build: hatchling (existing), uv (in-container). Ansible: new `community.docker` collection. (007-notifier-sidecar)
+- None. All approval state is in-memory in a `PendingApprovals` registry; never persisted (FR-009). (007-notifier-sidecar)
 
 - Ansible 2.14+ / YAML + `ansible.builtin`, `community.general` (for zypper module) (001-bootstrap-incus-host)
 
@@ -132,9 +134,9 @@ Provider SDKs (boto3, hcloud) are lazy-imported with clear error messages if mis
 - Ansible 2.14+ / YAML: Follow standard conventions plus Constitution principles
 
 ## Recent Changes
+- 007-notifier-sidecar: Added Python 3.11+ (package `requires-python = ">=3.11"`); service container runs Python 3.13-slim + Service (new `[notifier]` extra): FastAPI ≥0.115, uvicorn[standard] ≥0.32, pydantic ≥2.9, python-telegram-bot ≥21.6, structlog ≥24.4, tomli (py<3.11 only). CLI side: Click ≥8.1 (existing), no new laptop runtime deps. Build: hatchling (existing), uv (in-container). Ansible: new `community.docker` collection.
 - 005-provider-snapshots: Added cross-provider snapshot CLI (`remo <P> snapshot {create,list,restore,delete}`) + destroy-time cleanup hook across Incus / Proxmox / AWS / Hetzner.
 - 003-python-cli-rewrite: Added Python 3.11+ + Click (CLI framework), InquirerPy (interactive picker), boto3 (AWS, optional), hcloud (Hetzner, optional)
-- 002-incus-container-support: Added Ansible 2.14+ / YAML + `ansible.builtin`, `community.general` (existing), Incus CLI (local)
 
 
 <!-- MANUAL ADDITIONS START -->

--- a/README.md
+++ b/README.md
@@ -94,6 +94,42 @@ The `fzf`-powered menu shows your projects from `~/projects`:
 - **c**: Clone a new repository
 - **x**: Exit to shell
 
+### Jump Straight to a Project
+
+Skip the menu and land directly in a project (devcontainer auto-launches):
+
+```bash
+remo shell -p my-app
+```
+
+Run a one-shot command inside the project's devcontainer instead of opening
+a shell — quote the command as a single string:
+
+```bash
+remo shell -p my-app --exec 'pytest -x'
+remo shell -p my-app --exec 'claude --remote-control'
+```
+
+Fire-and-forget — kick off a command on the remote and exit SSH immediately:
+
+```bash
+remo shell -p my-app --detach --exec 'claude remote-control --name remo-rc'
+remo shell -p my-app --detach --exec './long-build.sh'
+```
+
+Detached output is captured to `~/.local/state/remo/<project>.log` on the
+remote, so you can tail it later (`remo shell -p my-app --exec 'tail -f
+~/.local/state/remo/my-app.log'`). The command's environment gets
+`REMO_INSTANCE` and `REMO_PROJECT` exported automatically — handy for
+deterministic naming, e.g.:
+
+```bash
+remo shell -p my-app --detach --exec \
+  'claude remote-control --name "remo-$REMO_INSTANCE-$REMO_PROJECT"'
+```
+
+Then on your phone, open claude.ai/code and pick the session by name.
+
 ### Port Forwarding
 
 Forward remote ports to your local machine during SSH sessions:
@@ -175,6 +211,9 @@ they continue to incur storage costs on AWS/Hetzner).
 # Connect to environment
 remo shell                          # Auto-connect (or picker if multiple)
 remo shell my-env                   # Connect to a specific environment
+remo shell -p my-app                # Skip the menu, jump to ~/projects/my-app
+remo shell -p my-app --exec 'pytest -x'              # Run command in devcontainer
+remo shell -p my-app --detach --exec 'claude remote-control --name rc'  # Fire and exit
 remo shell -L 8080                  # Shell + forward remote :8080 to local :8080
 remo shell -L 9000:8080             # Shell + forward remote :8080 to local :9000
 remo shell -L 8080 -L 3000          # Shell + forward multiple ports

--- a/README.md
+++ b/README.md
@@ -205,6 +205,57 @@ The `destroy` command on each provider checks for existing snapshots first and
 offers to clean them up. Decline and the snapshots remain (you'll be warned
 they continue to incur storage costs on AWS/Hetzner).
 
+## Notifier
+
+The **notifier** is a small approval bridge that runs as a hardened container on
+a remo host. When an agentsh-secured devcontainer needs human sign-off for an
+operation, it POSTs an approval request to the notifier, which messages you on
+Telegram with **Approve** / **Deny** buttons and returns your decision. It fails
+secure: a timeout, a shutdown, or a lost connection all mean *deny*. The wire
+protocol is documented in
+[`src/remo_cli/notifier/docs/wire-protocol.md`](src/remo_cli/notifier/docs/wire-protocol.md).
+
+The notifier's runtime dependencies (FastAPI, python-telegram-bot, …) live in an
+optional `notifier` extra and are installed only inside the container — a normal
+`remo` install does not pull them in.
+
+### Notifier setup
+
+1. **Create a Telegram bot**: message [`@BotFather`](https://t.me/BotFather), run
+   `/newbot`, follow the prompts, and save the bot token.
+2. **Find your chat id**: message `@userinfobot` from your own account; it
+   replies with your numeric user id — that's your `authorized_chat_id`.
+3. **Message your new bot once** (any message) so it can DM you.
+4. **Export credentials** on the machine where `remo` runs:
+   ```bash
+   export REMO_NOTIFIER_TELEGRAM_BOT_TOKEN="12345:ABC...your-token"
+   export REMO_NOTIFIER_TELEGRAM_CHAT_ID="987654321"
+   ```
+5. **Deploy**: `remo notifier deploy <host>` (omit `<host>` to fuzzy-pick).
+6. **Verify**: `remo notifier test <host>` — you should get a Telegram message
+   within ~2 s; tapping Approve or Deny returns the decision to the CLI.
+
+### Notifier commands
+
+```bash
+remo notifier deploy  <host> [--rebuild]   # apply the role; --rebuild forces a fresh image
+remo notifier status  <host>               # GET /v1/health
+remo notifier logs    <host> [-f] [-n N]   # journalctl -u remo-notifier.service
+remo notifier test    <host>               # push a test approval, print the decision
+remo notifier restart <host>               # systemctl restart remo-notifier.service
+```
+
+### "Always" — standing grants
+
+Approval messages offer **✅ Approve · ⏩ Always… · ❌ Deny**. Tapping **Always…**
+lets you auto-approve a *class* of operation (e.g. `git push *` in this project)
+so matching requests are approved instantly without pinging you again. Grants are
+held in memory only (cleared on restart → you're asked again — fail-closed),
+expire after a default 8h, and default to the narrowest scope. Manage them from
+Telegram: `/rules` (list + revoke), `/revoke <id>`, `/pause` and `/resume`.
+Auto-approvals are logged and summarized in a periodic digest. Tune via the
+`[grants]` config block (see `src/remo_cli/notifier/docs/config-schema.md`).
+
 ## CLI Reference
 
 ```bash

--- a/ansible/group_vars/all.yml
+++ b/ansible/group_vars/all.yml
@@ -27,3 +27,12 @@ zellij_session_name: "main"  # Session name for SSH auto-attach
 
 # Node.js Configuration
 nodejs_version: "24"  # LTS version
+
+# ============================================================================
+# Remo Notifier (spec 007)
+# ============================================================================
+# Notifier sidecar that delivers agentsh approval requests to Telegram and
+# returns the human's decision. Deployed by the remo_notifier role.
+
+remo_notifier_telegram_bot_token: "{{ lookup('env', 'REMO_NOTIFIER_TELEGRAM_BOT_TOKEN') }}"
+remo_notifier_telegram_chat_id: "{{ lookup('env', 'REMO_NOTIFIER_TELEGRAM_CHAT_ID') }}"

--- a/ansible/notifier_deploy.yml
+++ b/ansible/notifier_deploy.yml
@@ -1,0 +1,17 @@
+---
+# Deploy the remo notifier to an existing, provisioned host.
+#
+# Usage (via the CLI):
+#   remo notifier deploy <host>
+#
+# Direct usage:
+#   ansible-playbook notifier_deploy.yml -i "<host>," -e "ansible_user=remo" \
+#     -e "remo_notifier_build_context_local=/path/to/build/context"
+
+- name: Deploy remo notifier
+  hosts: all
+  become: true
+  gather_facts: true
+
+  roles:
+    - role: remo_notifier

--- a/ansible/requirements.yml
+++ b/ansible/requirements.yml
@@ -12,3 +12,5 @@ collections:
     version: ">=11.0.0"
   - name: community.crypto
     version: ">=3.1.0"
+  - name: community.docker
+    version: ">=4.0.0"

--- a/ansible/roles/remo_notifier/defaults/main.yml
+++ b/ansible/roles/remo_notifier/defaults/main.yml
@@ -1,0 +1,38 @@
+---
+# Defaults for the remo_notifier role. Override in group_vars/all.yml.
+
+remo_notifier_version: "0.1.0"
+remo_notifier_image: "remo-notifier:{{ remo_notifier_version }}"
+remo_notifier_listen_port: 18181
+remo_notifier_bind_address: "172.17.0.1"  # Docker bridge address
+remo_notifier_config_dir: "/etc/notifier"
+remo_notifier_secrets_dir: "/etc/notifier/secrets"
+remo_notifier_instance_id: "{{ inventory_hostname }}"
+remo_notifier_default_timeout_seconds: 300
+remo_notifier_max_timeout_seconds: 1800
+remo_notifier_max_pending_approvals: 50
+remo_notifier_log_level: "info"
+remo_notifier_message_parse_mode: "MarkdownV2"
+
+# Standing grants ("Always" auto-approval) — Addendum 001
+remo_notifier_grants_enabled: true
+remo_notifier_grants_default_ttl_seconds: 28800  # 8h; every grant expires
+remo_notifier_grants_max: 100
+remo_notifier_grants_allow_global_scope: true
+remo_notifier_grants_digest_interval_seconds: 3600  # 0 disables the digest
+
+remo_notifier_telegram_bot_token: "{{ lookup('env', 'REMO_NOTIFIER_TELEGRAM_BOT_TOKEN') }}"
+remo_notifier_telegram_chat_id: "{{ lookup('env', 'REMO_NOTIFIER_TELEGRAM_CHAT_ID') }}"
+
+# v1 builds the image on the host from a bundled context; future: pull from a
+# registry by setting this to false.
+remo_notifier_build_from_source: true
+remo_notifier_source_dir: "/opt/remo-notifier-build"
+
+# Absolute path to the build context bundled in the wheel
+# (remo_cli/notifier_build/). The CLI resolves and passes this; when running the
+# role directly, point it at a repo checkout root.
+remo_notifier_build_context_local: ""
+
+# Force a rebuild even if the image already exists.
+remo_notifier_force_rebuild: false

--- a/ansible/roles/remo_notifier/handlers/main.yml
+++ b/ansible/roles/remo_notifier/handlers/main.yml
@@ -1,0 +1,11 @@
+---
+- name: Reload systemd
+  ansible.builtin.systemd:
+    daemon_reload: true
+  listen: "Restart remo-notifier"
+
+- name: Restart remo-notifier
+  ansible.builtin.systemd:
+    name: remo-notifier.service
+    state: restarted
+  listen: "Restart remo-notifier"

--- a/ansible/roles/remo_notifier/meta/main.yml
+++ b/ansible/roles/remo_notifier/meta/main.yml
@@ -1,0 +1,5 @@
+---
+# The notifier runs as a Docker container, so it depends on the docker role
+# being applied first (installs the Docker runtime + community.docker prereqs).
+dependencies:
+  - role: docker

--- a/ansible/roles/remo_notifier/tasks/main.yml
+++ b/ansible/roles/remo_notifier/tasks/main.yml
@@ -1,0 +1,109 @@
+---
+# Deploy the remo notifier as a hardened Docker container managed by systemd.
+# Registered-variable access uses | default() throughout (Constitution I).
+
+- name: Pre-flight — Telegram credentials are present
+  ansible.builtin.assert:
+    that:
+      - remo_notifier_telegram_bot_token | default('') | length > 0
+      - remo_notifier_telegram_chat_id | default('') | string | length > 0
+    fail_msg: >-
+      Missing Telegram credentials. Set REMO_NOTIFIER_TELEGRAM_BOT_TOKEN and
+      REMO_NOTIFIER_TELEGRAM_CHAT_ID in your environment before deploying the
+      notifier (see the README "Notifier setup" section).
+    success_msg: "Telegram credentials present."
+
+- name: Create notifier config and secrets directories
+  ansible.builtin.file:
+    path: "{{ item }}"
+    state: directory
+    owner: root
+    group: root
+    mode: "0700"
+  loop:
+    - "{{ remo_notifier_config_dir }}"
+    - "{{ remo_notifier_secrets_dir }}"
+
+- name: Render notifier config
+  ansible.builtin.template:
+    src: notifier.toml.j2
+    dest: "{{ remo_notifier_config_dir }}/notifier.toml"
+    owner: root
+    group: root
+    mode: "0640"
+  notify: "Restart remo-notifier"
+
+- name: Write Telegram bot token secret
+  ansible.builtin.copy:
+    content: "{{ remo_notifier_telegram_bot_token }}"
+    dest: "{{ remo_notifier_secrets_dir }}/telegram_bot_token"
+    owner: root
+    group: root
+    mode: "0400"
+  no_log: true
+  notify: "Restart remo-notifier"
+
+- name: Stage the image build context on the host
+  ansible.builtin.copy:
+    src: "{{ remo_notifier_build_context_local }}/"
+    dest: "{{ remo_notifier_source_dir }}/"
+    mode: "0644"
+    directory_mode: "0755"
+  when:
+    - remo_notifier_build_from_source | default(true) | bool
+    - remo_notifier_build_context_local | default('') | length > 0
+
+- name: Build the notifier image on the host
+  community.docker.docker_image:
+    name: "{{ remo_notifier_image }}"
+    source: build
+    force_source: "{{ remo_notifier_force_rebuild | default(false) | bool }}"
+    build:
+      path: "{{ remo_notifier_source_dir }}"
+      dockerfile: notifier/Dockerfile
+  when: remo_notifier_build_from_source | default(true) | bool
+  notify: "Restart remo-notifier"
+
+- name: Pull the notifier image
+  community.docker.docker_image:
+    name: "{{ remo_notifier_image }}"
+    source: pull
+  when: not (remo_notifier_build_from_source | default(true) | bool)
+  notify: "Restart remo-notifier"
+
+- name: Install systemd unit
+  ansible.builtin.template:
+    src: remo-notifier.service.j2
+    dest: /etc/systemd/system/remo-notifier.service
+    owner: root
+    group: root
+    mode: "0644"
+  notify: "Restart remo-notifier"
+
+- name: Enable and start the notifier service
+  ansible.builtin.systemd:
+    name: remo-notifier.service
+    enabled: true
+    state: started
+    daemon_reload: true
+
+- name: Apply any pending restarts before health-checking
+  ansible.builtin.meta: flush_handlers
+
+- name: Wait for the notifier health endpoint
+  ansible.builtin.uri:
+    url: "http://{{ remo_notifier_bind_address }}:{{ remo_notifier_listen_port }}/v1/health"
+    status_code: 200
+  register: notifier_health
+  retries: 10
+  delay: 2
+  until: notifier_health.status | default(0) == 200
+  changed_when: false
+
+- name: Report notifier status
+  ansible.builtin.debug:
+    msg: >-
+      remo-notifier is healthy on
+      {{ remo_notifier_bind_address }}:{{ remo_notifier_listen_port }}
+      (pending approvals:
+      {{ notifier_health.json.pending_approvals | default('unknown') }}).

--- a/ansible/roles/remo_notifier/templates/notifier.toml.j2
+++ b/ansible/roles/remo_notifier/templates/notifier.toml.j2
@@ -1,0 +1,30 @@
+{{ ansible_managed | comment }}
+# Rendered by the remo_notifier Ansible role. Do not edit by hand.
+
+[server]
+listen_host = "0.0.0.0"
+listen_port = 18181
+log_level = "{{ remo_notifier_log_level }}"
+
+[approval]
+default_timeout_seconds = {{ remo_notifier_default_timeout_seconds | int }}
+max_timeout_seconds = {{ remo_notifier_max_timeout_seconds | int }}
+max_pending_approvals = {{ remo_notifier_max_pending_approvals | int }}
+
+[grants]
+enabled = {{ remo_notifier_grants_enabled | bool | lower }}
+default_ttl_seconds = {{ remo_notifier_grants_default_ttl_seconds | int }}
+max_grants = {{ remo_notifier_grants_max | int }}
+allow_global_scope = {{ remo_notifier_grants_allow_global_scope | bool | lower }}
+digest_interval_seconds = {{ remo_notifier_grants_digest_interval_seconds | int }}
+
+[transport]
+type = "telegram"
+
+[transport.telegram]
+bot_token_file = "/run/secrets/telegram_bot_token"
+authorized_chat_id = {{ remo_notifier_telegram_chat_id | int }}
+message_parse_mode = "{{ remo_notifier_message_parse_mode }}"
+
+[instance]
+id = "{{ remo_notifier_instance_id }}"

--- a/ansible/roles/remo_notifier/templates/remo-notifier.service.j2
+++ b/ansible/roles/remo_notifier/templates/remo-notifier.service.j2
@@ -1,0 +1,26 @@
+{{ ansible_managed | comment }}
+[Unit]
+Description=Remo Notifier (agentsh approval bridge)
+After=docker.service
+Requires=docker.service
+
+[Service]
+# Clean up any stale container before starting (idempotent restarts).
+ExecStartPre=-/usr/bin/docker rm -f remo-notifier
+ExecStart=/usr/bin/docker run --rm \
+    --name remo-notifier \
+    --network bridge \
+    -p {{ remo_notifier_bind_address }}:{{ remo_notifier_listen_port }}:18181 \
+    -v {{ remo_notifier_config_dir }}/notifier.toml:/etc/notifier/notifier.toml:ro \
+    -v {{ remo_notifier_secrets_dir }}/telegram_bot_token:/run/secrets/telegram_bot_token:ro \
+    --read-only \
+    --tmpfs /tmp:rw,size=64m \
+    --cap-drop ALL \
+    --user 65532:65532 \
+    {{ remo_notifier_image }}
+ExecStop=/usr/bin/docker stop remo-notifier
+Restart=always
+RestartSec=5
+
+[Install]
+WantedBy=multi-user.target

--- a/ansible/roles/user_setup/tasks/main.yml
+++ b/ansible/roles/user_setup/tasks/main.yml
@@ -330,13 +330,29 @@
               echo "Entering devcontainer (exit to return to host shell)..."
               echo ""
 
+              # If REMO_DEVCONTAINER_CMD is set (project-launch passthrough),
+              # run that command inside the devcontainer instead of dropping
+              # into the user's shell. Wrapped in `bash -lc` so the user's
+              # command gets variable expansion, pipes, &&, and PATH from
+              # the devcontainer's login profile.
+              if [[ -n "$REMO_DEVCONTAINER_CMD" ]]; then
+                  _bash_flags="-lc"
+                  _exec_cmd="$REMO_DEVCONTAINER_CMD"
+              else
+                  _bash_flags="-c"
+                  _exec_cmd='if command -v zsh &> /dev/null; then exec zsh; else exec bash; fi'
+              fi
+
               # Run devcontainer shell (not exec, so we can stop container after)
-              if ! devcontainer exec --workspace-folder "$_project_dir" /bin/bash -c \
-                  'if command -v zsh &> /dev/null; then exec zsh; else exec bash; fi'; then
+              if ! devcontainer exec --workspace-folder "$_project_dir" \
+                  env REMO_INSTANCE="${REMO_INSTANCE:-$(hostname)}" \
+                      REMO_PROJECT="$ZELLIJ_SESSION_NAME" \
+                  /bin/bash $_bash_flags "$_exec_cmd"; then
                   echo ""
                   echo "devcontainer exec failed. [Press any key to continue]"
                   read -n 1 -s -r
               fi
+              unset _exec_cmd _bash_flags
 
               # After exiting devcontainer, stop the container to free resources
               echo ""
@@ -389,6 +405,14 @@
   ansible.builtin.template:
     src: project-menu.sh.j2
     dest: "/home/{{ remo_user }}/.local/bin/project-menu"
+    owner: "{{ remo_user }}"
+    group: "{{ remo_user }}"
+    mode: '0755'
+
+- name: Install project-launch script
+  ansible.builtin.template:
+    src: project-launch.sh.j2
+    dest: "/home/{{ remo_user }}/.local/bin/project-launch"
     owner: "{{ remo_user }}"
     group: "{{ remo_user }}"
     mode: '0755'

--- a/ansible/roles/user_setup/templates/project-launch.sh.j2
+++ b/ansible/roles/user_setup/templates/project-launch.sh.j2
@@ -1,0 +1,147 @@
+#!/bin/bash
+# project-launch - Launch a project session non-interactively.
+# Managed by Ansible - do not edit manually
+#
+# Usage:
+#   project-launch --project NAME [--detach] [--exec SHELL_COMMAND]
+#
+# SHELL_COMMAND is a single string run via `bash -lc`, so variable
+# expansion, pipes, `&&`, etc. all work as written.
+#
+# Modes:
+#   Interactive (default):
+#       Acts like "pick NAME in project-menu". Drops into the project's
+#       zellij session; the existing .bashrc DEVCONTAINER block brings
+#       up the devcontainer and execs the user's shell (or SHELL_COMMAND
+#       when --exec is supplied — passed via REMO_DEVCONTAINER_CMD).
+#
+#   Detached (--detach):
+#       Requires --exec. Brings up the devcontainer (or runs on the
+#       host project dir if no .devcontainer), launches the command in
+#       the background via nohup+setsid + `bash -lc`, captures
+#       stdout/stderr to ~/.local/state/remo/<project>.log, and
+#       returns immediately.
+#
+# Environment passed to SHELL_COMMAND (both modes):
+#   REMO_INSTANCE  - hostname of the remo instance
+#   REMO_PROJECT   - the project name
+
+set -e
+
+PROJECTS_DIR="{{ dev_workspace_dir }}"
+
+PROJECT=""
+DETACH=false
+EXEC_CMD=""
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --project)
+            PROJECT="$2"
+            shift 2
+            ;;
+        --detach)
+            DETACH=true
+            shift
+            ;;
+        --exec)
+            EXEC_CMD="$2"
+            shift 2
+            ;;
+        -h|--help)
+            sed -n '2,25p' "$0" | sed 's/^# \{0,1\}//'
+            exit 0
+            ;;
+        *)
+            echo "project-launch: unknown argument: $1" >&2
+            exit 2
+            ;;
+    esac
+done
+
+if [[ -z "$PROJECT" ]]; then
+    echo "project-launch: --project NAME is required" >&2
+    exit 2
+fi
+
+PROJECT_DIR="$PROJECTS_DIR/$PROJECT"
+if [[ ! -d "$PROJECT_DIR" ]]; then
+    echo "project-launch: project not found: $PROJECT_DIR" >&2
+    exit 1
+fi
+
+HAS_DC=false
+if [[ -d "$PROJECT_DIR/.devcontainer" ]] || [[ -f "$PROJECT_DIR/.devcontainer.json" ]]; then
+    HAS_DC=true
+fi
+
+REMO_INSTANCE="$(hostname)"
+export REMO_INSTANCE
+export REMO_PROJECT="$PROJECT"
+
+# ---------------------------------------------------------------------------
+# Detached mode: no zellij, no interactive shell. Run EXEC_CMD in background.
+# ---------------------------------------------------------------------------
+if $DETACH; then
+    if [[ -z "$EXEC_CMD" ]]; then
+        echo "project-launch: --detach requires --exec SHELL_COMMAND" >&2
+        exit 2
+    fi
+
+    LOG_DIR="$HOME/.local/state/remo"
+    mkdir -p "$LOG_DIR"
+    LOG_FILE="$LOG_DIR/$PROJECT.log"
+
+    cd "$PROJECT_DIR"
+
+    if $HAS_DC; then
+        echo "Bringing up devcontainer for $PROJECT..."
+        devcontainer up --workspace-folder "$PROJECT_DIR" >/dev/null
+        printf -- '----- %s detached launch: %s -----\n' "$(date -Iseconds)" "$EXEC_CMD" >>"$LOG_FILE"
+        nohup setsid devcontainer exec --workspace-folder "$PROJECT_DIR" \
+            env REMO_INSTANCE="$REMO_INSTANCE" REMO_PROJECT="$PROJECT" \
+            bash -lc "$EXEC_CMD" >>"$LOG_FILE" 2>&1 </dev/null &
+    else
+        printf -- '----- %s detached launch: %s -----\n' "$(date -Iseconds)" "$EXEC_CMD" >>"$LOG_FILE"
+        nohup setsid env REMO_INSTANCE="$REMO_INSTANCE" REMO_PROJECT="$PROJECT" \
+            bash -lc "$EXEC_CMD" >>"$LOG_FILE" 2>&1 </dev/null &
+    fi
+
+    echo "Launched detached in $PROJECT (log: $LOG_FILE)"
+    exit 0
+fi
+
+# ---------------------------------------------------------------------------
+# Interactive mode.
+# Cases:
+#   1. Project HAS .devcontainer, no EXEC_CMD  → zellij + devcontainer
+#                                                auto-start drops you into
+#                                                devcontainer shell
+#   2. Project HAS .devcontainer, EXEC_CMD     → zellij + devcontainer block
+#                                                runs EXEC_CMD via bash -lc
+#                                                (REMO_DEVCONTAINER_CMD)
+#   3. Project has NO .devcontainer, no CMD    → zellij with plain shell in
+#                                                project dir
+#   4. Project has NO .devcontainer, EXEC_CMD  → skip zellij, run via bash
+#                                                -lc directly on host
+# ---------------------------------------------------------------------------
+cd "$PROJECT_DIR"
+
+if ! $HAS_DC && [[ -n "$EXEC_CMD" ]]; then
+    # Case 4: bypass zellij, run command on host via login shell
+    exec env REMO_INSTANCE="$REMO_INSTANCE" REMO_PROJECT="$PROJECT" \
+        bash -lc "$EXEC_CMD"
+fi
+
+if [[ -n "$EXEC_CMD" ]]; then
+    # Case 2: pass command through env var that .bashrc DEVCONTAINER block
+    # honors and runs via `bash -lc`.
+    export REMO_DEVCONTAINER_CMD="$EXEC_CMD"
+fi
+
+# Clean up any exited session of the same name (mirrors project-menu)
+if zellij list-sessions 2>/dev/null | sed 's/\x1b\[[0-9;]*m//g' | grep -q "^$PROJECT.*EXITED"; then
+    zellij delete-session "$PROJECT" 2>/dev/null || true
+fi
+
+exec zellij attach --create "$PROJECT"

--- a/ansible/tasks/configure_dev_tools.yml
+++ b/ansible/tasks/configure_dev_tools.yml
@@ -76,6 +76,14 @@
     name: zellij
   when: configure_zellij | default(true) | bool
 
+# Opt-in: the notifier requires Telegram credentials and is normally stood up
+# via `remo notifier deploy <host>`. It is NOT part of the default dev-tools
+# configure flow (deploying it without creds would fail the preflight assert).
+- name: Deploy Remo Notifier
+  ansible.builtin.include_role:
+    name: remo_notifier
+  when: configure_remo_notifier | default(false) | bool
+
 - name: Write remo version marker
   ansible.builtin.copy:
     content: "{{ remo_version | default('') }}"

--- a/docs/remo-fnox-spec.md
+++ b/docs/remo-fnox-spec.md
@@ -1,0 +1,316 @@
+# Feature Specification: Credential Broker
+
+**Feature Branch**: `005-credential-broker`
+**Created**: 2026-05-23
+**Status**: Draft
+**Input**: User description: "Defend against malicious-dependency supply-chain attacks by removing long-lived developer credentials from Remo instances. Replace ambient environment variables and dotfile-resident secrets with an on-instance broker process that surfaces narrowly-scoped, allowlisted credentials into each devcontainer via per-project Unix sockets."
+
+## Background and Motivation
+
+Recent supply-chain attacks against npm (Shai-Hulud, Mini Shai-Hulud against `@antv`), PyPI, and other ecosystems share a pattern: a malicious dependency's install or postinstall script runs with the developer's full ambient environment and reads `GITHUB_TOKEN`, `NPM_TOKEN`, `AWS_*`, `~/.aws/credentials`, `~/.netrc`, `~/.npmrc`, SSH private keys, and similar. The Remo instance — being where most active dev credentials accumulate — is a high-value target.
+
+Remo's existing isolation (one instance per developer, separate from the laptop) bounds blast radius, but the *contents* of the instance are exactly the secrets the attacker wants. Every `npm install`, `cargo build`, `pip install` of an untrusted package today runs with full credential access.
+
+The credential broker design closes this gap by ensuring:
+
+1. Long-lived developer credentials never live on the Remo instance at rest.
+2. The instance fetches credentials on demand from an external backend (1Password, Vault, AWS Secrets Manager, etc.).
+3. Each devcontainer sees only the credentials the project it hosts has explicitly declared a need for, enforced by kernel-level namespace separation, not just policy.
+
+## Terms and Definitions
+
+These terms are used consistently throughout this spec and should be adopted in all related code, CLI surface, and documentation.
+
+| Term | Definition |
+|---|---|
+| **Backend** (L0) | The external secret store of record — 1Password, HashiCorp Vault, AWS Secrets Manager, Azure Key Vault, GCP Secret Manager, age-encrypted file in a private repo, or an OS keychain. Holds the user's actual credential values. Never directly accessed by devcontainers or untrusted code. |
+| **Node** (L1) | A bare-metal or VM-based machine that hosts one or more Remo *instances*. Only applicable to self-hosted providers (Incus, Proxmox). For AWS and Hetzner, the cloud provider owns this layer and Remo does not address it. A node may host multiple instances belonging to one or many users. |
+| **Instance** (L2) | The compute resource Remo creates per `remo <provider> create`. The SSH target tracked in `known_hosts.yml`. Called *instance* (AWS), *server* (Hetzner), or *container* (Incus, Proxmox) in per-provider CLI labels — but structurally a single concept. The *broker* runs here. |
+| **Devcontainer** (L3) | A Docker container launched inside an *instance* by `devcontainer up`, one per *project*, where untrusted dependency code (npm install, etc.) actually executes. Consumes one *project socket*. |
+| **Project** (L4) | A directory under `~/projects/` on an instance, usually a git repo, typically containing a `.devcontainer/` config and a *project manifest*. The unit selected in the project menu. |
+| **Backend** identity | A credential the *broker* uses to authenticate upward to the backend (e.g., a 1Password Service Account token, Vault AppRole, AWS IAM instance profile). Scoped narrowly to a single *instance*'s allowed secrets. Not the same as the secrets it fetches. |
+| **Bootstrap token** | The on-disk form of the backend identity stored on an instance (file at `/etc/remo-broker/bootstrap-token` on the instance). For self-hosted providers, originates on the *node* and is bind-mounted in. For Hetzner, SSH-pushed at create time. For AWS, replaced by an instance profile (no on-disk token). |
+| **Broker** | The Remo-owned daemon (`remo-broker`) running on the instance as a systemd unit. Holds the bootstrap token, fetches credentials from the backend (using `fnox` internally as its multi-backend retrieval library), enforces per-project allowlists, and serves *project sockets* to devcontainers. One broker per instance. See "Component Sourcing" below for why this is built rather than adopted. |
+| **Project socket** | A Unix domain socket at `/run/remo-broker/<project>.sock` on the instance, one per active project, bind-mounted as `/run/remo-broker/sock` into the project's devcontainer. The broker enforces a per-project allowlist on each. |
+| **Project manifest** | `.remo/broker.toml` (auto-synthesized by Remo) or `.devcontainer/remo-broker.toml` (committed to the repo) declaring the set of backend-resolvable secret *names* this project is permitted to fetch. The broker reads this when creating the project socket and uses it as the per-project allowlist. Backend-side mappings (which credential store each name lives in, what backend identity to use) are configured separately at the instance level via the embedded fnox layer's own configuration. |
+| **Provisioning credential** | A credential Remo uses to call cloud APIs (HETZNER_API_TOKEN, AWS_ACCESS_KEY_ID, Incus/Proxmox API tokens, 1Password SA admin token). Lives only in the laptop's fnox configuration, fetched on demand per `remo` invocation, never persisted to an instance or node. |
+| **User secret** | A credential a project needs at runtime (GITHUB_TOKEN, NPM_TOKEN, runtime AWS keys, ANTHROPIC_API_KEY). Fetched on demand by the broker via the bootstrap token, held in broker memory only, exposed to devcontainers via project sockets. Never written to disk on the instance. |
+
+### Layer diagram
+
+```
+L0  Backend
+    └── 1Password / Vault / AWS Secrets Manager / age+git / keychain
+                          ▲
+                          │  broker authenticates with bootstrap token
+                          │
+L1  Node (Incus/Proxmox only; absent on AWS/Hetzner)
+    ├── /var/lib/remo-broker/instance-tokens/<instance>
+    └── bind-mounted read-only into the instance
+        │
+        ▼
+L2  Instance
+    ├── /etc/remo-broker/bootstrap-token    (file or IMDS-derived)
+    ├── remo-broker daemon  (systemd unit; embeds fnox for backend retrieval)
+    ├── /run/remo-broker/projA.sock         (allowlist: GITHUB_TOKEN, …)
+    └── /run/remo-broker/projB.sock         (allowlist: NPM_TOKEN, …)
+        │
+        ▼  (bind-mounted as /run/remo-broker/sock)
+L3  Devcontainer (one per project)
+    └── tools fetch secrets via the mounted project socket only
+        │
+        ▼
+L4  Project workspace (mounted from ~/projects/<name>)
+```
+
+For AWS/Hetzner, L1 collapses: there is no Remo-addressable node, and the bootstrap is delivered either via cloud workload identity (AWS instance profile) or SSH push (Hetzner).
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - Project creds available in devcontainer, never on the instance OS (Priority: P1)
+
+A developer SSHes into a Remo instance, picks a project from the menu, and lands in a devcontainer. Inside the devcontainer, `gh auth status` shows them authenticated, `npm publish` finds an NPM_TOKEN, `aws sts get-caller-identity` works. None of those credentials existed on the instance OS before the devcontainer started, and none persist after it stops. A worm in `npm install` running inside that devcontainer can only see the credentials the project's manifest declared a need for — not credentials from other projects, not the bootstrap token, not the developer's full secret backend.
+
+**Why this priority**: This is the entire point of the feature. Without it, no other behavior matters.
+
+**Independent Test**: Provision an instance, configure a project manifest declaring `GITHUB_TOKEN`, launch the devcontainer, verify `gh auth status` reports authenticated *and* `cat ~/.config/gh/hosts.yml` shows no on-disk token. From outside the devcontainer (on the instance OS), verify `printenv` shows no GITHUB_TOKEN and `~/.config/gh/` does not exist for the project's user.
+
+**Acceptance Scenarios**:
+
+1. **Given** an instance with the broker installed and a project with a manifest declaring `GITHUB_TOKEN`, **When** the user selects that project from the menu, **Then** the launched devcontainer can use `gh` against authenticated GitHub APIs.
+2. **Given** the same setup, **When** the user runs `printenv` or inspects `~/.aws/`, `~/.npmrc`, `~/.netrc` on the instance OS (outside any devcontainer), **Then** none of the project's credentials appear.
+3. **Given** two projects A and B where A's manifest declares `GITHUB_TOKEN` and B's declares `NPM_TOKEN`, **When** project A's devcontainer requests `NPM_TOKEN` via the broker, **Then** the request is denied.
+4. **Given** a devcontainer is running with a project socket mounted, **When** the devcontainer process exits, **Then** the project socket is removed from `/run/remo-broker/` and the broker drops the project's allowlist from memory.
+
+---
+
+### User Story 2 - Multi-device access to the same instance (Priority: P1)
+
+A developer creates an instance from their laptop, does some work, then later runs `remo shell` from a different machine (a second laptop, a web session, a phone-tethered tablet). The instance is reachable and project credentials work in devcontainers from any device, without re-bootstrapping the instance or re-unlocking anything device-specific.
+
+**Why this priority**: A broker design that only worked from the laptop that created the instance would fail Remo's core "remote dev environment" promise. The broker lives on the instance precisely to make this work.
+
+**Independent Test**: Create an instance from device A, run a devcontainer with broker creds successfully. Without reconnecting from device A, run `remo shell` from device B against the same instance, launch the same devcontainer, verify credentials still work.
+
+**Acceptance Scenarios**:
+
+1. **Given** an instance was created from device A, **When** the user runs `remo shell` from device B, **Then** the broker is already running and serves credentials to launched devcontainers without intervention.
+2. **Given** the instance has been rebooted, **When** the broker comes back up, **Then** it re-reads its bootstrap token, re-authenticates to the backend, and resumes serving without any device needing to connect.
+3. **Given** an autonomous Claude Code session was started in a devcontainer before the user disconnected, **When** the developer is offline overnight, **Then** the session continues to access its allowlisted credentials.
+
+---
+
+### User Story 3 - Provisioning credentials never reach the instance (Priority: P1)
+
+A developer runs `remo hetzner create myproject`. Remo reads the Hetzner API token from the laptop's fnox (not from `HETZNER_API_TOKEN` in the laptop's shell env), uses it to provision the VM, and then forgets it. After provisioning, the Hetzner API token has never been written to the instance, never appeared in cloud-init user-data visible in the Hetzner console, and is not present in the laptop's process environment.
+
+**Why this priority**: Provisioning credentials are typically the most powerful (can create/destroy any resource in the account) and the easiest to leak. The instance has no need for them.
+
+**Independent Test**: With `HETZNER_API_TOKEN` *unset* in the laptop shell but stored in the laptop's fnox config, run `remo hetzner create test`, then `ssh remo@test "env | grep -i hetzner"` returns nothing and the Hetzner console's user-data field for the VM contains no token.
+
+**Acceptance Scenarios**:
+
+1. **Given** Hetzner API token is stored in the laptop's fnox and *not* exported in the laptop's environment, **When** `remo hetzner create` runs, **Then** provisioning succeeds.
+2. **Given** an instance has been created, **When** the user inspects cloud provider metadata/user-data via the provider's console or API, **Then** no provisioning credentials are visible.
+3. **Given** the same setup, **When** the user inspects the instance OS, **Then** no provisioning credentials are present in environment, dotfiles, or any disk location.
+
+---
+
+### User Story 4 - Per-project credential allowlist via the manifest (Priority: P2)
+
+A developer clones a new repo into `~/projects/foo`. Selecting it from the menu either reads the committed `.devcontainer/remo-broker.toml`, or — if absent — synthesizes a default `.remo/broker.toml` declaring only `github_token` (enough for `git push`). The developer can broaden the allowlist by editing the manifest; secrets not in the manifest cannot be fetched, even by tools that know their names.
+
+**Why this priority**: The allowlist is the policy mechanism that makes the kernel-enforced isolation actually meaningful. Without it, every devcontainer would see every secret.
+
+**Independent Test**: Place a project with a manifest declaring only `github_token`. Inside the devcontainer, attempt to fetch `npm_token` via the broker socket (`remo-broker get npm_token`) — expect refusal. Add `npm_token` to the manifest, restart the devcontainer, retry — expect success.
+
+**Acceptance Scenarios**:
+
+1. **Given** a project with no manifest, **When** the user selects it from the menu, **Then** Remo synthesizes `.remo/broker.toml` with a minimal default allowlist (gitignored) and proceeds.
+2. **Given** a project with `.devcontainer/remo-broker.toml` declaring `[mcp] secrets = ["x", "y"]`, **When** the devcontainer requests secret `z`, **Then** the broker returns a denial and logs the attempt.
+3. **Given** the manifest is updated, **When** the devcontainer is rebuilt or restarted, **Then** the new allowlist takes effect.
+
+---
+
+### User Story 5 - Bootstrap token rotation and instance destruction revoke access (Priority: P2)
+
+When `remo destroy` runs against any instance, Remo revokes the bootstrap token at the backend *before* destroying the instance. A long-running rotation policy also periodically replaces each instance's bootstrap token. A token leaked from a destroyed or rotated-away instance has no remaining backend access.
+
+**Why this priority**: Without revocation, the broker design just relocates the attack surface from "credentials on disk" to "bootstrap tokens that live until manually rotated." Lifecycle integration is what makes the threat model honest.
+
+**Independent Test**: Create an instance, save a copy of its bootstrap token externally. Destroy the instance. Use the saved token to attempt to fetch a secret — expect failure within the backend's revocation propagation window (typically seconds).
+
+**Acceptance Scenarios**:
+
+1. **Given** an instance with an active bootstrap token, **When** `remo destroy` runs, **Then** the token is revoked at the backend before any instance-deletion API call.
+2. **Given** a rotation policy is configured, **When** the rotation interval elapses, **Then** a fresh bootstrap token is provisioned to the instance and the previous one is revoked.
+3. **Given** rotation fails for any reason, **When** the broker detects auth failures against the backend, **Then** it surfaces an actionable error and continues serving in-memory-cached credentials until they expire.
+
+---
+
+### User Story 6 - Devcontainer auto-synthesis for projects without one (Priority: P2)
+
+The current project menu launches `devcontainer up` only when a project contains `.devcontainer/devcontainer.json`; otherwise it falls back to a plain shell on the instance OS, defeating the credential boundary. With this feature, projects without a committed devcontainer get an auto-synthesized `.remo/devcontainer.json` based on simple language detection, so *every* project the user selects from the menu lands them in a devcontainer with a broker socket.
+
+**Why this priority**: The instance-OS fallback is the leak that defeats the rest of the design. Required for correctness.
+
+**Independent Test**: Clone a repo with no `.devcontainer/` and a `package.json`. Select it from the menu. Expect to land in a Node-based devcontainer with a project socket mounted, not in a shell on the instance OS.
+
+**Acceptance Scenarios**:
+
+1. **Given** a project with no devcontainer config and a recognized language marker (`package.json`, `Cargo.toml`, `pyproject.toml`, etc.), **When** the user selects it, **Then** Remo writes `.remo/devcontainer.json` matching the language and launches it.
+2. **Given** a project with no language marker, **When** the user selects it, **Then** Remo uses a generic base image and proceeds.
+3. **Given** the user explicitly wants a shell on the instance OS, **When** they pick the "exit to host shell" menu option, **Then** they get one — with a one-time warning that no broker is available there.
+
+---
+
+### Edge Cases
+
+- **Backend unavailable**: broker holds in-memory-cached secrets until they expire, then surfaces clear errors to devcontainers. Does not silently return stale values past expiry.
+- **Backend unreachable from instance (network issue)**: broker reports the error via the project socket; tools using the broker see a clear "credential unavailable" error rather than a generic auth failure.
+- **Two projects with the same name in different parent dirs**: project socket naming uses the absolute project path's hash (truncated) as suffix to avoid collisions.
+- **A devcontainer escape into the instance OS**: attacker gains access to every project socket currently mounted in the instance plus the bootstrap token. Rotation interval and per-instance scoping bound the damage; full-backend access is not possible.
+- **A node-level compromise on Incus/Proxmox**: attacker gains every instance's bootstrap token on that node. Threat model treats nodes as critical assets requiring OS hardening separate from instances.
+- **A user runs untrusted code on the instance OS rather than in a devcontainer** (via "exit to host shell"): no broker available, so user secrets are simply not present. The escape hatch is safe by absence.
+- **A project manifest declares a secret that doesn't exist in the backend**: broker returns a "not found" error to the devcontainer; tool's behavior depends on the tool, but the broker itself does not crash or fall back to other secrets.
+- **The user has chosen `age + git` as backend** (no per-instance scoping primitive): `remo init` warns that this backend does not support narrowly-scoped bootstrap tokens; either reject the combination or fall back to laptop-unlock-per-session for Hetzner/Incus/Proxmox.
+- **AWS SSM access mode**: bootstrap (instance profile) is metadata-based, no SSH push needed; broker installation still proceeds via the standard `*_configure.yml` flow which already works over SSM.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+**Backend integration**
+- **FR-001**: System MUST support pluggable backends for the credential store, with first-class support for 1Password, HashiCorp Vault, AWS Secrets Manager, and age-encrypted git for the v1 cut.
+- **FR-002**: System MUST allow per-installation backend choice via `remo init`, persisted to laptop-side fnox configuration.
+- **FR-003**: System MUST warn the user at `init` time when their selected backend lacks per-instance scoping primitives (age + git) and offer a more secure alternative or a clearly-described downgrade.
+
+**Provisioning credentials**
+- **FR-004**: System MUST read provisioning credentials (HETZNER_API_TOKEN, AWS access keys, Incus/Proxmox API tokens) from the laptop's fnox rather than the laptop's shell environment.
+- **FR-005**: System MUST NOT write provisioning credentials to any instance's disk, environment, or cloud-init user-data.
+- **FR-006**: System MUST replace `lookup('env', '<TOKEN>')` patterns in `ansible/group_vars/all.yml` with `lookup('pipe', 'fnox get ...')` invocations against the laptop's fnox.
+
+**Bootstrap & broker installation**
+- **FR-007**: System MUST install the broker (`remo-broker` daemon + systemd unit; Remo-owned, embeds fnox for backend retrieval) on every Remo instance as part of the standard `*_configure.yml` Ansible flow.
+- **FR-008**: For AWS, system MUST attach an instance-scoped IAM role at create time and configure the broker to use IMDS for credentials. No bootstrap token shall be written to disk.
+- **FR-009**: For Hetzner, system MUST mint an instance-scoped bootstrap token on the laptop, SSH-push it to `/etc/remo-broker/bootstrap-token` (mode 0400, root) after first boot, and not include the token in any cloud-init user-data.
+- **FR-010**: For Incus and Proxmox, system MUST mint the bootstrap token on the laptop, place it under `/var/lib/remo-broker/instance-tokens/<instance>` on the *node* (not in any instance), and bind-mount it read-only into the instance at `/etc/remo-broker/bootstrap-token`. The node itself MUST NOT inspect or store project information.
+- **FR-011**: System MUST register the node (one-time per Incus/Proxmox node) via a new `remo incus add-node` and `remo proxmox add-node` command, installing the token-manager helper.
+
+**Project sockets and manifests**
+- **FR-012**: System MUST discover project manifests in priority order: `.devcontainer/remo-broker.toml` (committed) → `.remo/broker.toml` (auto-synthesized, gitignored).
+- **FR-013**: System MUST auto-synthesize a minimal default manifest declaring `github_token` for projects with no existing manifest.
+- **FR-014**: System MUST create one project socket per active project at `/run/remo-broker/<project>.sock` on the instance, enforcing the project's manifest allowlist.
+- **FR-015**: System MUST mount the appropriate project socket into the project's devcontainer at `/run/remo-broker/sock` via devcontainer bind-mount configuration.
+- **FR-016**: System MUST remove a project socket when its associated devcontainer exits.
+
+**Devcontainer enforcement**
+- **FR-017**: The project menu MUST launch every selected project inside a devcontainer (committed or auto-synthesized), with no fallback to running the project on the instance OS.
+- **FR-018**: The project menu MUST provide an explicit "exit to instance shell" option that surfaces a one-time warning explaining the broker is not available outside a devcontainer.
+- **FR-019**: The instance OS shell MUST NOT have a broker socket available by default.
+
+**Lifecycle**
+- **FR-020**: `remo destroy` MUST revoke an instance's bootstrap token at the backend *before* destroying the instance.
+- **FR-021**: System MUST support periodic rotation of bootstrap tokens via a `remo rotate-bootstrap [instance]` command, configurable to run automatically on a cadence.
+- **FR-022**: The broker MUST hold user-secret values in memory only, never writing them to disk on the instance.
+
+**Auditability**
+- **FR-023**: The broker MUST log every secret-access request (project, secret name, allowed/denied, timestamp) to a local log file readable only by root on the instance.
+- **FR-024**: System MUST provide a `remo audit <instance>` command that retrieves and displays the broker's access log.
+
+### Non-Functional Requirements
+
+- **NFR-001**: A broker-mediated secret fetch in the steady state (warm cache) MUST add no more than 50 ms latency over a direct env-var read.
+- **NFR-002**: The broker MUST survive `systemd` restarts and instance reboots without manual reconfiguration.
+- **NFR-003**: An instance's broker MUST function for all configured backends across a backend network outage by serving the last in-memory-cached value until that value's TTL expires.
+
+### Key Entities
+
+- **Node** (new model): represents an Incus or Proxmox node registered with Remo. Fields include `name`, `host` (SSH target), `provider`, `bootstrap_admin_identity` (an SA admin token capable of minting per-instance sub-tokens, stored in laptop's fnox). Not used for AWS or Hetzner.
+- **Bootstrap token** (no Remo model — opaque string): the per-instance backend identity. Located at `/etc/remo-broker/bootstrap-token` on instance, `/var/lib/remo-broker/instance-tokens/<name>` on node (self-hosted only). On instances with a TPM, the token SHOULD be sealed at rest via systemd's `LoadCredentialEncrypted` / TPM2 binding so that an offline disk read does not yield a usable token.
+- **Project manifest** (TOML file in repo or `.remo/`): declares the set of backend secret names this project requires. Read by the broker when minting a project socket.
+- **Project socket** (Unix domain socket): per-project, per-instance, ephemeral, enforces the manifest's allowlist.
+- **Broker** (process): one per instance, runs as a systemd unit (`remo-broker.service`), Remo-owned code that holds the bootstrap token, embeds fnox as its multi-backend retrieval library, holds a memory-only TTL cache of recently-resolved user secrets, enforces per-project allowlists, and writes an append-only audit log.
+- **KnownHost** (existing model, unchanged): continues to represent L2 instances and their SSH-target metadata.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: After feature is fully adopted, **zero long-lived user secrets** are written to any Remo instance's disk. Verified by auditing `~/.aws/`, `~/.config/gh/`, `~/.npmrc`, `~/.netrc`, and `env` across a representative sample of instances.
+- **SC-002**: A simulated supply-chain attack — a malicious `postinstall` script running `printenv`, `cat ~/.aws/credentials`, `cat ~/.config/gh/hosts.yml`, and an outbound HTTP exfil call from inside a devcontainer — recovers **only** the secrets declared in that project's manifest, and no others.
+- **SC-003**: `remo shell` works from any device the user has authenticated to the backend from, with **no per-device instance reconfiguration** required.
+- **SC-004**: Provisioning a new instance and launching a devcontainer adds **no more than 30 seconds** to today's flow on a typical broadband connection (warm laptop fnox cache, warm backend).
+- **SC-005**: After `remo destroy`, a copy of the destroyed instance's bootstrap token is **rejected by the backend within 60 seconds**.
+- **SC-006**: When the user adds a secret to a project manifest, it becomes available inside that project's devcontainer **on the next devcontainer restart**, with no instance-level configuration changes.
+
+## Component Sourcing
+
+This section records why the broker is built rather than adopted, and which external components are leveraged.
+
+### Adopted: fnox (laptop CLI + on-instance retrieval library)
+
+[`fnox`](https://github.com/jdx/fnox) is a mature (v1.25.1, ~39 releases, post-1.0) multi-backend secret-fetching CLI that already abstracts 1Password, HashiCorp Vault, AWS Secrets Manager, age, and the OS keychain behind a single `fnox get <name>` interface. Remo adopts fnox in two roles:
+
+1. **Laptop-side provisioning credential lookup** — `lookup('pipe', 'fnox get …')` invocations in Ansible replace `lookup('env', …)` patterns (FR-006). The laptop already typically has fnox configured for the developer's day-to-day secret access.
+2. **On-instance backend retrieval inside the broker** — the `remo-broker` daemon embeds fnox (as a subprocess or library, design-deferred) to resolve a name like `GITHUB_TOKEN` to a fetched value via whichever backend is configured for that instance.
+
+This sidesteps the largest single body of work in the spec — writing and maintaining adapters for five different secret stores, each with its own auth model and SDK.
+
+### Built: the `remo-broker` daemon
+
+A broader survey of credential-broker-adjacent tooling (Vault Agent, OpenBao Agent, SPIFFE/SPIRE, Teleport Machine ID, Infisical Agent, systemd credentials, 1Password Connect, EKS Pod Identity Agent, Doppler, sops, Bitwarden Secrets Manager, aws-vault) found **no single existing tool that combines** the four properties this spec requires:
+
+1. Multi-backend retrieval (1Password + Vault + AWS SM + age + keychain in one process).
+2. Per-project Unix-socket serving (one socket per project, distinct allowlists).
+3. Manifest-driven allowlists that the broker itself enforces.
+4. Bootstrap modes spanning IMDS (AWS), token-file (Hetzner), and node-bind-mount (Incus/Proxmox).
+
+The closest single-tool fit is **Vault Agent / OpenBao Agent**, but it is single-backend (Vault-only) and its per-listener `role` / `require_request_header` knobs are anti-SSRF controls rather than per-project secret allowlists — true allowlisting would require one agent process per project, which defeats the operational model.
+
+The strongest patterns to *borrow* (not adopt wholesale) come from:
+
+- **EKS Pod Identity Agent** — proves the "token-file mounted into client → daemon returns only that client's allowed credentials" pattern in production.
+- **SPIFFE/SPIRE Workload API** — proves that kernel-attested per-caller scoping over a Unix socket is practical.
+
+The broker therefore is Remo-owned code, with these influences guiding its IPC and attestation design. It is small (estimated low single thousands of lines), policy-driven, and depends on fnox-core for the genuinely complex backend-integration work.
+
+#### Repository layout and implementation language
+
+The `remo-broker` daemon lives in a separate repository (`get2knowio/remo-broker`) for reasons of language asymmetry (Rust vs. Remo's Python), distribution shape (signed binary releases vs. PyPI), release cadence (the daemon is install-once, the laptop CLI iterates), and audit surface. Implementation language: **Rust**, with [`fnox-core`](https://crates.io/crates/fnox-core) (MIT, published by the fnox author) as a Cargo dependency — closes OQ-7 in the "library" direction by avoiding subprocess fork/exec per uncached fetch and keeping secret values inside fnox-core's typed wrappers end-to-end.
+
+The new repo owns the broker's internal design and the two cross-repo contracts:
+
+- `specs/001-broker-daemon/spec.md` — full feature spec for the daemon
+- `docs/manifest-schema.md` — versioned TOML schema for `remo-broker.toml` (cross-repo contract; source of truth here, JSON Schema published per release and consumed by Remo for laptop-side validation)
+- `docs/wire-protocol.md` — project-socket and admin-socket wire protocol (cross-repo contract)
+
+Schema-drift mitigations between the two repos: (1) JSON Schema generated from Rust types and validated on the Remo side, (2) `schema_version` integer in every manifest with broker-side refusal of unknown versions, (3) end-to-end CI test exercising both repos against a real manifest + socket round-trip.
+
+### Future escape hatches
+
+- If fnox becomes unmaintained or unsuitable, the natural swap is **OpenBao Agent** (MPL-2.0) running one agent per project behind a thin Remo supervisor. Trade-off: loss of native 1Password / OS-keychain support unless those are proxied via OpenBao secret engines.
+- If a generic broker daemon emerges upstream that meets all four requirements above, Remo's broker can be retired in favor of it.
+
+### Complementary, used underneath the broker
+
+- **systemd `LoadCredentialEncrypted` + TPM2** — used to seal the bootstrap-token file at rest on TPM-equipped instances (typically Incus / Proxmox nodes), so an offline disk read does not yield a usable token. Does not replace any broker function — it hardens token storage.
+
+## Out of Scope
+
+- **Sandboxing untrusted code beyond the devcontainer boundary**: this spec does not require additional in-devcontainer sandboxing (gVisor, firejail, network egress restrictions per-install-script). Those are complementary defenses worth considering separately.
+- **Replacing existing SSH key management**: the broker handles user secrets fetched at runtime by devcontainer tooling. SSH key material for `remo shell` itself remains handled by the existing flow (laptop ssh-agent forwarding or instance-resident keys, depending on access mode).
+- **Backend selection UI improvements** beyond the minimum needed at `remo init`. A full backend management TUI is future work.
+- **Secret rotation at the user-secret level**: this spec rotates *bootstrap tokens* (the broker's identity). Rotation of the actual GitHub PAT, NPM token, etc. is the backend's concern and the user's policy choice.
+- **Multi-user instances**: this spec assumes each instance has one developer user. Multi-tenant instances would need per-user project-socket isolation, deferred to future work.
+
+## Open Questions
+
+- **OQ-1**: Should the project socket be created per-devcontainer-lifetime or per-project-lifetime? The former gives strict ephemerality but may complicate background tasks like `cargo build` running across `devcontainer exec` invocations. The latter is operationally simpler.
+- **OQ-2**: For Incus/Proxmox nodes that host instances from multiple developers, how is the node's admin identity (used to mint sub-tokens for each developer's instances) bootstrapped? Per-developer admin SAs, or a single node admin SA with logical sub-scoping?
+- **OQ-3**: Should the broker also serve the `gh` git credential helper protocol natively, or is `gh auth login --with-token` against a broker-fetched token sufficient?
+- **OQ-4**: Default rotation cadence for bootstrap tokens — 24h, 7d, or "never (revoke only on destroy)"? Trade-off is operational noise vs. exposure window.
+- **OQ-5**: How should the broker behave when a backend requires interactive auth (e.g., 1Password biometric prompt) and the requesting context is non-interactive (autonomous AI agent at 3am)? Refuse and surface the requirement, or rely entirely on non-interactive backend identities (SA tokens) and forbid interactive ones for instance use?
+- **OQ-6**: Should the broker make the bootstrap-token file's TPM2 sealing mandatory on instances where a TPM is available, or remain opt-in via configuration? Mandatory closes the offline-disk-read attack reliably; opt-in avoids surprises for users on older hardware or with custom systemd setups.
+- **OQ-7**: Should the broker embed fnox as a Rust library (tight coupling, one process, faster) or shell out to the `fnox` binary as a subprocess (loose coupling, version-independent, slower)? Subprocess is simpler to ship and lets users upgrade fnox independently; library is faster and avoids a fork+exec per uncached fetch but locks the broker to a specific fnox version.
+- **OQ-8**: What's the wire protocol on the project socket — a simple line-based `GET <name>\n` / `<value>\n` shape, a fnox-CLI-compatible protocol (so tools that already speak fnox work unchanged), or something richer (gRPC, JSON-RPC) that supports streaming, watches, and structured errors? Simpler is easier to audit; richer enables future features like credential-change notifications.

--- a/notifier/Dockerfile
+++ b/notifier/Dockerfile
@@ -1,0 +1,38 @@
+# Remo Notifier — multi-stage build.
+#
+# All COPY paths are relative to the build-context root. The context root is
+# either the repo root (local builds: `docker build -f notifier/Dockerfile .`)
+# or the on-host copy of the bundled context (remo_notifier Ansible role), which
+# reproduces the same layout. See specs/007-notifier-sidecar (finding U1).
+
+# ---- Stage 1: builder ------------------------------------------------------
+FROM python:3.13-slim AS builder
+WORKDIR /build
+RUN pip install --no-cache-dir uv
+# pyproject.toml + README.md + source are required to install the project.
+# uv.lock is included for an optional `uv sync --frozen` locked build; a plain
+# `uv pip install` does not consume it (finding I1).
+COPY pyproject.toml uv.lock README.md ./
+COPY src/ ./src/
+# The remo-cli wheel force-includes ansible/ (and the Dockerfile lives under
+# notifier/), so both must be present in the build context for hatchling to
+# resolve its forced includes during install.
+COPY ansible/ ./ansible/
+COPY notifier/ ./notifier/
+RUN uv venv /opt/venv && \
+    . /opt/venv/bin/activate && \
+    uv pip install --no-cache-dir ".[notifier]"
+
+# ---- Stage 2: runtime ------------------------------------------------------
+FROM python:3.13-slim
+RUN groupadd --system --gid 65532 notifier && \
+    useradd --system --uid 65532 --gid notifier --no-create-home \
+        --shell /usr/sbin/nologin notifier
+COPY --from=builder /opt/venv /opt/venv
+ENV PATH="/opt/venv/bin:$PATH"
+USER 65532:65532
+EXPOSE 18181
+HEALTHCHECK --interval=30s --timeout=3s --start-period=5s --retries=3 \
+    CMD python -c "import urllib.request; urllib.request.urlopen('http://127.0.0.1:18181/v1/health', timeout=2)"
+ENTRYPOINT ["remo-notifier"]
+CMD ["serve", "--config", "/etc/notifier/notifier.toml"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,3 +54,9 @@ asyncio_mode = "auto"
 [tool.ruff]
 src = ["src"]
 line-length = 100
+
+[tool.uv]
+# Supply-chain cooldown: ignore distributions uploaded in the last 7 days so a
+# malicious release has time to be detected/yanked before it can be resolved.
+# Relative (rolling) window; relies on PyPI's PEP 700 upload-time metadata.
+exclude-newer = "7 days"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,13 +21,25 @@ dependencies = [
 dev = [
     "pytest",
     "pytest-mock",
+    "pytest-asyncio",
+    "pytest-cov",
+    "httpx",
     "ruff",
     "mypy",
+]
+notifier = [
+    "fastapi>=0.115",
+    "uvicorn[standard]>=0.32",
+    "pydantic>=2.9",
+    "python-telegram-bot>=21.6",
+    "structlog>=24.4",
+    "tomli>=2.0; python_version<'3.11'",
 ]
 
 [project.scripts]
 remo-cli = "remo_cli.cli.main:cli"
 remo = "remo_cli.cli.main:cli"
+remo-notifier = "remo_cli.notifier.cli:main"
 
 [tool.hatch.build.targets.wheel]
 packages = ["src/remo_cli"]
@@ -37,6 +49,7 @@ packages = ["src/remo_cli"]
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]
+asyncio_mode = "auto"
 
 [tool.ruff]
 src = ["src"]

--- a/specs/007-notifier-sidecar/addendum-001-standing-grants.md
+++ b/specs/007-notifier-sidecar/addendum-001-standing-grants.md
@@ -1,0 +1,338 @@
+# Addendum 001 — Standing Grants ("Always" auto-approval)
+
+**Parent spec**: [`spec.md`](./spec.md) (Notifier Sidecar, spec 007)
+**Status**: Draft (design only — no implementation)
+**Created**: 2026-05-31
+**Depends on**: the implemented v1 notifier (FR-001…FR-034, FR-003a, FR-010a).
+
+## Purpose
+
+Add a third decision to the approval flow: alongside **Approve** / **Deny**, the
+human can choose **Always** — auto-approving the *class* of operation this
+request belongs to, so future matching requests are answered without a Telegram
+round-trip.
+
+This extends the per-event model (today every tap approves exactly one
+`approval_id`) with a **standing grant**: a human-authored, deterministic rule
+the notifier matches on intake.
+
+## Architecture decision (why the grant lives in the notifier, for now)
+
+agentsh's `api` approval mode **delegates the approve decision to the notifier**
+(it is the registered REST approver). An approver answering from a human's prior
+standing instruction is within that delegated authority — it is not a shadow
+policy, it is the approver having memory. agentsh has no path today for an
+approver to hand a rule back into its signed/versioned policy, so the only
+buildable home for the grant is the notifier.
+
+Consequences this addendum accepts deliberately:
+
+- The notifier becomes **`allow`-capable**. Today a notifier fault fails secure
+  (no prompt → deny); with grants, a matcher fault can manufacture `allow`. The
+  matcher is therefore the most security-critical code in the service and MUST
+  be deterministic and exact (see FR-G4).
+- Standing grants live **outside** agentsh's audited policy, so the notifier's
+  own list / revoke / audit surface is the backstop (FR-G7, FR-G8).
+- The v1 grant store is **in-memory, scoped, and TTL-bounded** — it fails closed
+  on restart (you get re-asked), avoiding an on-disk security datastore. This
+  keeps the "no durable state" property of the parent spec intact.
+
+### Forward compatibility (promotion to agentsh policy)
+
+The grant predicate is **shaped like an agentsh policy rule** (its
+`paths`/`operations`/`match`/host+port grammar). If agentsh later grows an
+"approver returns a signed rule" capability, a notifier grant promotes straight
+into agentsh's signed, versioned, audited policy with no reshaping — moving the
+grant from "the approver remembers" up to "it's in the audited policy," the
+better long-term home. This addendum does not require that agentsh change; it
+only keeps the door open.
+
+## Decisions captured (from design discussion)
+
+- **D1**: Grant enforcement lives in the notifier (in-memory) for v1, under the
+  delegated-approver model above. Not agentsh-side yet (no such capability).
+- **D2**: **Everything is generalizable** in v1 — no category that is ineligible
+  for "Always." The schema carries an `eligible` flag so a denylist
+  (destructive / egress / secrets) can be added later via config with no
+  protocol change.
+- **D3**: Grants are **in-memory, scoped, TTL-bounded, fail-closed**. No
+  cross-restart persistence in v1.
+- **D4**: Grant predicates are agentsh-rule-shaped for future promotion (D-fwd).
+- **D5**: The matcher is deterministic/exact; the *intelligence* (proposing the
+  class) happens once, at tap-time, with the human confirming.
+
+## Clarifications
+
+### Session 2026-06-01
+
+- Q: Does a single "Always" cover a bundle of related syscall-level events, and how is the bundle identified? → A: No bundling in v1. The matcher is strictly per-operation; breadth comes from the human choosing a broader predicate, with `policy_rule_name` available as the broadest candidate rung (folds into FR-G6, not a new primitive).
+- Q: Should "Always" be offered on first encounter or only after the class repeats N times? → A: Offer on every prompt; rely on tightest-first candidates (FR-G6) and narrow default scope (FR-G7) as guardrails. Repeat-gated offering is a future enhancement.
+- Q: Single global default TTL or per-grant lifetime choice? → A: Single configurable `default_ttl_seconds` (default 8h) applied to every grant; no "until revoked" / indefinite grants in v1. Per-grant lifetime choice deferred.
+- Q: How are active grants listed — bridge read endpoint, or Telegram/SSH only? → A: No bridge read endpoint in v1 (avoids disclosing the auto-approve set to co-located containers). Telegram `/rules` is the only list+revoke surface; `GET /v1/grants` and the `remo notifier rules` CLI are dropped/deferred (loopback-only admin port is the future option).
+
+## User Scenarios
+
+### US-G1 — Human grants "Always" for a class (Priority: P1)
+
+A request arrives the human has seen before. Instead of Approve, they tap
+**Always…**, pick a generalization + scope from a short list, and confirm. This
+request is approved *and* a standing grant is created. The next matching request
+returns `allow` instantly with no Telegram message.
+
+**Independent test**: Tap Always on a request; send a second matching request →
+it returns `allow` in well under a second with no notification, and the audit
+log records the grant id.
+
+### US-G2 — Human reviews and revokes standing grants (Priority: P1)
+
+The human runs `/rules` in Telegram and sees active grants (class, scope, age,
+TTL, use count). They `/revoke <id>` (or tap a revoke button); subsequent
+matching requests prompt again.
+
+**Independent test**: Create a grant, `/revoke` it, send a matching request →
+the human is prompted again.
+
+### US-G3 — Auto-approvals stay visible (Priority: P2)
+
+Auto-approved operations are logged with their grant id, and a periodic digest
+("auto-approved N ops via M rules") is delivered so standing grants are never
+silent.
+
+## Functional Requirements (additive)
+
+### Intake short-circuit
+
+- **FR-G1**: On `POST /v1/approve`, before reserving a slot or notifying, the
+  notifier MUST evaluate the request against active standing grants. On a match,
+  it MUST return `200` with `decision: allow` immediately, without sending any
+  notification and without occupying a pending slot.
+- **FR-G2**: An auto-approval response MUST identify its source: `responder` =
+  `rule:{grant_id}` and `reason` = a fixed marker (e.g. `auto-approved via
+  standing grant`). The `grant_id` MUST appear in the response so callers and
+  audit can correlate.
+- **FR-G3**: On no match, the existing flow (reserve → notify → await, FR-001…
+  FR-010a) applies unchanged.
+
+### The matcher (allow-capable — highest criticality)
+
+- **FR-G4**: A request matches a grant **iff** all hold, evaluated
+  deterministically (no fuzzy/semantic matching at runtime): (a) the grant is
+  active (not expired, not revoked); (b) the request scope satisfies the grant
+  scope (FR-G9); (c) the operation satisfies the grant predicate exactly
+  (FR-G5). Any ambiguity or evaluation error MUST be treated as **no match**
+  (fail-closed → prompt the human).
+- **FR-G5**: The grant predicate MUST be a structured, inspectable rule over the
+  operation fields (kind; for `command`: command + an args matcher of exact /
+  prefix / glob; for `file`: path globs + operations; for `network`: host
+  exact-or-suffix + port; for `signal`: signal + target). It MUST NOT contain
+  free-form/learned matching. Predicate grammar mirrors agentsh policy rules
+  (D4).
+
+### Deriving the class (proposal, at tap-time)
+
+- **FR-G6**: When the human taps **Always…**, the notifier MUST present a small
+  ordered set of candidate generalizations — **at most 4** (tightest first) — derived from the
+  request via deterministic templates per operation kind, each paired with a
+  scope choice. The broadest candidate rung MAY be a `policy_rule_name`-based
+  predicate (auto-approve operations agentsh attributes to the same rule, within
+  scope). The human selects exactly one. The notifier MUST NOT create a grant
+  broader than what the human selected, and there is **no bundling primitive** —
+  every grant is matched per-operation (FR-G4/G5).
+
+### Lifecycle, scope, limits
+
+- **FR-G7**: Grants MUST carry a **scope** (`session` | `workspace` | `project`
+  | `instance` | `global`) and the notifier MUST default new grants to the
+  **narrowest scope that covers the request** unless the human explicitly widens
+  it. (`global` is permitted in v1 per D2 but is never the default.)
+- **FR-G8**: Grants MUST carry a **TTL** and MUST stop matching once expired.
+  v1 applies a single configurable `default_ttl_seconds` (default 8h) to every
+  grant; there is **no indefinite / "until revoked" grant** (per-grant lifetime
+  choice is deferred). Revocation (FR-G10) is always available before expiry.
+- **FR-G9**: Grant state MUST be **in-memory only**; a restart loses all grants
+  and subsequent requests fail closed (re-prompt). The notifier MUST enforce a
+  configurable **maximum number of active grants**, rejecting new grants beyond
+  it with a clear Telegram message (mirrors the pending-approval cap, FR-034).
+
+### Visibility, revocation, audit
+
+- **FR-G10**: The human MUST be able to **list** active grants and **revoke** any
+  grant, from Telegram (`/rules`, `/revoke <id>`), with effect on subsequent
+  requests being immediate. A **global pause** ("disable all auto-approval") MUST
+  be available.
+- **FR-G11**: Every auto-approval MUST be logged with its `grant_id` and the
+  matched operation's structural metadata (never secrets/bodies — FR-017), and
+  the notifier SHOULD deliver a periodic digest of auto-approval activity.
+
+### Configuration
+
+- **FR-G12**: Configuration MUST include: grants enabled/disabled,
+  `default_ttl_seconds`, `max_grants`, `allow_global_scope`, and
+  `digest_interval_seconds` (0 disables the digest). The grant schema MUST carry
+  an `eligible` flag per class so a future ineligibility denylist (D2) can be
+  applied without a protocol change.
+
+## Wire-protocol changes (additive, backward-compatible)
+
+### `ApprovalResponse` — new optional fields
+
+- `responder` already exists; auto-approvals set it to `rule:{grant_id}`.
+- Add optional `grant_id` (string) — present on auto-approved (FR-G2) and on the
+  response that *created* a grant (the "Always" tap), echoing the new grant's id.
+
+### `Grant` (new object)
+
+Returned to the caller on the response that creates a grant, and the internal
+record the matcher evaluates. Agentsh-rule-shaped (D4):
+
+```json
+{
+  "grant_id": "uuid",
+  "created_at": "RFC3339",
+  "created_by": "telegram:paulofallon",
+  "expires_at": "RFC3339",
+  "source_approval_id": "uuid",
+  "scope": { "type": "project", "value": "myproj" },
+  "eligible": true,
+  "predicate": {
+    "kind": "command | file | network | signal",
+    "command": "git",
+    "args_match": { "type": "prefix", "value": ["push"] },
+    "paths": ["{{workspace}}/**"],
+    "operations": ["delete"],
+    "host": { "type": "suffix", "value": ".github.com" },
+    "port": 443
+  },
+  "uses_count": 0,
+  "last_used_at": null
+}
+```
+
+(Only the predicate fields relevant to `kind` are present.)
+
+### Endpoints
+
+- `POST /v1/approve` — gains the FR-G1 short-circuit; response may carry
+  `grant_id`. No breaking change for callers that ignore it.
+- **No** new externally-mutating endpoint. Grant creation happens only via a
+  human Telegram tap; grant revocation happens via Telegram (`/revoke`). This
+  keeps mutation authenticated to the authorized chat and off the unauthenticated
+  bridge port.
+- **No `GET /v1/grants` in v1** (resolved OQ4): a bridge-bound read endpoint
+  would disclose the auto-approve set to co-located containers — the very agents
+  being gated. Listing is **Telegram `/rules` only**. A future host-loopback-only
+  admin port could back a CLI lister without bridge exposure.
+
+## Telegram UX
+
+Inline keyboard becomes a two-tap flow:
+
+```
+[✅ Approve]   [⏩ Always…]   [❌ Deny]
+```
+
+- **Always…** edits the message into a granularity + scope picker built from
+  FR-G6 candidates, e.g. for `git push origin main` in project `myproj`:
+
+  ```
+  Always allow:
+  [git push *  · this project]
+  [git *       · this project]
+  [git push *  · everywhere]
+  [Cancel]
+  ```
+
+  with the default TTL shown (e.g. "expires in 8h"). v1 keeps a single
+  configurable TTL; per-grant TTL choice is an open question (OQ2).
+- Selecting a candidate approves *this* request (allow) **and** creates the grant
+  (FR-G7/G8). The message is edited to confirm (`⏩ Always: git push * · myproj ·
+  8h · by @paulofallon`).
+- `/rules` lists active grants with inline `[Revoke]` buttons; `/revoke <id>`
+  and a `/pause` global toggle (FR-G10).
+
+## CLI additions
+
+- **None in v1** (resolved OQ4). Grant listing and revocation are Telegram-only
+  (`/rules`, `/revoke`, `/pause`). A `remo notifier rules <host>` command is
+  deferred until a host-loopback-only admin surface exists, to avoid exposing the
+  grant set on the bridge.
+
+## Config additions (sketch)
+
+```toml
+[grants]
+enabled = true
+default_ttl_seconds = 28800   # 8h
+max_grants = 100
+allow_global_scope = true     # D2: everything generalizable in v1
+```
+
+## Security considerations
+
+- **Allow-capable matcher** is the crown-jewel risk. Keep it exact and
+  deterministic; treat any uncertainty as no-match (FR-G4). Test the matcher as
+  adversarially as the fail-secure paths.
+- **Scope defaults narrow** (FR-G7) and **TTL bounds every grant** (FR-G8): the
+  two compensating controls that carry the safety budget now that everything is
+  eligible (D2). `global` is opt-in, never default.
+- **Fail-closed everywhere**: grant store unavailable, ambiguous match, expired,
+  or post-restart → prompt, never auto-allow.
+- **Revocation + visibility** (FR-G10) is the human's backstop since grants sit
+  outside agentsh's audited policy.
+- **No secrets in grant logs** (FR-017 still applies).
+- **Authority**: in v1's single-chat model, the one authorized chat mints and
+  revokes grants. Multi-chat authority is out of scope (parent spec constraint).
+
+## Out of scope (this addendum)
+
+- Cross-restart / on-disk grant persistence (revisit only if "forgot my Always
+  after redeploy" proves painful).
+- Promotion of grants into agentsh's signed policy (future; requires an agentsh
+  capability that does not exist today — see Forward compatibility).
+- A category **ineligibility** denylist (schema-ready via `eligible`, but no
+  enforced denylist in v1 per D2).
+- LLM/semantic class proposal. Candidate generation is deterministic templates
+  in v1; an LLM could later *suggest* labels but MUST NOT enter the runtime
+  matcher.
+- "Offer Always only after N repeats" behavioral heuristic (nice-to-have; see
+  OQ3).
+
+## Open questions
+
+- **OQ1 (agentsh)**: Does agentsh's `api` approval response have any extension
+  point, and what is its signing model for programmatically-added rules? This
+  determines if/when grants can be promoted into signed policy.
+- **OQ2 (TTL)**: ✅ Resolved (2026-06-01) — single configurable
+  `default_ttl_seconds` (default 8h) for every grant; no indefinite grants in
+  v1. See Clarifications.
+- **OQ3 (offer timing)**: ✅ Resolved (2026-06-01) — offer on every prompt;
+  guardrails are tightest-first candidates + narrow default scope. Repeat-gated
+  offering deferred. See Clarifications.
+- **OQ4 (read exposure)**: ✅ Resolved (2026-06-01) — no bridge read endpoint;
+  listing is Telegram `/rules` only; CLI lister deferred to a future
+  loopback-only admin port. See Clarifications.
+- **OQ5 (match granularity)**: ✅ Resolved (2026-06-01) — no bundling in v1; the
+  matcher is per-operation, with `policy_rule_name` available as the broadest
+  candidate predicate rung. See Clarifications.
+
+## Success criteria
+
+- [x] **SC-G1**: After a human grants Always for a class, a subsequent matching
+  request returns `allow` with no Telegram traffic. *(Verified: short-circuit
+  returns allow with no transport send — `test_grant_short_circuit_allows`. The
+  <500 ms bound is an in-memory dict+predicate match, not separately asserted —
+  accepted finding G2.)*
+- [x] **SC-G2**: No request is ever auto-approved except by an active, unexpired,
+  unrevoked, human-created grant whose deterministic predicate + scope it
+  satisfies; every other path still prompts or fails closed. *(Verified:
+  `test_grants.py` matcher suite + server fall-through/disabled/paused tests.)*
+- [x] **SC-G3**: A human can list and revoke any standing grant and globally pause
+  auto-approval, with immediate effect. *(Verified: `test_cmd_rules_revoke_pause`.)*
+- [x] **SC-G4**: Every auto-approval is individually auditable by `grant_id`, with
+  no secrets in the record. *(Verified: `test_auto_approval_audit_log_has_no_secrets`.)*
+- [x] **SC-G5**: A restart clears all grants and the system fails closed
+  (re-prompts). *(Verified: `test_fresh_store_is_empty_restart_fail_closed`.)*
+
+All SC-G verified via the local test suite (108 notifier tests, 91% coverage).
+No live-host/bot acceptance was required for grants — the loop is fully
+exercised against a fake transport and a mocked Bot.

--- a/specs/007-notifier-sidecar/checklists/requirements.md
+++ b/specs/007-notifier-sidecar/checklists/requirements.md
@@ -1,0 +1,37 @@
+# Specification Quality Checklist: Notifier Sidecar — Telegram approval bridge for agentsh
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-05-31
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+- The source prompt was implementation-heavy (named FastAPI, structlog, Dockerfile contents, file layout, etc.). Those details were intentionally deferred to the planning phase; the spec captures only observable behavior, the durable wire-protocol contract, the fail-secure guarantees, and the operator workflow.
+- "Telegram" and "HTTP" appear in the spec as they are intrinsic to the feature's purpose (the human-facing channel and the integration surface), not incidental technology choices. They are treated as product-level constraints, not implementation leakage.
+- Three clarifications (restart behavior, single authorized chat, network exposure) were resolved up front from the self-contained source prompt and recorded in the Clarifications section rather than left as markers.
+- Items marked incomplete require spec updates before `/speckit.clarify` or `/speckit.plan`.

--- a/specs/007-notifier-sidecar/contracts/grant-schema.md
+++ b/specs/007-notifier-sidecar/contracts/grant-schema.md
@@ -1,0 +1,128 @@
+# Contract — Standing Grants (Addendum 001)
+
+Defines the grant object, the deterministic match predicate grammar, the intake
+short-circuit behavior, and the Telegram interaction surface. Companion to
+[`openapi.yaml`](./openapi.yaml) (which carries the additive `grant_id` field)
+and the data model in `../data-model-addendum-001.md`.
+
+## Intake short-circuit (server)
+
+On `POST /v1/approve`, **before** the shutdown/health gate and `reserve()`:
+
+1. If grants are disabled or globally paused → skip to the normal pipeline.
+2. Else evaluate `GrantStore.match(request, now)`.
+3. On a match → respond `200` immediately with `ApprovalResponse`:
+   - `decision: "allow"`, `responder: "rule:{grant_id}"`,
+     `reason: "auto-approved via standing grant"`, `grant_id: "{id}"`,
+     `latency_ms` measured, `decided_at` now.
+   - No notification is sent; no pending slot is reserved.
+   - A structural audit line is logged; the grant's `uses_count` increments.
+4. On no match → the parent v1 pipeline runs unchanged (clamp → reserve → send →
+   await → 200/408/409/503).
+
+**Fail-closed**: any error evaluating a grant, an expired/revoked grant, a
+scope/predicate mismatch, or a missing request field the rule keys on ⇒ **no
+match** ⇒ the human is prompted.
+
+## Grant object
+
+```json
+{
+  "grant_id": "uuid",
+  "created_at": "2026-06-01T14:00:00Z",
+  "created_by": "telegram:paulofallon",
+  "expires_at": "2026-06-01T22:00:00Z",
+  "source_approval_id": "uuid",
+  "scope": { "type": "project", "value": "myproj" },
+  "eligible": true,
+  "predicate": { "kind": "command", "command": "git",
+                 "args": ["push"], "args_match": "prefix" },
+  "uses_count": 0,
+  "last_used_at": null
+}
+```
+
+`expires_at = created_at + grants.default_ttl_seconds` (default 8h). No
+indefinite grants in v1. `eligible` is always `true` in v1 (reserved for a future
+ineligibility denylist).
+
+## Predicate grammar (deterministic match)
+
+A request matches iff the grant is **active** (`now < expires_at`, not revoked),
+its **scope** matches, and its **predicate** matches — all exact/deterministic
+(no fuzzy/semantic matching at runtime).
+
+**Scope match** (exact equality; `global` always; missing field ⇒ no match):
+
+| scope.type | compares request field |
+|------------|------------------------|
+| session | `session_id` |
+| workspace | `workspace` |
+| project | `project` |
+| instance | `instance_id` (or configured instance id) |
+| global | — (always; only if `allow_global_scope`) |
+
+**Predicate match** by `kind` (or by `policy_rule_name` if set — broadest rung):
+
+| kind | fields | rule |
+|------|--------|------|
+| any (rule rung) | `policy_rule_name` | request `policy_rule_name` equals it |
+| command | `command`, `args`, `args_match` | command equal; args by `exact` (equal) / `prefix` (request starts with `args`) / `glob` (positional glob) |
+| file | `paths`, `operations` | request path matches a `paths` glob (`{workspace}` expanded) AND request op ∈ `operations` |
+| network | `host`, `host_match`, `port` | host `exact`/`suffix` match AND port equal (port omitted ⇒ any) |
+| signal | `signal` | signal equal |
+
+## Telegram surface
+
+### Approval keyboard (additive third button)
+
+```
+[✅ Approve]   [⏩ Always…]   [❌ Deny]
+```
+`callback_data`: `approve:{id}`, `always:{id}`, `deny:{id}`.
+
+### "Always…" picker (second tap)
+
+On `always:{id}`, the transport computes `GrantStore.propose(request)`
+(tightest-first, **at most 4 candidates**), stashes the candidate list keyed by
+`{id}`, and renders:
+
+```
+Always allow:
+[<candidate 0 label>]      → pick:{id}:0
+[<candidate 1 label>]      → pick:{id}:1
+[<candidate 2 label>]      → pick:{id}:2
+[Cancel]                   → pick:{id}:cancel
+```
+
+Labels include scope, e.g. `git push * · this project`. `callback_data` stays
+≤ 64 bytes by indexing into the stashed candidates (predicate never goes in
+`callback_data`).
+
+On `pick:{id}:{index}`: create the grant (TTL applied), resolve the approval
+`allow` (+`grant_id`), edit the message to confirm
+(`⏩ Always: git push * · myproj · 8h · by @paulofallon`). On `pick:{id}:cancel`:
+restore the original Approve/Deny keyboard. Unauthorized chat, unknown id, or
+expired picker ⇒ ignored (consistent with parent FR-011/FR-012). Over the
+`max_grants` cap ⇒ confirm message reports "grant limit reached" and the approval
+is still allowed once (the grant just isn't created).
+
+### Slash commands (authorized chat only)
+
+| Command | Effect |
+|---------|--------|
+| `/rules` | list active grants (id, class label, scope, age, TTL, uses) with inline `[Revoke]` buttons |
+| `/revoke <id>` | revoke a grant; subsequent matches re-prompt |
+| `/pause` / `/resume` | global pause/resume of all auto-approval (FR-G10) |
+
+Listing is **Telegram-only** — there is no bridge HTTP read endpoint and no CLI
+lister in v1 (avoids disclosing the auto-approve set to co-located containers).
+
+## Audit & digest
+
+- Each auto-approval logs `auto_approved {approval_id, grant_id, kind, summary,
+  latency_ms}` at INFO — **no secrets, bodies, or workspace paths** (parent
+  FR-017).
+- A periodic digest (default hourly; `digest_interval_seconds: 0` disables)
+  messages the chat a count summary when there was activity, so standing grants
+  are never silent (FR-G11).

--- a/specs/007-notifier-sidecar/contracts/openapi.yaml
+++ b/specs/007-notifier-sidecar/contracts/openapi.yaml
@@ -1,0 +1,149 @@
+openapi: 3.1.0
+info:
+  title: Remo Notifier — agentsh approval wire protocol
+  version: "1.0.0"
+  description: >
+    Durable contract between agentsh (or any future approval emitter) and the
+    notifier sidecar. The notifier listens on 0.0.0.0:18181 inside its container;
+    the host binds it to the Docker bridge address (e.g. 172.17.0.1:18181),
+    reachable only by co-located devcontainers. No transport encryption and no
+    caller authentication in v1 (see spec FR-021). Fail-secure: no outcome other
+    than an explicit authorized human Approve ever yields "allow".
+servers:
+  - url: http://172.17.0.1:18181
+    description: Host Docker-bridge binding (example)
+paths:
+  /v1/approve:
+    post:
+      summary: Submit an approval request and block until a decision exists
+      description: >
+        The connection is held open until a human decides, the timeout fires, or
+        the service shuts down. Exactly one response is returned.
+      operationId: approve
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema: { $ref: "#/components/schemas/ApprovalRequest" }
+      responses:
+        "200":
+          description: >
+            A decision was made (allow or deny) by an authorized human, OR the
+            request matched an active human-created standing grant and was
+            auto-approved (Addendum 001). Auto-approvals set responder to
+            "rule:{grant_id}" and include grant_id. See contracts/grant-schema.md.
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/ApprovalResponse" }
+        "400":
+          description: Schema validation failure (unknown field, bad type, bad UUID).
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/ErrorResponse" }
+        "408":
+          description: >
+            No human responded within the (clamped) timeout. Fail-secure: body is
+            a full ApprovalResponse with decision=deny, reason="timeout".
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/ApprovalResponse" }
+        "409":
+          description: >
+            The supplied approval_id matches an approval already pending (FR-003a).
+            The original pending approval is left running; no second notification.
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/ErrorResponse" }
+        "503":
+          description: >
+            Service unavailable — shutting down, transport unreachable, no
+            human-side configuration loaded, at max pending-approval capacity
+            (FR-034), or the notification for THIS request failed to send
+            (FR-010a). No pending slot is held in the send-failure case.
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/ErrorResponse" }
+  /v1/health:
+    get:
+      summary: Liveness probe (no auth)
+      operationId: health
+      responses:
+        "200":
+          description: Service is up.
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/HealthResponse" }
+components:
+  schemas:
+    Operation:
+      type: object
+      additionalProperties: false
+      required: [kind]
+      properties:
+        kind: { type: string, enum: [command, file, network, signal] }
+        command: { type: string }
+        args: { type: array, items: { type: string }, default: [] }
+        path: { type: string }
+        remote_host: { type: string }
+        remote_port: { type: integer, minimum: 1, maximum: 65535 }
+        context: { type: string, enum: [direct, nested], default: direct }
+        depth: { type: integer, minimum: 0, default: 0 }
+    ApprovalRequest:
+      type: object
+      additionalProperties: false
+      required: [operation, policy_rule_name, policy_message]
+      properties:
+        approval_id:
+          type: string
+          format: uuid
+          description: Optional; server generates if absent. Duplicate-of-pending → 409.
+        session_id: { type: string, description: Opaque agentsh session id. }
+        operation: { $ref: "#/components/schemas/Operation" }
+        policy_rule_name: { type: string }
+        policy_message: { type: string }
+        workspace: { type: string, description: DEBUG-log only; never logged at INFO+. }
+        instance_id: { type: string, description: Falls back to configured instance id. }
+        project: { type: string }
+        timeout_seconds:
+          type: integer
+          minimum: 1
+          description: Clamped to [1, max_timeout_seconds]; defaults to default_timeout_seconds.
+        submitted_at: { type: string, format: date-time }
+    ApprovalResponse:
+      type: object
+      required: [approval_id, decision, responder, reason, decided_at, latency_ms]
+      properties:
+        approval_id: { type: string }
+        decision: { type: string, enum: [allow, deny] }
+        responder:
+          type: string
+          description: >
+            e.g. "telegram:paulofallon", "system:timeout", or "rule:{grant_id}"
+            for a standing-grant auto-approval (Addendum 001).
+        reason: { type: string, description: May be empty; "timeout" on 408; "auto-approved via standing grant" on a grant match. }
+        decided_at: { type: string, format: date-time }
+        latency_ms: { type: integer, minimum: 0 }
+        grant_id:
+          type: string
+          description: >
+            Present when this response was auto-approved by a standing grant, or
+            when the response created a grant (the "Always" tap). Optional;
+            backward-compatible (Addendum 001).
+    HealthResponse:
+      type: object
+      required: [status, version, transport, uptime_seconds, pending_approvals]
+      properties:
+        status: { type: string, example: ok }
+        version: { type: string }
+        transport: { type: string, example: telegram }
+        uptime_seconds: { type: integer, minimum: 0 }
+        pending_approvals: { type: integer, minimum: 0 }
+    ErrorResponse:
+      type: object
+      required: [error]
+      properties:
+        error:
+          type: string
+          enum: [validation_error, duplicate_approval_id, unavailable]
+        detail: { type: string, description: Human-readable; never contains secrets. }
+        approval_id: { type: string, description: Present on 409. }

--- a/specs/007-notifier-sidecar/contracts/telegram-message.md
+++ b/specs/007-notifier-sidecar/contracts/telegram-message.md
@@ -1,0 +1,56 @@
+# Contract: Telegram message & callback
+
+Defines the exact human-facing surface for the Telegram transport. Parse mode: `MarkdownV2` (configurable). All dynamic values MUST be MarkdownV2-escaped before insertion (Telegram requires escaping `_ * [ ] ( ) ~ \` > # + - = | { } . !`).
+
+## Outgoing approval message
+
+```
+🔐 Approval requested
+
+*Project:* {project}
+*Operation:* {operation.kind}: {operation.command} {operation.args}
+*Rule:* {policy_rule_name}
+*Message:* {policy_message}
+*Instance:* {instance_id}
+
+Decide within {timeout_seconds // 60} minutes.
+```
+
+Field rendering:
+- `{operation.args}` rendered space-joined; long arg lists may be truncated with an ellipsis for readability (the full args are never required in the message — agentsh holds ground truth).
+- Missing optional fields (`project`, `command`) render as a placeholder (`—`) rather than the literal `None`.
+- `timeout_seconds` is the **effective** (clamped) timeout; if `< 60`, show seconds instead of minutes.
+
+## Inline keyboard
+
+Two buttons on one row:
+
+| Button text | `callback_data` |
+|-------------|-----------------|
+| ✅ Approve | `approve:{approval_id}` |
+| ❌ Deny | `deny:{approval_id}` |
+
+`callback_data` MUST stay ≤ 64 bytes (Telegram limit); a UUID approval_id (36 chars) + verb fits.
+
+## Callback handling
+
+1. Reject if `callback_query.message.chat.id != authorized_chat_id` → answer the callback quietly, take no action (FR-011).
+2. Parse `verb:approval_id`. Unknown verb → ignore.
+3. If `approval_id` is not currently pending → answer "already decided / expired", no state change (FR-012).
+4. Else resolve: `allow` for `approve`, `deny` for `deny`; responder = `telegram:{username or user_id}`; reason empty.
+5. `answerCallbackQuery` to clear the client spinner.
+
+## Message edits on terminal outcome (FR-013)
+
+| Outcome | Edited message suffix (replaces buttons) |
+|---------|------------------------------------------|
+| Approved | `✅ Approved by @{user} at {HH:MM}` |
+| Denied | `❌ Denied by @{user} at {HH:MM}` |
+| Timeout | `⌛ Timed out — denied (fail-secure)` |
+| Cancelled (external/shutdown) | `🚫 Cancelled — resolved elsewhere` |
+
+Edits remove the inline keyboard so the message can't be re-tapped. Edit failures (e.g. message deleted by the user) are logged at DEBUG and otherwise ignored — they never block resolving the caller.
+
+## Test command surface (`remo notifier test`)
+
+Sends an `ApprovalRequest` with `policy_rule_name: "test"`, `policy_message: "This is a test approval — please tap Approve or Deny to confirm wiring."`, `project: "remo-notifier-selftest"`, a short `timeout_seconds` (e.g. 120), and `operation: {kind: command, command: "echo", args: ["wiring-check"]}`. The CLI prints the returned decision (FR-027).

--- a/specs/007-notifier-sidecar/contracts/transport.md
+++ b/specs/007-notifier-sidecar/contracts/transport.md
@@ -1,0 +1,81 @@
+# Contract: `NotificationTransport` ABC
+
+Location: `src/remo_cli/notifier/transports/base.py`. The notifier core depends only on this interface; Telegram is the sole v1 implementation (`transports/telegram.py`). Future Slack/Discord/ntfy backends subclass it without touching intake or registry logic (FR-015).
+
+```python
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from collections.abc import Callable
+
+from remo_cli.notifier.models import ApprovalDecision, ApprovalRequest
+
+
+class NotificationTransport(ABC):
+    """Delivers approval requests to a human and reports their decision.
+
+    Lifecycle: start() once at app startup; stop() once at shutdown. Between
+    them, the server calls send_approval_request() per accepted request and may
+    call cancel() to retract one resolved by other means.
+    """
+
+    name: str  # e.g. "telegram" — surfaced in /v1/health
+
+    @abstractmethod
+    async def start(self) -> None:
+        """Begin receiving human input (e.g. start long-polling). Idempotent."""
+
+    @abstractmethod
+    async def stop(self) -> None:
+        """Stop receiving input and release resources. Idempotent; safe after start failure."""
+
+    @abstractmethod
+    async def send_approval_request(
+        self,
+        request: ApprovalRequest,
+        on_response: Callable[[ApprovalDecision], None],
+    ) -> None:
+        """Deliver one request to the human.
+
+        MUST raise on delivery failure (the server maps this to 503 and holds no
+        pending slot — FR-010a). On success, returns once the notification is
+        delivered; the human's eventual tap invokes on_response(decision) exactly
+        once with an authorized decision. on_response is a synchronous, loop-safe
+        callback that resolves the pending approval's Future.
+        """
+
+    @abstractmethod
+    async def cancel(self, approval_id: str) -> None:
+        """Retract a still-displayed request (e.g. resolved elsewhere or on shutdown).
+
+        Edits/annotates the human-facing message to reflect the non-human outcome.
+        Idempotent and a no-op for unknown ids.
+        """
+
+    async def healthy(self) -> bool:
+        """Optional readiness signal. Default True; transports may override.
+
+        When False, the server answers new /v1/approve calls with 503 (FR-007).
+        """
+        return True
+```
+
+## Behavioral contract
+
+| Guarantee | Requirement |
+|-----------|-------------|
+| `on_response` is called at most once per request, only with an **authorized** human decision | FR-008, FR-011 |
+| Unauthorized chats / unknown approval ids are ignored (no `on_response`) | FR-011, FR-012, edge cases |
+| `send_approval_request` raises ⇒ server returns 503, no pending slot held | FR-010a |
+| `cancel` edits the human-facing message to show the final non-human outcome | FR-013 |
+| `start`/`stop` are idempotent and tolerate partial init | Constitution III (idempotent), shutdown edge case |
+| `name` reflected verbatim in `/v1/health.transport` | FR-016 |
+
+## Telegram implementation notes (normative for v1)
+
+- Built on `telegram.ext.Application`; long-polling via `updater.start_polling()` inside FastAPI lifespan; **never** `run_polling()` and **never** webhook mode (R1, FR-014).
+- Message body and inline keyboard exactly as in `telegram-message.md`.
+- `callback_data`: `approve:{approval_id}` / `deny:{approval_id}`.
+- A `CallbackQueryHandler` checks the originating chat equals `authorized_chat_id` (else ignore, FR-011), parses `verb:approval_id`, and calls `on_response(ApprovalDecision(...))` guarded so a non-pending id is a no-op (FR-012).
+- On resolution it edits the original message (`✅ Approved by @user at HH:MM` / `❌ Denied …` / `⌛ Timed out — denied (fail-secure)` / cancelled) (FR-013).
+- Bot token read from file at startup, kept in memory only (FR-019); never logged (FR-017).

--- a/specs/007-notifier-sidecar/data-model-addendum-001.md
+++ b/specs/007-notifier-sidecar/data-model-addendum-001.md
@@ -1,0 +1,151 @@
+# Phase 1 Data Model — Addendum 001: Standing Grants
+
+Pydantic v2 models, `extra="forbid"` where they parse external/config input. All
+times aware-UTC internally, RFC3339 on the wire. **Nothing is persisted** — these
+describe in-memory state and additive wire fields. New module:
+`src/remo_cli/notifier/grants.py`.
+
+## Enums (extend existing or add)
+
+- `OperationKind` — reused from `models.py` (`command|file|network|signal`).
+- `GrantScopeType` — `session | workspace | project | instance | global`.
+- `ArgMatchType` — `exact | prefix | glob`.
+- `HostMatchType` — `exact | suffix`.
+
+## GrantPredicate (`grants.py`)
+
+The deterministic, inspectable match rule. Only fields relevant to `kind` are
+set. Agentsh-rule-shaped (forward-compat).
+
+| Field | Type | Applies to | Notes |
+|-------|------|-----------|-------|
+| `kind` | OperationKind | all | must equal the request operation kind |
+| `command` | str \| None | command, signal | exact command string |
+| `args` | list[str] | command | the reference args |
+| `args_match` | ArgMatchType | command | how `args` compares (exact list / prefix / glob) |
+| `paths` | list[str] | file | glob list; `{workspace}` placeholder allowed |
+| `operations` | list[str] | file | e.g. `read`/`write`/`delete` |
+| `host` | str \| None | network | reference host |
+| `host_match` | HostMatchType | network | exact or domain-suffix |
+| `port` | int \| None | network | 1–65535 |
+| `signal` | str \| None | signal | signal name |
+| `policy_rule_name` | str \| None | any | broadest rung: match by agentsh rule name |
+
+**Match semantics** (`predicate.matches(operation, policy_rule_name) -> bool`),
+deterministic, fail-closed on anything unexpected:
+- If `policy_rule_name` is set on the predicate → match iff request
+  `policy_rule_name` equals it (kind still must match). This is the broadest rung.
+- Else by kind:
+  - `command`: request kind==command AND command equal AND args satisfy
+    `args_match` (exact: equal lists; prefix: request args start with `args`;
+    glob: each pattern matches positionally).
+  - `file`: kind==file AND request path matches any `paths` glob (after
+    `{workspace}` expansion) AND request op ∈ `operations`.
+  - `network`: kind==network AND host matches (`exact` equal / `suffix`
+    `request_host.endswith(host)`) AND `port` equal (or predicate port None ⇒ any).
+  - `signal`: kind==signal AND signal equal.
+- Any missing/None field the rule keys on, or an unparseable glob → **False**.
+
+## GrantScope (`grants.py`)
+
+| Field | Type | Notes |
+|-------|------|-------|
+| `type` | GrantScopeType | |
+| `value` | str | the captured session/workspace/project/instance id; ignored for `global` |
+
+`scope.matches(request) -> bool`: equality of the corresponding request field
+(`session`→`session_id`, etc.); `global`→True; missing field → **False** (FR-G5/RG5).
+**Exception:** for `instance` scope, a request with no `instance_id` falls back
+to the notifier's configured instance id (the instance is known from config, not
+fail-closed); this is the one intentional deviation from the missing-field rule.
+
+## Grant (`grants.py` + additive wire object)
+
+| Field | Type | Notes |
+|-------|------|-------|
+| `grant_id` | str (uuid) | server-generated |
+| `created_at` | datetime | |
+| `created_by` | str | e.g. `telegram:paulofallon` |
+| `expires_at` | datetime | `created_at + default_ttl_seconds` (FR-G8) |
+| `source_approval_id` | str | the approval the human tapped Always on |
+| `scope` | GrantScope | |
+| `predicate` | GrantPredicate | |
+| `eligible` | bool | always True in v1 (D2); reserved for future denylist (FR-G12) |
+| `uses_count` | int | incremented on each auto-approval |
+| `last_used_at` | datetime \| None | |
+
+`grant.active(now) -> bool`: `not revoked and now < expires_at`.
+`grant.matches(request, now) -> bool`: `active(now) and scope.matches(request)
+and predicate.matches(request.operation, request.policy_rule_name)`.
+
+## CandidateGrant (`grants.py`, transient)
+
+Returned by `propose(request)` to build the Telegram picker. Not persisted, not
+on the wire.
+
+| Field | Type | Notes |
+|-------|------|-------|
+| `label` | str | human-facing, e.g. `git push * · this project` |
+| `predicate` | GrantPredicate | |
+| `scope` | GrantScope | |
+
+## GrantStore (`grants.py`, in-memory)
+
+State: `dict[str, Grant]` + `asyncio.Lock` + `max_grants` + `paused: bool`.
+
+| Method | Behaviour |
+|--------|-----------|
+| `match(request, now) -> Grant \| None` | first active grant whose `matches()` is true; None if paused/disabled/none. Allow-capable — exact, deterministic (FR-G4). |
+| `create(grant) -> Grant` | under lock; raise `GrantLimitReached` if at `max_grants`; else store. |
+| `propose(request) -> list[CandidateGrant]` | deterministic tightest-first templates (RG2), at most 4 candidates. Pure. |
+| `list() -> list[Grant]` | active grants (for `/rules`). |
+| `revoke(grant_id) -> bool` | remove; True if existed. |
+| `set_paused(bool)` / `paused` | global pause (FR-G10). |
+| `sweep(now) -> int` | drop expired; return count (RG4 hygiene). |
+
+State transitions:
+
+```text
+            create()                          revoke() / expire / restart
+ (none) ───────────────▶ ACTIVE ───────────────────────────────────────▶ (gone)
+                           │  ▲
+              match() hit  │  │ uses_count++ , last_used_at=now
+                           └──┘   (stays ACTIVE)
+   paused=true ⇒ match() returns None for ALL grants (not a state change)
+```
+
+Invariants:
+- `match()` returns a grant only if `active(now)` and scope+predicate match.
+- An expired grant is never returned even if the sweeper hasn't run (lazy check).
+- `len(store) <= max_grants`.
+- No `allow` is produced by the store except via a `match()` hit on a
+  human-created grant (parent FR-008, evolved).
+
+## Wire/config additions
+
+### `ApprovalResponse` (modify `models.py`)
+- Add `grant_id: str | None = None`. Present when the response was auto-approved
+  (`responder = rule:{grant_id}`) or when this response *created* a grant (the
+  Always tap echoes the new grant id). Backward-compatible (optional).
+
+### `GrantsConfig` (modify `config.py`, `extra="forbid"`)
+
+| Key | Type | Default | Notes |
+|-----|------|---------|-------|
+| `enabled` | bool | true | master switch |
+| `default_ttl_seconds` | int ≥ 1 | 28800 | 8h; applied to every grant (FR-G8) |
+| `max_grants` | int ≥ 1 | 100 | cap (FR-G9) |
+| `allow_global_scope` | bool | true | D2; if false, `global` scope is refused |
+| `digest_interval_seconds` | int ≥ 0 | 3600 | 0 disables the digest |
+
+Add `grants: GrantsConfig = Field(default_factory=GrantsConfig)` to
+`NotifierConfig`.
+
+## Relationships
+
+- `GrantStore` 1—N `Grant`; each `Grant` 1—1 `GrantPredicate` + `GrantScope`.
+- A short-circuited `ApprovalRequest` maps to exactly one matched `Grant`
+  (echoed as `grant_id`); a non-matched request flows through the parent v1
+  pipeline unchanged.
+- `propose()` turns one `ApprovalRequest` into N `CandidateGrant`s for the picker;
+  the human's pick becomes one persisted-in-memory `Grant`.

--- a/specs/007-notifier-sidecar/data-model.md
+++ b/specs/007-notifier-sidecar/data-model.md
@@ -1,0 +1,166 @@
+# Phase 1 Data Model: Notifier Sidecar
+
+All models are Pydantic v2 (`model_config = ConfigDict(extra="forbid")` for strictness where noted). Times are RFC3339 UTC strings on the wire; internally `datetime` (aware, UTC). No model is persisted — these describe in-flight HTTP payloads, configuration, and the in-memory registry.
+
+## Wire models (`notifier/models.py`)
+
+### Operation
+
+Describes the operation agentsh is asking to approve. All fields optional except `kind`; presence depends on `kind`.
+
+| Field | Type | Required | Notes |
+|-------|------|----------|-------|
+| `kind` | enum: `command` \| `file` \| `network` \| `signal` | yes | drives which other fields are meaningful |
+| `command` | str | no | e.g. `rm`, `curl` (command/signal ops) |
+| `args` | list[str] | no | default `[]` |
+| `path` | str | no | file ops |
+| `remote_host` | str | no | network ops |
+| `remote_port` | int | no | network ops; 1–65535 if present |
+| `context` | enum: `direct` \| `nested` | no | default `direct` |
+| `depth` | int | no | ≥0; default 0 |
+
+Validation: `extra="forbid"`. No hard cross-field requirement (agentsh owns semantics); notifier renders whatever is present.
+
+### ApprovalRequest (POST /v1/approve body)
+
+| Field | Type | Required | Notes |
+|-------|------|----------|-------|
+| `approval_id` | str (UUID) | no | server generates if absent (FR-003); if present and already pending → 409 (FR-003a) |
+| `session_id` | str | no | opaque to notifier |
+| `operation` | Operation | yes | |
+| `policy_rule_name` | str | yes | |
+| `policy_message` | str | yes | human-readable prompt |
+| `workspace` | str | no | filesystem path; DEBUG-log only (FR-017) |
+| `instance_id` | str | no | falls back to configured instance id if absent |
+| `project` | str | no | devcontainer/project name |
+| `timeout_seconds` | int | no | clamped to `[1, max_timeout_seconds]`; defaults to `default_timeout_seconds` (FR-006) |
+| `submitted_at` | str (RFC3339) | no | informational |
+
+Validation: `extra="forbid"` → unknown fields produce 400 (FR-001). `approval_id`, if supplied, must be a valid UUID string.
+
+### ApprovalDecision (internal resolution value)
+
+The value a `PendingApproval`'s Future is resolved with.
+
+| Field | Type | Notes |
+|-------|------|-------|
+| `decision` | enum: `allow` \| `deny` | `allow` only from authorized human Approve (FR-008) |
+| `responder` | str | e.g. `telegram:paulofallon`, or `system:timeout` |
+| `reason` | str | may be empty; `"timeout"` on timeout |
+| `decided_at` | datetime (UTC) | |
+
+### ApprovalResponse (POST /v1/approve response body)
+
+| Field | Type | Notes |
+|-------|------|-------|
+| `approval_id` | str | echoes the (possibly generated) id (FR-003) |
+| `decision` | enum: `allow` \| `deny` | |
+| `responder` | str | |
+| `reason` | str | |
+| `decided_at` | str (RFC3339) | |
+| `latency_ms` | int | wall time from intake to resolution |
+
+### HealthResponse (GET /v1/health body)
+
+| Field | Type | Notes |
+|-------|------|-------|
+| `status` | str | `"ok"` |
+| `version` | str | the **notifier component** version (e.g. `0.1.0`), sourced from a module constant `remo_cli.notifier.__version__` and matching the image tag `remo_notifier_version` — not the `remo-cli` package version (I2) |
+| `transport` | str | active transport name, e.g. `"telegram"` |
+| `uptime_seconds` | int | since process start |
+| `pending_approvals` | int | current registry size |
+
+### ErrorResponse (4xx/503 bodies, where not the 408 deny shape)
+
+| Field | Type | Notes |
+|-------|------|-------|
+| `error` | str | machine code, e.g. `duplicate_approval_id`, `validation_error`, `unavailable` |
+| `detail` | str | human-readable; never contains secrets |
+| `approval_id` | str | present on 409 |
+
+408 body is the special fail-secure shape: `{ "approval_id": "...", "decision": "deny", "reason": "timeout", ... }` (a full `ApprovalResponse`), per FR-005.
+
+## Configuration models (`notifier/config.py`)
+
+Loaded from TOML (`--config`, default `/etc/notifier/notifier.toml`). Every model is `extra="forbid"` (FR-018 strict mode → unknown keys raise a clear error).
+
+```text
+NotifierConfig
+├── server: ServerConfig
+│   ├── listen_host: str = "0.0.0.0"
+│   ├── listen_port: int = 18181          # 1–65535
+│   └── log_level: enum(debug|info|warning|error) = "info"
+├── approval: ApprovalConfig
+│   ├── default_timeout_seconds: int = 300         # ≥1
+│   ├── max_timeout_seconds: int = 1800            # ≥ default
+│   └── max_pending_approvals: int = 50            # ≥1 (FR-034)
+├── transport: TransportConfig
+│   ├── type: enum(telegram) = "telegram"          # only telegram in v1
+│   └── telegram: TelegramConfig
+│       ├── bot_token_file: str = "/run/secrets/telegram_bot_token"
+│       ├── authorized_chat_id: int                # required
+│       └── message_parse_mode: str = "MarkdownV2"
+└── instance: InstanceConfig
+    └── id: str                                    # shown to humans (FR-020)
+```
+
+Validation rules:
+- `max_timeout_seconds >= default_timeout_seconds` (model validator).
+- `transport.type == "telegram"` requires `transport.telegram` present and `authorized_chat_id` set.
+- `bot_token_file` must exist and be readable at startup; the token is read then (never stored in config) (FR-019). Empty/missing token → fail fast with a clear message (mirrors role pre-flight, FR-023/Constitution IV).
+
+## In-memory registry (`notifier/state.py`)
+
+### PendingApproval
+
+| Field | Type | Notes |
+|-------|------|-------|
+| `approval_id` | str | key |
+| `request` | ApprovalRequest | the originating request (effective timeout already computed) |
+| `future` | `asyncio.Future[ApprovalDecision]` | resolved exactly once |
+| `created_at` | datetime (UTC) | for latency + uptime accounting |
+
+### PendingApprovals (registry)
+
+State: `dict[str, PendingApproval]` + `asyncio.Lock` + `max_pending` cap.
+
+Operations (all cap/dup checks under the lock):
+- `try_register(request) -> PendingApproval | RegisterError` — returns `DUPLICATE` if id pending (→409), `AT_CAPACITY` if `len == max_pending` (→503), else inserts and returns the entry. **Caller registers only after a successful notification send** (R2/FR-010a) — so the public flow is: capacity/dup *pre-check* under lock to reserve, send, then finalize; on send failure, release the reservation. Implementation reserves the slot+id atomically, then rolls back on send failure to honor both FR-034 and FR-010a.
+- `resolve(approval_id, decision)` — if still pending, `future.set_result(decision)` and remove; else no-op (late/duplicate callback edge case).
+- `cancel(approval_id, decision)` — transport-driven external resolution; same as resolve plus message edit responsibility lies with the transport.
+- `count()` — current size (for health).
+- `drain(decision)` — on shutdown, resolve all pending with a non-allow outcome / release callers (edge case: shutdown).
+
+### State transitions
+
+```text
+            try_register (slot reserved, id locked)
+   (none) ─────────────────────────────────────────▶ RESERVED
+                                                         │
+                       send notification                │
+              ┌──────────────────────────────┬──────────┘
+        send fails                       send ok
+              │                               │
+              ▼                               ▼
+   release slot → 503 (FR-010a)            PENDING ──────────────┐
+                                              │                  │
+                 human Approve/Deny ──────────┤                  │ timeout
+                                              │                  ▼
+                                              │              RESOLVED(deny,"timeout") → 408
+                 cancel(external) ────────────┤
+                                              │                  shutdown
+                                              ▼                  ▼
+                                       RESOLVED(decision) → 200   drained → conn drop/503
+```
+
+Invariants:
+- A Future is resolved exactly once; all post-resolution callbacks are no-ops.
+- `allow` enters the system only via the authorized-human Approve edge (FR-008, SC-005).
+- `len(registry) <= max_pending` always (FR-034).
+- At most one PENDING entry per `approval_id` (FR-003a).
+
+## Relationships
+
+- `ApprovalRequest` 1—1 `PendingApproval` (while in flight) 1—1 `ApprovalResponse` (at resolution).
+- `NotifierConfig.transport` selects exactly one `Transport` instance for the process lifetime.
+- `Transport` delivers a message per `PendingApproval` and reports decisions back through the registry's `resolve`/`cancel`.

--- a/specs/007-notifier-sidecar/plan-addendum-001.md
+++ b/specs/007-notifier-sidecar/plan-addendum-001.md
@@ -1,0 +1,120 @@
+# Implementation Plan — Addendum 001: Standing Grants ("Always")
+
+**Branch**: `007-notifier-sidecar` | **Date**: 2026-06-01
+**Spec**: [`addendum-001-standing-grants.md`](./addendum-001-standing-grants.md)
+**Parent plan**: [`plan.md`](./plan.md) (shipped v1 notifier)
+
+**Note**: This plans the *addendum* only. The base notifier (server, registry,
+Telegram transport, config, CLI, role, tests) is implemented and merged on this
+branch; this layers standing-grant auto-approval on top. It does not overwrite
+the base artifacts.
+
+## Summary
+
+Add human-authored **standing grants** so a third Telegram choice — **Always** —
+auto-approves a *class* of operation without a round-trip. A new
+`src/remo_cli/notifier/grants.py` holds the `Grant`/predicate/scope models, an
+in-memory `GrantStore` (TTL-bounded, capped, fail-closed), a **deterministic
+per-operation matcher**, and a **candidate-generalization** proposer. `server.py`
+gains an intake short-circuit (`/v1/approve` checks the store before
+reserve/notify). The Telegram transport gains the `[✅ Approve] [⏩ Always…]
+[❌ Deny]` flow with a scope/granularity picker, plus `/rules`, `/revoke`,
+`/pause` command handlers and an auto-approval digest. Config grows a `[grants]`
+block; the `remo_notifier` role's config template + defaults grow matching
+variables. All grant state is in-memory (no persistence); everything stays
+fail-secure — nothing is auto-`allow`ed except by an active, unexpired,
+unrevoked, human-created grant whose deterministic predicate the request
+satisfies.
+
+## Technical Context
+
+**Language/Version**: Python 3.11+ (service container 3.13) — unchanged.
+**Primary Dependencies**: unchanged (`[notifier]` extra: FastAPI, uvicorn,
+pydantic, python-telegram-bot, structlog). **No new runtime dependencies.**
+**Storage**: None — grants are in-memory in a `GrantStore`, never persisted
+(extends parent FR-009; restart re-prompts, fail-closed).
+**Testing**: pytest + pytest-asyncio + httpx (existing). New `tests/notifier/
+test_grants.py`; extensions to `test_server.py` and `test_telegram.py`.
+**Target Platform**: unchanged (Linux container; operator CLI cross-platform).
+**Project Type**: single project — additive within `src/remo_cli/notifier/`.
+**Performance Goals**: auto-approve match returns `allow` in < 500 ms (SC-G1) —
+trivially met by an in-memory dict/predicate match.
+**Constraints**: deterministic exact matcher (allow-capable — highest
+criticality, FR-G4); narrow default scope (FR-G7); single global TTL default 8h,
+no indefinite grants (FR-G8); max-grants cap (FR-G9); fail-closed on miss /
+ambiguity / restart; no secrets in grant logs (FR-017); listing/revoke
+Telegram-only, no bridge read endpoint (OQ4).
+**Scale/Scope**: one authorized chat; ≤ `max_grants` (default 100) active grants
+per instance; ~250–400 LOC Python + ~15 LOC Ansible (config block) + tests/docs.
+
+## Constitution Check
+
+*GATE: must pass before Phase 0. Re-check after Phase 1.*
+
+| Principle | Gate | Status |
+|-----------|------|--------|
+| I. Defensive Variable Access (Ansible) | Only the role's `notifier.toml.j2` + `defaults/main.yml` change (a `[grants]` block + vars); no registered-variable access added | PASS — no new `.rc`/`.stdout` usage |
+| II. Test All Conditional Paths | Matcher branches (match / no-match / expired / revoked / paused / at-capacity / scope-mismatch) and the short-circuit vs miss paths are each tested both ways | PASS — enumerated in tasks/tests |
+| III. Idempotent by Default | The role change is a templated config block (handler-restart on change); re-runs are no-ops. Runtime grant state is in-memory, not config | PASS |
+| IV. Fail Fast with Clear Messages | `GrantsConfig` is strict (`extra="forbid"`); invalid grant config fails startup with a clear message, like the rest of the config | PASS |
+| V. Documentation Reflects Reality | wire-protocol.md (short-circuit + `grant_id`), config-schema.md (`[grants]`), notifier README, top-level README updated alongside code | PASS |
+
+**Fail-secure invariant evolution (explicit):** parent FR-008 ("`allow` only from
+an explicit human tap") becomes "`allow` only from an explicit human tap **or** a
+matching active human-created standing grant." Still human-authored; every
+non-matching path still prompts or fails closed. This is a deliberate,
+documented relaxation, not a violation. No other constitution gate is affected.
+
+**Complexity Tracking**: empty (no deviations to justify).
+
+Post-Phase-1 re-check: design keeps grants additive under `notifier/`, the
+matcher deterministic and transport-agnostic (enforcement in `server.py`), grant
+UI confined to the Telegram transport, and the store in-memory. **Still PASS.**
+
+## Project Structure (delta)
+
+```text
+src/remo_cli/notifier/
+├── grants.py            # NEW — Grant/predicate/scope models, GrantStore,
+│                        #       deterministic matcher, candidate proposer
+├── server.py            # MODIFIED — intake short-circuit; own GrantStore;
+│                        #            inject into transport; TTL sweep + digest
+│                        #            in lifespan
+├── config.py            # MODIFIED — GrantsConfig (enabled/ttl/max/global)
+├── models.py            # MODIFIED — ApprovalResponse gains optional grant_id
+└── transports/
+    ├── base.py          # MODIFIED (minimal) — transport may accept a grant
+    │                    #   service; grant UI is implementation-specific
+    └── telegram.py      # MODIFIED — Always button + picker callback flow,
+                         #            grant creation, /rules /revoke /pause,
+                         #            digest sender
+
+ansible/roles/remo_notifier/
+├── defaults/main.yml            # MODIFIED — grant vars (enabled/ttl/max/global)
+└── templates/notifier.toml.j2   # MODIFIED — [grants] block
+
+tests/notifier/
+├── test_grants.py       # NEW — store, matcher, candidates, TTL, cap, revoke,
+│                        #       pause, scope, fail-closed, concurrency
+├── test_server.py       # MODIFIED — short-circuit allow; miss→existing flow
+└── test_telegram.py     # MODIFIED — Always flow, picker callback_data,
+                         #            grant creation, /rules /revoke /pause
+
+src/remo_cli/notifier/docs/   # MODIFIED — wire-protocol.md, config-schema.md
+README.md                     # MODIFIED — notifier "always" note
+specs/007-notifier-sidecar/contracts/
+├── openapi.yaml          # MODIFIED — ApprovalResponse.grant_id; 200 may be auto
+└── grant-schema.md       # NEW — Grant/predicate grammar, matching, callback_data
+```
+
+**Structure Decision**: Additive within the existing notifier package. Critical
+separation: **enforcement (matching) lives in `server.py`/`grants.py`
+(transport-agnostic); the grant UI (button, picker, slash-commands) lives in the
+Telegram transport.** The `GrantStore` is owned by the app (constructed in
+`create_app`) and injected into the transport so the transport can propose/create
+grants and serve `/rules`/`/revoke`/`/pause`, while the server alone performs the
+allow-capable match. No CLI changes (OQ4); no new top-level integration points.
+
+## Complexity Tracking
+
+> No constitution violations — section intentionally empty.

--- a/specs/007-notifier-sidecar/plan.md
+++ b/specs/007-notifier-sidecar/plan.md
@@ -1,0 +1,124 @@
+# Implementation Plan: Notifier Sidecar — Telegram approval bridge for agentsh
+
+**Branch**: `007-notifier-sidecar` | **Date**: 2026-05-31 | **Spec**: [spec.md](./spec.md)
+**Input**: Feature specification from `/specs/007-notifier-sidecar/spec.md`
+
+## Summary
+
+Add a self-contained notifier service to the existing `remo-cli` package: a long-running FastAPI daemon that runs in a hardened OCI container on each remo-provisioned host. It accepts agentsh approval requests over HTTP, delivers them to one authorized human via a Telegram bot (long-polling, no public URL), and returns the human's allow/deny decision synchronously — failing secure (deny) on timeout, shutdown, send failure, or capacity exhaustion. The service holds no persistent state.
+
+Technical approach: a new `src/remo_cli/notifier/` sub-package (a fourth peer of `cli/`, `providers/`, `core/`) carries the server, config, in-memory pending-approval registry, wire-protocol models, and a pluggable `NotificationTransport` ABC with a single Telegram implementation. The Telegram `Application` runs long-polling inside the FastAPI lifespan on the same asyncio loop. A new `remo_notifier` Ansible role (depends-on `docker`) builds the image on the host from a build context shipped inside the wheel, renders config + secret, and installs a systemd unit that runs `docker run` bound to the Docker bridge address. New `remo notifier {deploy,status,logs,test,restart}` CLI subcommands drive deployment and day-2 ops using the existing host-resolution, picker, SSH, and ansible-runner helpers. The notifier's runtime deps live behind a `[notifier]` optional extra so the laptop install is unaffected.
+
+## Technical Context
+
+**Language/Version**: Python 3.11+ (package `requires-python = ">=3.11"`); service container runs Python 3.13-slim  
+**Primary Dependencies**: Service (new `[notifier]` extra): FastAPI ≥0.115, uvicorn[standard] ≥0.32, pydantic ≥2.9, python-telegram-bot ≥21.6, structlog ≥24.4, tomli (py<3.11 only). CLI side: Click ≥8.1 (existing), no new laptop runtime deps. Build: hatchling (existing), uv (in-container). Ansible: new `community.docker` collection.  
+**Storage**: None. All approval state is in-memory in a `PendingApprovals` registry; never persisted (FR-009).  
+**Testing**: pytest (existing) + new dev deps pytest-asyncio and httpx (FastAPI `TestClient`/`AsyncClient`). Tests under `tests/notifier/`.  
+**Target Platform**: Service: Linux/amd64 OCI container on Ubuntu 24.04 hosts. Operator CLI: cross-platform (existing remo install).  
+**Project Type**: Single project — Python package (`src/remo_cli/`) + Ansible (`ansible/`), matching existing repo layout.  
+**Performance Goals**: Decision delivered to caller within 5 s of a human tap (SC-001); timeout-deny returned within ~1 s of the request deadline (SC-002); health check answers within 5 s of container start (SC-003).  
+**Constraints**: Container image <250 MB (SC/AC-2); listener bound to the Docker bridge address only, no TLS, no caller auth (FR-021); no secrets at INFO+ log level (FR-017); fail-secure — never "allow" except an explicit human tap (FR-008); no persistence (FR-009); default max 50 concurrent pending approvals (FR-034).  
+**Scale/Scope**: One authorized Telegram chat per instance; ~600–900 LOC Python, ~150 LOC Ansible/Jinja, ~50 LOC CLI; configurable cap (default 50) on concurrent pending approvals per instance.
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
+
+The constitution (v1.0.0) is centered on Ansible quality plus fail-fast and docs-reflect-reality. Evaluating the new `remo_notifier` role and surrounding work:
+
+| Principle | Gate | Status |
+|-----------|------|--------|
+| I. Defensive Variable Access (Ansible) | All registered-var attribute access in `remo_notifier` role uses `\| default()`; `.rc`/`.stdout` never bare; `when:` guards use `is defined` / `\| default()` | PASS — committed; pre-commit grep (`grep -r '\.rc ==' ansible/`, `grep -r '\.stdout' ansible/`) in the task list |
+| II. Test All Conditional Paths | Role toggles (`configure_remo_notifier`, `remo_notifier_build_from_source`) and Python fail-secure branches (timeout, send-failure, capacity, shutdown, duplicate-id) are each tested both ways | PASS — Python branches covered by T010/T011 (incl. timeout-clamp); role toggle/pull paths covered by **T031a** (or explicitly deferred there) |
+| III. Idempotent by Default | Role re-run yields identical state: config/secret templates use `changed_when`/handlers; image build is conditional; `docker run` via systemd is declarative; health-wait is a read-only check | PASS — verified by the rerun check in **T045a** |
+| IV. Fail Fast with Clear Messages | Pre-flight `assert` for empty bot token / chat id with actionable `fail_msg` (FR-023); config strict-validation rejects unknown keys with a clear error (FR-018); deploy fails if health never comes up (FR-025) | PASS |
+| V. Documentation Reflects Reality | wire-protocol.md + config-schema.md + notifier README + top-level README "Notifier" section land with the code; examples are runnable (FR/req 10) | PASS |
+
+No violations. **Complexity Tracking** is empty (no deviations to justify).
+
+Post-Phase-1 re-check: design keeps the notifier strictly additive (no edits to `docker`/`devcontainers`/provider roles per spec constraint), the role self-contained with a single `meta` dependency on `docker`, and the laptop install free of service deps — all consistent with the gates above. **Still PASS.**
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/007-notifier-sidecar/
+├── plan.md              # This file
+├── spec.md              # Feature spec (already written + clarified)
+├── research.md          # Phase 0 output
+├── data-model.md        # Phase 1 output
+├── quickstart.md        # Phase 1 output
+├── contracts/           # Phase 1 output
+│   ├── openapi.yaml      # HTTP wire protocol (POST /v1/approve, GET /v1/health)
+│   ├── transport.md      # NotificationTransport ABC contract
+│   └── telegram-message.md # Telegram message + callback_data contract
+├── checklists/
+│   └── requirements.md  # Spec quality checklist (done)
+└── tasks.md             # /speckit.tasks output (NOT created here)
+```
+
+### Source Code (repository root)
+
+```text
+src/remo_cli/
+├── notifier/                    # NEW — fourth layer, peer of cli/ providers/ core/
+│   ├── __init__.py
+│   ├── cli.py                   # `remo-notifier serve` entry point (Click or argparse)
+│   ├── server.py                # FastAPI app, lifespan (start/stop transport), routes
+│   ├── config.py                # Pydantic config models + strict TOML loader
+│   ├── state.py                 # PendingApprovals registry (asyncio, cap-aware)
+│   ├── models.py                # ApprovalRequest/Response/Operation/Decision (Pydantic)
+│   ├── logging_setup.py         # structlog config; secret-safe processors
+│   ├── transports/
+│   │   ├── __init__.py
+│   │   ├── base.py              # NotificationTransport ABC
+│   │   └── telegram.py          # Telegram Application (long-polling) implementation
+│   ├── docs/
+│   │   ├── wire-protocol.md
+│   │   └── config-schema.md
+│   └── README.md
+├── cli/
+│   └── notifier.py              # NEW — `remo notifier {deploy,status,logs,test,restart}`
+├── cli/main.py                  # MODIFIED — register the `notifier` group
+├── core/ providers/ models/     # UNCHANGED (constraint: no notifier code here)
+└── ansible/                     # force-included into wheel (existing mechanism)
+
+ansible/                         # (mirrors into wheel at remo_cli/ansible)
+├── roles/remo_notifier/         # NEW role
+│   ├── tasks/main.yml
+│   ├── defaults/main.yml
+│   ├── handlers/main.yml
+│   ├── meta/main.yml            # dependencies: [docker]
+│   └── templates/
+│       ├── remo-notifier.service.j2
+│       └── notifier.toml.j2
+├── notifier_deploy.yml          # NEW playbook: apply remo_notifier to a target host
+├── tasks/configure_dev_tools.yml# MODIFIED — include remo_notifier when toggled
+├── group_vars/all.yml           # MODIFIED — notifier vars (env-backed secrets)
+└── requirements.yml             # MODIFIED — add community.docker collection
+
+notifier/
+└── Dockerfile                   # NEW — multi-stage build (repo root, NOT under src/)
+
+tests/notifier/                  # NEW — mirrors the package
+├── __init__.py
+├── conftest.py                  # fixtures: fake transport, test config, async loop
+├── test_models.py
+├── test_config.py
+├── test_state.py                # registry: register/cancel/timeout/resolve/cap/dup-id
+├── test_server.py               # all status codes; TestClient + AsyncClient
+├── test_telegram.py             # Bot mock; message/keyboard/callback/edit/cancel
+└── test_cli_notifier.py         # subcommands with mocked SSH + fake host registry
+
+pyproject.toml                   # MODIFIED — [notifier] extra, remo-notifier script,
+                                 #   dev deps (pytest-asyncio, httpx), force-include build ctx
+README.md                        # MODIFIED — "Notifier" + "Notifier setup" sections
+```
+
+**Structure Decision**: Single-project layout, matching the existing repo. The notifier is an additive fourth peer package under `src/remo_cli/notifier/`; the only edits to existing files are pure additions/registrations (`cli/main.py`, `pyproject.toml`, `group_vars/all.yml`, `tasks/configure_dev_tools.yml`, `requirements.yml`) so no existing command's behavior changes (FR-032). The Ansible role is self-contained with one `meta` dependency on `docker`; no existing role is modified (spec constraint).
+
+## Complexity Tracking
+
+> No constitution violations — section intentionally empty.

--- a/specs/007-notifier-sidecar/quickstart.md
+++ b/specs/007-notifier-sidecar/quickstart.md
@@ -1,0 +1,170 @@
+# Quickstart: Notifier Sidecar
+
+Two audiences: an **operator** standing the notifier up on a host, and a **developer** working on the notifier code. Both assume the existing remo dev setup (`uv sync`, Python ≥3.11).
+
+## Operator: zero → working approval loop
+
+### 1. Create a Telegram bot
+- In Telegram, message `@BotFather`, run `/newbot`, follow the prompts. Save the bot token it returns.
+
+### 2. Find your chat id
+- Message `@userinfobot` from your own account; it replies with your numeric user id. That is your `authorized_chat_id`.
+
+### 3. Message your new bot once
+- Open a chat with your bot and send any message. A bot cannot DM you until you've initiated a chat.
+
+### 4. Export credentials on the laptop (where `remo` runs)
+```bash
+export REMO_NOTIFIER_TELEGRAM_BOT_TOKEN="12345:ABC...your-token"
+export REMO_NOTIFIER_TELEGRAM_CHAT_ID="987654321"
+```
+
+### 5. Deploy to a host
+```bash
+remo notifier deploy <host>     # omit <host> to fuzzy-pick from known hosts
+```
+This applies the `remo_notifier` Ansible role: pre-flights the credentials, renders `/etc/notifier/notifier.toml`, writes the token to `/etc/notifier/secrets/telegram_bot_token` (0400), builds the image on the host, installs and starts `remo-notifier.service`, and waits for `/v1/health` to return 200.
+
+### 6. Verify end-to-end
+```bash
+remo notifier test <host>
+```
+You should get a Telegram message within ~2 s; tapping **Approve** prints `decision: allow`, **Deny** prints `decision: deny`.
+
+### Day-2
+```bash
+remo notifier status <host>            # /v1/health JSON
+remo notifier logs <host> --follow     # journalctl -u remo-notifier.service -f
+remo notifier restart <host>           # systemctl restart
+remo notifier deploy <host> --rebuild  # force image rebuild
+```
+
+### Rotate the bot token
+Update the secret on the host and restart:
+```bash
+remo notifier restart <host>   # after rewriting /etc/notifier/secrets/telegram_bot_token
+```
+(The service also re-reads the token on `SIGHUP`.)
+
+## Developer: run and test locally
+
+### Install with the notifier extra
+```bash
+uv pip install -e ".[notifier]"      # adds FastAPI, uvicorn, pydantic, python-telegram-bot, structlog
+remo-notifier --help
+```
+
+### Run the server against a local config
+```toml
+# /tmp/notifier.toml
+[server]
+listen_host = "127.0.0.1"
+listen_port = 18181
+log_level = "debug"
+
+[approval]
+default_timeout_seconds = 300
+max_timeout_seconds = 1800
+max_pending_approvals = 50
+
+[transport]
+type = "telegram"
+
+[transport.telegram]
+bot_token_file = "/tmp/telegram_token"   # echo your token into this file
+authorized_chat_id = 987654321
+message_parse_mode = "MarkdownV2"
+
+[instance]
+id = "dev-local"
+```
+```bash
+printf '%s' "$REMO_NOTIFIER_TELEGRAM_BOT_TOKEN" > /tmp/telegram_token
+chmod 0400 /tmp/telegram_token
+remo-notifier serve --config /tmp/notifier.toml
+curl -s http://127.0.0.1:18181/v1/health | jq
+```
+
+### Exercise the wire protocol
+```bash
+# Times out → 408 fail-secure deny after ~5s
+curl -i -X POST http://127.0.0.1:18181/v1/approve \
+  -H 'content-type: application/json' \
+  -d '{"operation":{"kind":"command","command":"rm","args":["-rf","/tmp/x"]},
+       "policy_rule_name":"demo","policy_message":"approve rm?","timeout_seconds":5}'
+```
+
+### Build & size-check the image
+```bash
+docker build -t remo-notifier:0.1.0 -f notifier/Dockerfile .
+docker images remo-notifier:0.1.0       # expect < 250 MB
+docker run --rm -p 18181:18181 \
+  -v /tmp/notifier.toml:/etc/notifier/notifier.toml:ro \
+  -v /tmp/telegram_token:/run/secrets/telegram_bot_token:ro \
+  remo-notifier:0.1.0
+```
+
+### Tests, lint, types
+```bash
+uv run pytest tests/notifier/ --cov=remo_cli.notifier   # target > 85%
+uv run ruff check src/remo_cli/notifier/
+uv run mypy src/remo_cli/notifier/
+# Ansible safety (constitution): expect no bare attribute access
+grep -r '\.rc ==' ansible/roles/remo_notifier/ ; grep -r '\.stdout' ansible/roles/remo_notifier/
+```
+
+## Acceptance smoke (maps to spec Success Criteria)
+
+| Check | Spec |
+|-------|------|
+| Tap Approve → caller gets `allow` < 5 s | SC-001 |
+| No tap, 5 s timeout → 408 `{decision: deny, reason: timeout}` in 5–6 s | SC-002, AC-7 |
+| `deploy` → service `active (running)`, health 200 < 5 s | SC-003, AC-3 |
+| Zero → working via documented steps + deploy + test | SC-004 |
+| Only human Approve yields `allow` (timeout/400/503/shutdown never do) | SC-005 |
+| No token/body/workspace at INFO+ logs | SC-006 |
+| Existing `remo` commands unchanged; laptop install lacks notifier deps | SC-007 |
+| Wire protocol fully documented (contracts/) | SC-008 |
+| Image < 250 MB; health 200 < 5 s in container | AC-2 |
+| `pytest tests/notifier/` > 85% coverage | AC-8 |
+| `ruff` + `mypy` clean on notifier package | AC-9 |
+
+## Standing grants — "Always" (Addendum 001)
+
+### Try it locally
+
+With `remo-notifier serve` running and a real bot:
+
+```bash
+# Send a request; in Telegram tap [⏩ Always…], then pick a generalization+scope.
+curl -i -X POST http://127.0.0.1:18181/v1/approve -H 'content-type: application/json' \
+  -d '{"operation":{"kind":"command","command":"git","args":["push","origin","main"]},
+       "policy_rule_name":"vcs-push","policy_message":"allow git push?","project":"demo"}'
+
+# Repeat the same request — it should now return 200 allow instantly, no Telegram,
+# with responder "rule:<grant_id>" and a grant_id field.
+```
+
+Manage grants from Telegram: `/rules` (list + revoke buttons), `/revoke <id>`,
+`/pause` and `/resume`.
+
+### Config (notifier.toml)
+
+```toml
+[grants]
+enabled = true
+default_ttl_seconds = 28800   # 8h; every grant expires (no indefinite grants)
+max_grants = 100
+allow_global_scope = true
+digest_interval_seconds = 3600  # 0 disables the auto-approval digest
+```
+
+### Acceptance smoke (Addendum)
+
+| Check | Spec |
+|-------|------|
+| After "Always", a matching request returns `allow` < 500 ms, no Telegram | SC-G1 |
+| Only an active/unexpired/unrevoked human grant ever auto-approves; else prompt/fail-closed | SC-G2 |
+| `/rules` lists, `/revoke` and `/pause` take effect immediately | SC-G3 |
+| Every auto-approval is auditable by `grant_id`, no secrets in the record | SC-G4 |
+| Restart clears all grants → re-prompts (fail-closed) | SC-G5 |

--- a/specs/007-notifier-sidecar/research-addendum-001.md
+++ b/specs/007-notifier-sidecar/research-addendum-001.md
@@ -1,0 +1,152 @@
+# Phase 0 Research — Addendum 001: Standing Grants
+
+Product-level questions were settled in `/speckit.clarify` (see the addendum's
+Clarifications: no bundling, offer-always, single 8h TTL, Telegram-only listing).
+This document resolves the remaining **implementation** decisions. No
+`NEEDS CLARIFICATION` markers remain except the external OQ1 (agentsh signing),
+which only gates the *future* promotion path, not v1.
+
+## RG1. Where the GrantStore lives and how the transport reaches it
+
+**Decision**: `GrantStore` is instantiated in `create_app()` (one per process,
+alongside the `PendingApprovals` registry). The **server** performs the
+allow-capable match at intake. The store is **injected into the transport**
+(constructor arg) so the Telegram transport can (a) ask `grants.propose(request)`
+for picker candidates, (b) call `grants.create(grant)` on selection, and (c) back
+`/rules`/`/revoke`/`/pause`. Matching (enforcement) never happens in the
+transport.
+
+**Rationale**: Keeps the security-critical match in one transport-agnostic place
+(`server.py`), while the grant UI is a Telegram concern. One store owner avoids
+split state. Mirrors how the registry is already owned by `create_app`.
+
+**Alternatives**: store inside the transport (rejected — couples enforcement to a
+specific transport, and the server needs it for the short-circuit); global
+singleton (rejected — breaks test isolation, which relies on per-app instances).
+
+## RG2. Candidate-generalization templates (the proposer)
+
+**Decision**: `grants.propose(request) -> list[CandidateGrant]` returns an
+ordered, **tightest-first** list of `(predicate, scope, label)` built by
+deterministic templates per `operation.kind`:
+
+- `command`: ① exact command+args → ② command + arg-prefix (`git push *`) →
+  ③ command only (`git *`) → ④ (broadest) `policy_rule_name` predicate.
+- `file`: ① exact path+op → ② path's directory glob + op (`{workspace}/sub/** ·
+  delete`) → ③ workspace-rooted glob + op → ④ `policy_rule_name`.
+- `network`: ① exact host+port → ② host **suffix** + port (`*.github.com:443`) →
+  ③ `policy_rule_name`.
+- `signal`: ① exact signal+target → ② `policy_rule_name`.
+
+Each candidate is paired with the **narrowest scope covering the request** by
+default (FR-G7); the picker also offers one widened scope rung. The proposer is
+pure (no I/O), so it is unit-testable in isolation.
+
+**Rationale**: Deterministic, inspectable, matches the FR-G6 ladder and the
+no-bundling decision (policy_rule_name is the broadest *rung*, not a bundle).
+
+**Alternatives**: LLM-proposed labels (deferred — must never enter the runtime
+matcher; could later enrich labels only); fixed single generalization (rejected —
+removes human control over breadth).
+
+## RG3. Telegram multi-step picker without busting callback_data
+
+**Decision**: Telegram `callback_data` is ≤ 64 bytes, too small for a predicate.
+So: on **Always…** tap, the transport looks up the request's already-stored
+`_Sent` entry, computes candidates via `grants.propose()`, stashes them in a
+short-lived `_pending_picker[approval_id] = [candidates]`, and renders buttons
+with `callback_data = pick:{approval_id}:{index}`. On the pick callback it reads
+`_pending_picker[approval_id][index]`, creates the grant, resolves the approval
+`allow`, and edits the message to confirm. A `pick:{approval_id}:cancel` returns
+to the original Approve/Deny choice.
+
+**Rationale**: Keeps `callback_data` tiny and within Telegram limits; the
+candidate set lives in process memory keyed by the approval, consistent with how
+the transport already tracks `_Sent`.
+
+**Alternatives**: encode predicate in callback_data (rejected — 64-byte limit);
+inline-query/web-app picker (rejected — overkill, needs more bot setup).
+
+## RG4. TTL expiry + max-grants enforcement
+
+**Decision**: Expiry is enforced **lazily at match time** (an expired grant never
+matches — FR-G8) *and* swept periodically by a lightweight asyncio task started
+in the FastAPI lifespan (default every 60 s) to reclaim memory and keep
+`/rules` honest. `create()` enforces `max_grants` under the store lock; over the
+cap it raises a typed error the transport surfaces in Telegram ("grant limit
+reached"). On shutdown the store is simply dropped (no drain needed — grants are
+advisory, losing them just re-prompts).
+
+**Rationale**: Lazy check guarantees correctness even if the sweeper lags; the
+sweeper is for hygiene, not correctness. Cap mirrors the pending-approval cap
+(FR-034) for symmetric backpressure.
+
+**Alternatives**: per-grant timer tasks (rejected — needless task churn);
+sweep-only without lazy check (rejected — a lag window could match an expired
+grant, violating FR-G8).
+
+## RG5. Scope derivation and matching
+
+**Decision**: A grant's scope is one of `session|workspace|project|instance|
+global` with a captured `value`. Matching compares against the request fields:
+`session`→`session_id`, `workspace`→`workspace`, `project`→`project`,
+`instance`→`instance_id` (falling back to configured instance id), `global`→
+always. A grant matches only if the request's corresponding field **equals** the
+grant's captured value (or scope is `global`). If the request lacks the field the
+scope keys on, it is **no match** (fail-closed).
+
+**Rationale**: Exact-equality scope keeps matching deterministic and prevents a
+grant created in project A from firing in project B. Fail-closed on missing
+fields avoids accidental broadening.
+
+**Alternatives**: hierarchical/prefix scope (deferred — adds matching complexity
+not needed in v1); ignore scope (rejected — removes the primary blast-radius
+control).
+
+## RG6. Auto-approval audit + digest
+
+**Decision**: Each short-circuit auto-approval emits a structured INFO log
+`auto_approved {approval_id, grant_id, kind, command|host|path-summary,
+latency_ms}` (no secrets/bodies — FR-017) and increments the grant's
+`uses_count`/`last_used_at`. A digest task (lifespan, default hourly; configurable
+or off) sends the authorized chat a summary ("auto-approved N ops via M grants in
+the last hour") when count > 0. Digest cadence reuses the same lightweight task
+loop pattern as the sweeper.
+
+**Rationale**: Satisfies FR-G11 (no silent standing grants) without a per-event
+Telegram message (which would defeat the purpose). Structural-only fields honor
+the logging redaction already built.
+
+**Alternatives**: per-auto-approval Telegram message (rejected — noise, negates
+the feature); no digest (rejected — violates the "never silent" intent).
+
+## RG7. Interaction with the existing intake flow
+
+**Decision**: The short-circuit is the **first** step of `POST /v1/approve`,
+before the shutdown/health gate and before `reserve()`. Order: parse → (if grants
+enabled and not paused) `match` → on hit return `allow` (+`grant_id`) and log;
+on miss fall through to the existing shutdown/health → clamp → reserve → send →
+await pipeline unchanged. Timeout/capacity/duplicate logic is untouched on the
+miss path.
+
+**Rationale**: Auto-approved requests should cost nothing (no slot, no transport
+call), and a paused/disabled grant system must transparently fall back to the
+proven v1 behavior.
+
+**Alternatives**: match after reserve (rejected — wastes a slot and a send for an
+auto-approvable request).
+
+## Resolved summary
+
+| Topic | Resolution |
+|-------|-----------|
+| Store ownership / access | app-owned, injected into transport; match in server (RG1) |
+| Candidate templates | deterministic tightest-first per kind + policy_rule_name rung (RG2) |
+| Telegram picker | stash candidates, `pick:{id}:{index}` callback_data (RG3) |
+| TTL + cap | lazy-at-match + periodic sweep; cap on create (RG4) |
+| Scope matching | exact-equality per scope field, fail-closed on missing (RG5) |
+| Audit + digest | structural INFO log + periodic digest, no secrets (RG6) |
+| Intake ordering | short-circuit first, miss falls through unchanged (RG7) |
+| Agentsh promotion/signing | external OQ1 — deferred, not a v1 blocker |
+
+All v1 implementation unknowns resolved — ready for Phase 1 / tasks.

--- a/specs/007-notifier-sidecar/research.md
+++ b/specs/007-notifier-sidecar/research.md
@@ -1,0 +1,124 @@
+# Phase 0 Research: Notifier Sidecar
+
+This document resolves the open technical decisions implied by the spec and the repo's existing conventions. Each entry is a Decision / Rationale / Alternatives triple. No `NEEDS CLARIFICATION` markers remained in the spec after `/speckit.clarify`; the items below are technical-approach choices, not requirement gaps.
+
+## R1. FastAPI + Telegram on one asyncio event loop
+
+**Decision**: Run the FastAPI app under uvicorn programmatically (`uvicorn.Server(Config(...)).serve()`); start the `python-telegram-bot` `Application` (initialize → start → `updater.start_polling()`) inside the FastAPI **lifespan** startup and stop it (stop polling → stop → shutdown) in lifespan shutdown. Both share the single running asyncio loop.
+
+**Rationale**: The spec mandates long-polling (no public URL) and a single shared loop. PTB v21's `Application` is asyncio-native and composes with an externally-owned loop when driven via its lower-level `initialize/start/updater.start_polling` methods rather than the blocking `run_polling()` (which calls `asyncio.run` and owns the loop — incompatible with uvicorn already owning it). The lifespan hook is the documented FastAPI seam for background services.
+
+**Alternatives considered**:
+- `Application.run_polling()` directly — rejected: it creates/owns its own loop and blocks, conflicting with uvicorn.
+- Separate thread for the bot with its own loop — rejected: cross-loop `asyncio.Event` resolution is error-prone; the spec explicitly wants one loop.
+- Webhook mode — rejected by constraint (needs a public URL).
+
+## R2. Pending-approval registry and timeout race
+
+**Decision**: `PendingApprovals` holds `approval_id -> PendingApproval`, where each entry owns an `asyncio.Future[ApprovalDecision]`. Intake flow: validate → reject if `approval_id` already pending (409) → reject if at capacity (503) → deliver notification via transport → only then register the entry → `await asyncio.wait_for(future, timeout=clamped_timeout)`. On `TimeoutError`, resolve to fail-secure deny (reason `timeout`), call `transport.cancel`/edit, and return 408. A callback resolves the Future via `loop.call_soon_threadsafe`-safe path (same loop, so direct `set_result` guarded by "still pending"). All mutations go through an `asyncio.Lock` to keep cap-check + insert atomic.
+
+**Rationale**: Futures (not Events) carry the decision payload directly. Registering only *after* successful send (R5) keeps the cap meaningful and satisfies FR-010a. The lock makes the capacity gate (FR-034) and duplicate-id gate (FR-003a) race-free. "Still pending" guards make late/duplicate callbacks no-ops (edge cases).
+
+**Alternatives considered**:
+- `asyncio.Event` + side dict for the decision — rejected: two structures to keep consistent; Future is one.
+- Register before send — rejected: would hold a cap slot for a request that failed to notify (violates FR-010a intent).
+- Per-entry lock only — rejected: capacity is a global invariant, needs a registry-level lock.
+
+## R3. Timeout clamping and defaults
+
+**Decision**: Effective timeout = `min(max(request.timeout_seconds or default, 1), max_timeout_seconds)`, with `default_timeout_seconds` and `max_timeout_seconds` from config (defaults 300 / 1800). Clamp silently (no error) per FR-006.
+
+**Rationale**: Matches FR-006 directly; a silent clamp is friendlier than rejecting and keeps the caller contract simple. A 1 s floor prevents zero/negative pathological waits.
+
+**Alternatives considered**: 400 on over-max — rejected: FR-006 says clamp, not reject.
+
+## R4. Fail-secure decision algebra
+
+**Decision**: A single internal resolver yields exactly one terminal outcome per approval: `ALLOW` only from an authorized human tapping Approve; everything else (`Deny` tap, timeout, transport/send failure, shutdown, lost connection) is `DENY` or no response at all. HTTP mapping: human decision → 200; timeout → 408 with `{decision: deny, reason: "timeout"}`; validation → 400; duplicate-id → 409; transport down / no config / shutting down / at capacity / send failure → 503.
+
+**Rationale**: Centralizes FR-008's invariant in one place that tests can target (SC-005). The 409 for duplicate-id (FR-003a) is the one non-spec-enumerated code; documented in the contract as a sub-case of "client error" from FR-003a/FR-001's 400 family — see R9.
+
+**Alternatives considered**: Returning 200-with-deny on transport failure — rejected: 503 lets the caller distinguish "no human saw this" from "human denied".
+
+## R5. Getting the image build context onto the host
+
+**Decision**: Force-include the minimal Docker build context into the wheel next to the already-included `ansible/` tree, at `remo_cli/notifier_build/` (containing `Dockerfile`, `pyproject.toml`, `uv.lock`, `README.md`, and the `remo_cli` source needed to `pip install ".[notifier]"`). The `remo_notifier` role copies this directory to `remo_notifier_source_dir` on the host and runs `community.docker.docker_image` with `source: build`. A resolver in the role (or passed as an extra-var by the CLI) locates the installed build context via `importlib`/package path, mirroring how `core/config.get_ansible_dir()` resolves the bundled `ansible/`.
+
+**Rationale**: A `pip install remo-cli` user has no repo checkout, yet the spec requires v1 to build on the host. Shipping the build context in the wheel (the same trick already used for `ansible/`) makes `remo notifier deploy` work from a bare install. The Dockerfile at repo root (`notifier/Dockerfile`, per spec) is the source of truth; the wheel-included copy is produced by a hatch force-include mapping.
+
+**Alternatives considered**:
+- Build in CI, pull from ghcr.io — explicitly deferred by the spec (out of scope v1).
+- Copy from the user's repo checkout — rejected: not present for pip installs.
+- Build an sdist on the host — rejected: heavier and still needs the source shipped.
+
+**Layout contract (U1)**: the bundled context at `remo_cli/notifier_build/` MUST reproduce a repo-root-relative tree — `Dockerfile`, `pyproject.toml`, `README.md`, `uv.lock`, `src/remo_cli/…` — so the *same* `notifier/Dockerfile` builds identically from the repo root and from the on-host copy. The role (T025) copies this directory verbatim, preserving layout; the CLI (T028) resolves the installed path and passes it as an extra-var. `uv.lock` is shipped only for an optional `uv sync --frozen` locked build; a plain `uv pip install ".[notifier]"` does not consume it (I1).
+
+**Risk/Note**: Force-including `src/` doubles some files in the wheel. Keep the included context minimal (only what `.[notifier]` install needs). Confirm image stays <250 MB (AC-2) — Python 3.13-slim + these deps is ~180–220 MB.
+
+## R6. Secret handling and rotation
+
+**Decision**: The bot token is read once from `bot_token_file` (default `/run/secrets/telegram_bot_token`) at startup and kept only in memory. The TOML config never contains the token. Rotation: operator rewrites the secret file and restarts the service; additionally the process installs a `SIGHUP` handler that re-reads the secret file and re-initializes the bot (supports the spec's "rotation via kill -HUP" note) — best-effort, not a v1 acceptance criterion. structlog is configured with a processor that drops/reduces known-sensitive keys; the token is never passed to a logger.
+
+**Rationale**: Satisfies FR-019 (separate file, never config), FR-017 (no secrets in logs), and the out-of-scope note that HUP-rotation is supported without a CLI wrapper.
+
+**Alternatives considered**: Env-var token — rejected: env is visible in `/proc` and process listings; file with `0400` is tighter and rotatable.
+
+## R7. structlog configuration matching remo
+
+**Decision**: Configure structlog at process start: ISO timestamp, level, logger name, JSON renderer in the container (machine-readable for journald), key-value renderer if a TTY. INFO+ emits only structural fields (`approval_id`, `decision`, `latency_ms`, `transport`, `pending_count`). A dedicated DEBUG path may log operation/workspace/raw-body. A redaction processor strips `bot_token`, `authorization`, and full request bodies from any event not explicitly at DEBUG.
+
+**Rationale**: FR-017 + the "do not log secrets" constraint. JSON to stdout is the right shape for `docker logs` → journald → `remo notifier logs`.
+
+**Alternatives considered**: stdlib logging — rejected: spec names structlog and it gives cleaner structured redaction.
+
+## R8. CLI subcommand transport (SSH vs direct HTTP)
+
+**Decision**: `remo notifier {status,logs,test,restart}` operate **over SSH to the host** using the existing `core/ssh.build_ssh_opts` + a subprocess `ssh` invocation, consistent with `remo shell`/`cp`. `status` runs `curl -sf http://{bind}:{port}/v1/health` on the host; `test` runs `curl` POSTing a test `ApprovalRequest` to the same bridge address from the host; `logs` runs `journalctl -u remo-notifier.service [-f] [-n N]`; `restart` runs `sudo systemctl restart remo-notifier.service`. `deploy` runs the `notifier_deploy.yml` playbook via `core/ansible_runner.run_playbook` with `-i "{host},"` and `-e ansible_user=...`, exactly like `hetzner update`. Every subcommand resolves the host via `core/known_hosts` + `core/picker` (fuzzy pick when no host given, FR-031).
+
+**Rationale**: The listener is bound to the bridge and unreachable from the laptop (FR-021), so the laptop cannot curl it directly — it must hop through the host over SSH. Reusing the established SSH/ansible/picker helpers keeps UX identical to existing commands and adds zero laptop runtime deps.
+
+**Alternatives considered**:
+- Direct HTTP from laptop — rejected: bridge binding makes it unreachable by design.
+- A second control endpoint exposed publicly — rejected: widens attack surface against FR-021.
+
+## R9. HTTP status code for duplicate approval_id
+
+**Decision**: Return **409 Conflict** for a duplicate-of-pending `approval_id` (FR-003a), documented in the contract alongside the spec's 400/408/503. Body: `{ "error": "duplicate_approval_id", "approval_id": "..." }`.
+
+**Rationale**: 409 is the precise semantic ("conflict with current resource state — already pending"). The spec phrased FR-003a as "a client-error signal"; 409 is the most accurate client-error code and is additive to the spec's enumerated set, not contradictory.
+
+**Alternatives considered**: 400 — acceptable per the literal spec wording but less precise; 200-attach (idempotent) was rejected during clarification (Option B not chosen).
+
+## R10. Ansible collection + role wiring
+
+**Decision**: Add `community.docker (>=4.0.0)` to `ansible/requirements.yml` (used by `community.docker.docker_image`). The `remo_notifier` role declares `meta/main.yml` `dependencies: [{role: docker}]`. A new top-level `notifier_deploy.yml` playbook (`hosts: all`, `become: true`) applies the role; `remo notifier deploy` invokes it. Inclusion in the standard configure flow is via `configure_dev_tools.yml` guarded by `configure_remo_notifier | default(true) | bool` (FR-033), following the existing toggle pattern.
+
+**Rationale**: `docker_image`/`docker_container`/systemd are the idiomatic Ansible path here; `community.docker` is the only missing collection. The standalone `notifier_deploy.yml` lets `remo notifier deploy <host>` target an already-provisioned host without re-running the whole configure, while the toggle lets first-time provisioning include it.
+
+**Alternatives considered**:
+- `docker_container` module instead of a systemd unit running `docker run` — rejected: the spec mandates a systemd unit with specific `docker run` hardening flags and `Restart=always`; a templated unit matches the spec exactly and keeps restart semantics in systemd.
+- Reuse a provider configure playbook — rejected: would couple the notifier to one provider; a dedicated playbook is provider-agnostic.
+
+## R11. Test strategy and new dev dependencies
+
+**Decision**: Add `pytest-asyncio` and `httpx` to the `dev` extra. Tests: `test_state.py` drives the registry directly (register/resolve/timeout/cancel/cap/duplicate-id, including concurrency via `asyncio.gather`); `test_server.py` uses FastAPI `TestClient` (sync) for status-code coverage and `httpx.AsyncClient` + ASGI transport for the await-until-decision and timeout (408) paths with a fake transport that resolves on command; `test_telegram.py` injects a mocked `Bot` into the PTB `Application` and asserts message text, inline keyboard `callback_data`, the callback→resolve path, message edits, and `cancel`; `test_cli_notifier.py` patches the SSH/subprocess and ansible-runner seams and a fake known-hosts registry. Target >85% line coverage on `src/remo_cli/notifier/` (SC/AC-8).
+
+**Rationale**: Mirrors the spec's testing section and existing `tests/` patterns (`tests/unit`, `tests/integration`, `conftest.py`). A fake `NotificationTransport` makes server timeout/fail-secure tests deterministic without Telegram.
+
+**Alternatives considered**: Live Telegram in CI — rejected: non-deterministic, needs secrets; reserved for the manual `remo notifier test` acceptance step.
+
+## Resolved unknowns summary
+
+| Topic | Resolution |
+|-------|-----------|
+| One-loop FastAPI + PTB | lifespan start/stop, low-level PTB API (R1) |
+| Registry + timeout race | Future + registry lock, register-after-send (R2) |
+| Timeout clamp | min/max with config bounds (R3) |
+| Fail-secure mapping | central resolver; 200/408/400/409/503 (R4, R9) |
+| Build context to host | force-include in wheel, role copies + builds (R5) |
+| Secrets | file-only token, in-memory, HUP re-read, redaction (R6, R7) |
+| CLI transport | SSH hop reusing existing helpers (R8) |
+| Ansible wiring | community.docker, role meta→docker, deploy playbook + toggle (R10) |
+| Tests/deps | pytest-asyncio + httpx, fake transport, Bot mock (R11) |
+
+All items resolved — ready for Phase 1.

--- a/specs/007-notifier-sidecar/spec.md
+++ b/specs/007-notifier-sidecar/spec.md
@@ -1,0 +1,212 @@
+# Feature Specification: Notifier Sidecar — Telegram approval bridge for agentsh
+
+**Feature Branch**: `007-notifier-sidecar`  
+**Created**: 2026-05-31  
+**Status**: Draft  
+**Input**: User description: "Notifier Sidecar: Telegram approval bridge for agentsh — a long-running HTTP daemon in an OCI container on each remo-provisioned instance that receives agentsh approval webhooks, delivers them to a human via a Telegram bot, and returns the human's decision back to agentsh within the approval timeout."
+
+## Overview
+
+When the future agentsh execution-layer security model decides an operation needs human approval, it must reach a human who is not watching the terminal. The notifier is the push channel that closes that gap: it accepts an approval request from a devcontainer on the same instance, alerts a human on Telegram, and returns the human's allow/deny decision synchronously — failing secure (deny) if no one answers in time.
+
+This spec establishes the notifier service and, critically, the **durable wire protocol** that future approval emitters integrate against. Telegram is the only delivery channel implemented in v1, but the request/response contract and the operator workflow (deploy, test, observe) are the lasting deliverables.
+
+## Clarifications
+
+### Session 2026-05-31
+
+- Q: When the notifier restarts while approvals are in flight, what happens to those pending approvals? → A: They are lost; the caller's open connection drops and the caller (agentsh) treats a dropped connection as a fail-secure deny. No persistence.
+- Q: Who is authorized to answer an approval? → A: Exactly one pre-configured Telegram chat per instance (single human/chat). Multi-recipient and identity-aware routing are out of scope for v1.
+- Q: What is the network exposure of the approval endpoint? → A: Bound to the host's container-bridge address only — reachable by co-located devcontainers but not from outside the host; no transport encryption or caller authentication in v1.
+- Q: Is there a bound on how many approvals can be pending at once (any bridge container can POST with no caller auth)? → A: Yes — a configurable maximum concurrent pending approvals (default 50); beyond it, new requests are rejected with a service-unavailable signal until capacity frees up.
+- Q: What happens when delivering the notification for one specific request fails while the transport is otherwise up? → A: Fail that request immediately with a service-unavailable signal and hold no pending slot; the caller retries or applies its own deny.
+- Q: What happens when a request arrives carrying an approval_id that is already pending? → A: Reject the duplicate with a client-error signal while the original is still pending; the original keeps running.
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - Human approves or denies an operation from their phone (Priority: P1)
+
+A devcontainer's security layer encounters an operation its policy flags for human approval and sends an approval request to the notifier. The human receives a Telegram message describing the operation (project, command, rule, instance) with **Approve** and **Deny** buttons. They tap one; the decision is delivered back to the waiting caller, and the Telegram message updates to show who decided and when.
+
+**Why this priority**: This is the entire reason the service exists. Without it there is no human-in-the-loop approval channel and the agentsh security model cannot function. It is the MVP — everything else supports this loop.
+
+**Independent Test**: Send a single approval request to a running notifier; confirm a Telegram message with two buttons arrives, tap a button, and confirm the caller receives the matching decision within seconds and the Telegram message reflects the outcome.
+
+**Acceptance Scenarios**:
+
+1. **Given** a running, configured notifier, **When** an approval request arrives and the human taps **Approve** within the timeout, **Then** the caller receives an "allow" decision identifying the responder and the elapsed time, and the original Telegram message is edited to show it was approved.
+2. **Given** a running, configured notifier, **When** an approval request arrives and the human taps **Deny**, **Then** the caller receives a "deny" decision and the Telegram message is edited to show it was denied.
+3. **Given** an approval request with a 5-second timeout, **When** no human responds, **Then** the caller receives a fail-secure "deny" decision marked as a timeout within roughly 5–6 seconds, and the Telegram message is edited to show it timed out.
+
+---
+
+### User Story 2 - Operator deploys the notifier to an instance (Priority: P1)
+
+An operator who already manages remo-provisioned hosts wants the approval channel running on a specific host. From their laptop they run a single deploy command naming the host. The notifier is built/installed and started on that host as a managed background service, bound so that only co-located devcontainers can reach it. The command fails loudly if the required Telegram credentials are not configured.
+
+**Why this priority**: An approval loop nobody can stand up has no value. Deployment must be a one-command operator action consistent with the rest of the remo CLI, and it is a prerequisite for Story 1 to run anywhere real.
+
+**Independent Test**: Run the deploy command against a fresh host that has only the base container runtime, then confirm the service is active and answering its health probe, with no manual steps in between.
+
+**Acceptance Scenarios**:
+
+1. **Given** a reachable host and valid Telegram credentials available to the operator, **When** the operator runs the deploy command for that host, **Then** the notifier service ends up active and running and the deploy reports success.
+2. **Given** missing or empty Telegram credentials, **When** the operator runs the deploy command, **Then** it fails with a clear message naming what is missing and does not start a broken service.
+3. **Given** an already-deployed host, **When** the operator runs deploy again with a rebuild flag, **Then** the service is rebuilt and restarted and ends up active and running.
+
+---
+
+### User Story 3 - Operator verifies wiring end-to-end (Priority: P2)
+
+After deploying (or when first setting up Telegram), the operator runs a test command for the host. This sends a clearly test-labeled approval through the full path; the human receives a test Telegram message and taps a button; the command reports the round-trip succeeded and shows the decision. This confirms the bot token, chat ID, network binding, and decision return path all work without waiting for a real agentsh event.
+
+**Why this priority**: First-time Telegram setup has several independent failure points (wrong token, wrong chat ID, bot never messaged, port binding). A dedicated test command turns a frustrating multi-step debug into one observable action. Valuable but not required for the core loop to function.
+
+**Independent Test**: Run the test command against a deployed host; confirm a test-labeled Telegram message arrives, tap a button, and confirm the command prints the returned decision.
+
+**Acceptance Scenarios**:
+
+1. **Given** a deployed, healthy notifier, **When** the operator runs the test command, **Then** a test-labeled approval arrives on Telegram and the operator's tapped decision is reported back by the command.
+2. **Given** a host where the notifier is not running, **When** the operator runs the test command, **Then** it reports the service is unreachable rather than hanging indefinitely.
+
+---
+
+### User Story 4 - Operator observes and controls a running notifier (Priority: P3)
+
+An operator wants to check whether a host's notifier is healthy, read its logs to diagnose an issue, or restart it after a configuration change. The CLI exposes status, logs (optionally followed), and restart subcommands for a named host, matching the host-selection UX of the rest of remo (including fuzzy host picking when no host is named).
+
+**Why this priority**: Day-2 operability. The service can be deployed and exercised without these, but they make ongoing operation and debugging practical. Lowest priority because each is a thin convenience over what an operator could otherwise do by hand.
+
+**Independent Test**: Against a deployed host, run status and confirm it reports the health summary; run logs and confirm service log lines stream; run restart and confirm the service returns to active.
+
+**Acceptance Scenarios**:
+
+1. **Given** a deployed notifier, **When** the operator runs status, **Then** the current health summary (status, version, transport, uptime, count of pending approvals) is displayed.
+2. **Given** a deployed notifier, **When** the operator runs logs with the follow option, **Then** service log output streams until the operator stops it.
+3. **Given** a deployed notifier, **When** the operator runs restart, **Then** the service stops and comes back to active and running.
+4. **Given** no host is named on any of these subcommands, **When** the operator runs it, **Then** they are offered an interactive fuzzy picker of known hosts, consistent with other remo commands.
+
+---
+
+### Edge Cases
+
+- **Late or duplicate response**: A human taps a button for an approval that already timed out, or taps twice. The notifier ignores responses for approvals that are no longer pending and does not change an already-decided outcome.
+- **Unauthorized responder**: A button tap or message arrives from a chat that is not the configured authorized chat. It is ignored and has no effect on any approval.
+- **Malformed request**: An approval request that fails schema validation is rejected with a client error and never produces a Telegram message.
+- **Transport unavailable**: The Telegram channel cannot be reached, or no human-side configuration is loaded. New approval requests are refused with a service-unavailable signal rather than silently hanging.
+- **Shutdown with in-flight approvals**: The service is stopping while approvals await a human. In-flight callers are released (their connections drop / they receive a service-unavailable signal); no decision is fabricated as "allow". Restart loses all pending approvals (no persistence), and callers treat the dropped connection as deny.
+- **Oversized timeout**: A request asks for a timeout beyond the configured maximum. The notifier clamps to the maximum rather than honoring an unbounded wait.
+- **Secret rotation**: The Telegram bot token changes. The operator rotates it by updating the stored secret and restarting (or signaling) the service; the token is never read from the main config file or emitted in logs.
+- **Concurrent approvals**: Multiple approval requests are pending at once. Each is tracked independently by its own identifier; a decision on one never resolves another.
+- **Duplicate request identifier**: A request arrives bearing an approval identifier already in flight. It is rejected with a client error and the original pending approval is untouched; no second notification is sent.
+- **Capacity reached**: The maximum number of concurrent pending approvals is already in flight. New requests are refused with a service-unavailable signal and no notification, until a pending approval resolves.
+- **Notification send failure**: Delivery of a specific request's notification fails though the transport is otherwise up. That request fails immediately with a service-unavailable signal and never occupies a pending slot.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+#### Approval intake and response
+
+- **FR-001**: The notifier MUST accept approval requests over HTTP at a versioned endpoint and validate them against the published request schema, rejecting malformed requests with a client-error status and no notification.
+- **FR-002**: The notifier MUST hold the caller's request open and return a single response only when a decision exists — a human decision, a timeout, or service shutdown.
+- **FR-003**: For each request, the notifier MUST generate an approval identifier if the caller did not supply one, and echo the approval identifier in the response.
+- **FR-003a**: If a request supplies an approval identifier that matches an approval already pending, the notifier MUST reject the duplicate with a client-error signal and leave the original pending approval running undisturbed (one live approval per identifier).
+- **FR-004**: On a human allow/deny, the notifier MUST return a success status with the decision, the responder's identity, an optional reason, the decision timestamp, and the elapsed latency.
+- **FR-005**: On expiry of the request's timeout with no human response, the notifier MUST return a distinct timeout status carrying a fail-secure "deny" decision marked with a timeout reason.
+- **FR-006**: The notifier MUST clamp any requested timeout to a configured maximum and apply a configured default when the request omits a timeout.
+- **FR-007**: When the transport is unreachable, no human-side configuration is loaded, or the service is shutting down, the notifier MUST refuse new approval requests with a service-unavailable signal rather than hanging or fabricating an allow.
+- **FR-034**: The notifier MUST enforce a configurable maximum number of concurrent pending approvals (default 50). While that limit is reached, the notifier MUST reject further approval requests with a service-unavailable signal — without sending a notification — until a pending approval resolves and frees capacity. This bounds memory use and protects the single human channel from notification flooding by a co-located container.
+
+#### Fail-secure guarantees
+
+- **FR-008**: The notifier MUST NEVER return "allow" except as the direct result of an authorized human explicitly approving. Every other terminal outcome (timeout, error, shutdown, lost connection) MUST resolve to deny or to no decision at all.
+- **FR-009**: The notifier MUST NOT persist approval state; a restart loses all in-flight approvals, and callers whose connection drops MUST be able to treat that as a deny.
+
+#### Telegram delivery
+
+- **FR-010**: For each accepted request, the notifier MUST send a message to the single configured authorized chat describing the project, the operation (kind, command, arguments), the triggering rule, the human-readable policy message, the instance identifier, and the decision deadline, with inline **Approve** and **Deny** controls.
+- **FR-010a**: If delivering the notification for a specific request fails while the transport is otherwise available, the notifier MUST fail that request immediately with a service-unavailable signal and MUST NOT hold a pending slot for it. A request is registered as pending only once its notification has been delivered.
+- **FR-011**: The notifier MUST accept a decision only from the configured authorized chat and MUST ignore responses originating from any other chat.
+- **FR-012**: The notifier MUST correlate each response to its originating approval by identifier and MUST ignore responses for approvals that are no longer pending (already decided, timed out, or unknown).
+- **FR-013**: After an outcome (approved, denied, timed out, or cancelled), the notifier MUST update the original Telegram message to reflect that outcome, including the responder and time for human decisions.
+- **FR-014**: The notifier MUST use a delivery mode that requires no publicly reachable inbound URL for the bot, so the service needs no public endpoint.
+- **FR-015**: The notification channel MUST be pluggable behind a single transport abstraction so additional channels can be added later without changing the intake or state logic. Only the Telegram channel is implemented in v1, and the abstraction MUST also expose a cancellation path for an approval resolved by other means.
+
+#### Health and observability
+
+- **FR-016**: The notifier MUST expose an unauthenticated health endpoint returning status, service version, active transport name, uptime, and the count of currently pending approvals.
+- **FR-017**: The notifier MUST NOT emit secrets or sensitive request content at normal log levels; the bot token, raw request bodies, and workspace paths MUST appear only at debug level, while normal levels carry structural metadata only (such as approval identifier, decision, and latency).
+
+#### Configuration and secrets
+
+- **FR-018**: The notifier MUST read its configuration from a single file, validate it strictly, and reject unknown configuration keys with a clear error.
+- **FR-019**: The notifier MUST read the Telegram bot token from a separate secret file at startup (never from the main configuration file) so the secret can be rotated by editing that file and restarting or signaling the service.
+- **FR-020**: Configuration MUST include the listening parameters, default and maximum approval timeouts, the maximum number of concurrent pending approvals, the selected transport, the transport's authorized chat identifier and secret location, and the instance identifier shown to humans.
+
+#### Network exposure
+
+- **FR-021**: The deployed notifier MUST be reachable by devcontainers co-located on the same host but MUST NOT be reachable from outside the host; it is bound to the host's container-bridge address.
+
+#### Operator deployment and lifecycle
+
+- **FR-022**: The remo CLI MUST provide a command to deploy the notifier to a named known host — including a fresh host that has only the base container runtime — ending with the service running as a managed, auto-restarting background unit.
+- **FR-023**: Deployment MUST fail loudly with a clear message if the required Telegram credentials are not available, and MUST NOT leave a half-configured or broken service running.
+- **FR-024**: Deployment MUST provide an option to force a rebuild of the service image on the host.
+- **FR-025**: Deployment MUST verify the service answers its health endpoint before reporting success, and MUST fail if it does not come up within a reasonable bound.
+- **FR-026**: The deployed service MUST run with hardened, least-privilege container settings (non-root user, dropped capabilities, read-only root filesystem) and MUST restart automatically if it exits.
+
+#### Operator verification and observability commands
+
+- **FR-027**: The remo CLI MUST provide a test command that sends a clearly test-labeled approval through the full path against a named host and reports the returned decision, surfacing an unreachable service rather than hanging.
+- **FR-028**: The remo CLI MUST provide a status command that retrieves and displays the named host's notifier health summary.
+- **FR-029**: The remo CLI MUST provide a logs command for a named host, with options to follow the stream and to limit the number of lines.
+- **FR-030**: The remo CLI MUST provide a restart command that restarts the named host's notifier service.
+- **FR-031**: Every notifier CLI subcommand that takes a host MUST offer an interactive fuzzy host picker when no host is named, consistent with existing remo commands.
+
+#### Non-regression and packaging
+
+- **FR-032**: Adding the notifier MUST NOT change the behavior of any existing remo command, and the laptop-side CLI install MUST NOT be forced to pull in the notifier's runtime dependencies (they live behind an optional install).
+- **FR-033**: Deployment MUST be integrable into the existing per-host configuration flow via a toggle (`configure_remo_notifier`), consistent with how other optional host components are enabled/disabled. The toggle MUST default to **off** — the notifier requires Telegram credentials and its preflight fails loudly without them (FR-023), so a normal provision must not attempt to deploy it; the primary path is the explicit `remo notifier deploy <host>` command. (Corrected from an initial default-on, which broke credential-less provisioning.)
+
+### Key Entities *(include if feature involves data)*
+
+- **Approval Request**: An inbound ask for a human decision. Carries an optional approval identifier, an opaque session identifier, an operation descriptor (kind, command, arguments, optional path/remote host/port, nesting context and depth), the triggering rule name, a human-readable policy message, the workspace path, the instance identifier, the project name, a requested timeout, and a submission timestamp.
+- **Approval Response**: The outbound decision. Carries the approval identifier, the decision (allow or deny), the responder identity, an optional reason, the decision timestamp, and the measured latency.
+- **Pending Approval**: The in-memory record of a request awaiting resolution, keyed by approval identifier, holding the means to deliver the eventual decision back to the waiting caller. Exists only between intake and resolution; never persisted.
+- **Transport**: A notification channel responsible for delivering an approval request to a human, collecting their decision, and reflecting cancellation. Telegram is the only concrete transport in v1.
+- **Notifier Configuration**: The validated settings governing listening parameters, timeout bounds, the selected transport and its parameters (authorized chat, secret location, message formatting), and the instance identity shown to humans.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: After a human taps a decision button, the waiting caller receives the matching decision within 5 seconds.
+- **SC-002**: A request whose timeout elapses with no human response returns a fail-secure deny within roughly its timeout window (within about 1 second of the deadline).
+- **SC-003**: An operator can take a fresh host to a running, health-passing notifier with a single deploy command and no manual post-steps, and the service reports healthy within 5 seconds of starting.
+- **SC-004**: A first-time user can go from zero (no bot) to a confirmed working approval round-trip using only the documented setup steps plus the deploy and test commands.
+- **SC-005**: No terminal outcome other than an explicit authorized human approval ever yields "allow" — verified across timeout, malformed-request, transport-down, and shutdown scenarios.
+- **SC-006**: Secrets and sensitive request content (bot token, raw bodies, workspace paths) never appear in logs at normal verbosity.
+- **SC-007**: Installing and using the notifier introduces no change to any existing remo command's behavior, and a default laptop install does not acquire the notifier's extra runtime dependencies.
+- **SC-008**: The published wire protocol (request schema, response schema, status codes, timeout and cancellation semantics) is documented completely enough that an independent emitter could integrate against it without reading the notifier's code.
+
+## Assumptions
+
+- The target hosts already have a container runtime available (provisioned by the existing remo host configuration), so the notifier role can depend on it rather than installing it.
+- Exactly one human (one Telegram chat) is authorized per instance in v1; multi-recipient routing, first-response-wins, and identity-aware authorization are deferred.
+- Telegram is the only delivery channel in v1; the transport abstraction keeps other channels possible but none are built.
+- The threat model excludes cross-host eavesdropping in v1: the endpoint is bound to the host container bridge and is not encrypted or caller-authenticated. This is revisited only if multi-host networking becomes a feature.
+- The service image is built on the host during deployment in v1; publishing a prebuilt image is deferred until the container surface stabilizes.
+- Callers (agentsh) own their own timeout-action policy; the notifier's responsibility ends at returning a deny on timeout.
+
+## Out of Scope
+
+- Any non-Telegram delivery channel (Slack, Discord, ntfy, email).
+- Multi-user / multi-chat fanout, first-response-wins routing, and identity-aware authorization.
+- Persistent storage of in-flight approvals across restarts.
+- A web UI or dashboard for in-flight or historical approvals.
+- Approval history / audit export beyond what the host's service logs already provide.
+- Integration with downstream consumers (e.g. workflow status announcers or lifecycle-event emitters); this spec ships the foundation and the wire-protocol contract only.
+- Prebuilt published container images.
+- Transport encryption (TLS) for the listener.
+- A dedicated CLI wrapper for bot-token rotation (rotation is supported by editing the secret file and restarting/signaling).

--- a/specs/007-notifier-sidecar/tasks-addendum-001.md
+++ b/specs/007-notifier-sidecar/tasks-addendum-001.md
@@ -1,0 +1,174 @@
+# Tasks — Addendum 001: Standing Grants ("Always")
+
+**Input**: `addendum-001-standing-grants.md`, `plan-addendum-001.md`,
+`research-addendum-001.md`, `data-model-addendum-001.md`,
+`contracts/grant-schema.md`, `contracts/openapi.yaml` (updated), `quickstart.md`.
+
+**Tests**: INCLUDED — the parent spec requests tests (§9) and SC-G1…SC-G5
+require them. Test tasks precede their implementation within each story.
+
+**Scope**: Additive to the shipped v1 notifier. Task IDs are namespaced `TA###`
+to avoid collision with the base `tasks.md` (T001–T046). All paths repo-relative.
+
+**Shared-file note**: `transports/telegram.py` is touched by US-G1, US-G2, and
+US-G3; `server.py` by Foundational + US-G3; `tests/notifier/test_telegram.py` by
+US-G1/US-G2/US-G3. Same-file tasks are sequenced, not parallel — flagged below.
+
+---
+
+## Phase 1: Setup
+
+- [X] TA001 Add the `[grants]` config block to `GrantsConfig` planning surface: extend `src/remo_cli/notifier/config.py` with a `GrantsConfig` Pydantic model (`extra="forbid"`: `enabled` bool=true, `default_ttl_seconds` int≥1=28800, `max_grants` int≥1=100, `allow_global_scope` bool=true, `digest_interval_seconds` int≥0=3600) and add `grants: GrantsConfig = Field(default_factory=GrantsConfig)` to `NotifierConfig`. (data-model-addendum §GrantsConfig; FR-G12)
+- [X] TA002 [P] Add the rendered `[grants]` section to `ansible/roles/remo_notifier/templates/notifier.toml.j2` (enabled/default_ttl_seconds/max_grants/allow_global_scope/digest_interval_seconds from role vars).
+- [X] TA003 [P] Add grant defaults to `ansible/roles/remo_notifier/defaults/main.yml` (`remo_notifier_grants_enabled: true`, `_default_ttl_seconds: 28800`, `_max_grants: 100`, `_allow_global_scope: true`, `_digest_interval_seconds: 3600`).
+- [X] TA003a [P] Add `GrantsConfig` validation cases to `tests/notifier/test_config.py`: a `[grants]` block parses with defaults; an unknown `[grants]` key is rejected (`extra="forbid"`); `default_ttl_seconds < 1` and `max_grants < 1` are rejected; `digest_interval_seconds = 0` is accepted (disables digest). (validates TA001; C1 / Constitution IV parity)
+
+---
+
+## Phase 2: Foundational (Blocking Prerequisites)
+
+**Purpose**: The grant domain model + store + matcher + proposer that every story
+depends on. **No story work begins until this is complete.**
+
+- [X] TA004 Create `src/remo_cli/notifier/grants.py` models: enums (`GrantScopeType`, `ArgMatchType`, `HostMatchType`), `GrantPredicate`, `GrantScope`, `Grant`, `CandidateGrant` (Pydantic v2; reuse `OperationKind` from `models.py`). Include `predicate.matches(operation, policy_rule_name)`, `scope.matches(request)`, `grant.active(now)`, `grant.matches(request, now)` — all deterministic and fail-closed per data-model-addendum + grant-schema. (FR-G4/G5)
+- [X] TA005 Implement `GrantStore` in `src/remo_cli/notifier/grants.py`: in-memory `dict[str,Grant]` + `asyncio.Lock` + `max_grants` + `paused`; methods `match(request, now)`, `create(grant)` (raises `GrantLimitReached` at cap), `list()`, `revoke(id)`, `set_paused()`, `sweep(now)`. (FR-G4/G7/G8/G9/G10; research RG1/RG4/RG5)
+- [X] TA006 Implement `GrantStore.propose(request) -> list[CandidateGrant]` in `src/remo_cli/notifier/grants.py` (pure): deterministic tightest-first templates per kind + `policy_rule_name` broadest rung, each paired with the narrowest covering scope plus one widened rung; **return at most 4 candidates**. (FR-G6; research RG2)
+- [X] TA007 [P] Add optional `grant_id: str | None = None` to `ApprovalResponse` in `src/remo_cli/notifier/models.py`. (data-model-addendum; backward-compatible)
+- [X] TA008 [P] Unit tests `tests/notifier/test_grants.py`: predicate match per kind (command exact/prefix/glob, file path-glob+op, network exact/suffix+port, signal, policy_rule_name rung); scope equality + missing-field fail-closed; `active()`/expiry; `match()` returns None when paused/expired/revoked/mismatch; `create()` cap → `GrantLimitReached`; `revoke()`; `sweep()`; `propose()` ordering tightest-first; concurrent `create()` respects cap via `asyncio.gather`; **a freshly constructed `GrantStore` is empty (SC-G5 restart fail-closed: a new process holds no grants → re-prompts).** (validates TA004–TA006)
+
+**Checkpoint**: grant model, store, matcher, proposer importable and unit-tested.
+
+---
+
+## Phase 3: User Story G1 — Human grants "Always" for a class (Priority: P1) 🎯 MVP
+
+**Goal**: Tapping **Always…** approves this request and creates a standing grant; a subsequent matching request is auto-approved server-side with no Telegram.
+
+**Independent Test**: Tap Always on a request; send a second matching request → `200 allow` in <500 ms, `responder: rule:{id}`, `grant_id` set, no Telegram, audit line logged.
+
+### Tests for US-G1 (write first)
+
+- [X] TA009 [P] [US-G1] Server short-circuit tests in `tests/notifier/test_server.py`: with a grant pre-seeded in `app.state.grant_store`, a matching `POST /v1/approve` returns 200 `allow` with `responder` `rule:{id}` + `grant_id`, **no** transport send and **no** pending slot reserved; a non-matching request falls through to the existing flow; with grants disabled or paused the short-circuit is skipped. (validates TA011; FR-G1/G2/G3, research RG7)
+- [X] TA010 [P] [US-G1] Telegram "Always" flow tests in `tests/notifier/test_telegram.py` (Bot mock): approval keyboard now includes `always:{id}`; tapping it renders a picker with `pick:{id}:{index}` candidates from `propose()`; selecting one calls `grant_store.create(...)` and resolves the approval `allow` (+grant_id); `pick:{id}:cancel` restores Approve/Deny; unauthorized chat / unknown id ignored; at `max_grants` the approval still allows once but reports the limit. (validates TA012/TA013; grant-schema "Telegram surface")
+
+### Implementation for US-G1
+
+- [X] TA011 [US-G1] Wire the intake short-circuit into `src/remo_cli/notifier/server.py`: construct `GrantStore` in `create_app` (expose as `app.state.grant_store`), inject it into the transport; at the top of `POST /v1/approve` (before shutdown/health gate and `reserve`), if grants enabled and not paused, `match()` → on hit return 200 `allow` (+`grant_id`, responder `rule:{id}`), increment `uses_count`, emit the structural audit log; on miss fall through unchanged. Start the TTL `sweep` loop in the lifespan. (FR-G1/G2/G3/G11; research RG4/RG6/RG7)
+- [X] TA012 [US-G1] Add the third button + picker to `src/remo_cli/notifier/transports/telegram.py`: render `[✅ Approve] [⏩ Always…] [❌ Deny]`; on `always:{id}` compute `grant_store.propose(request)`, stash candidates keyed by approval id, render `pick:{id}:{index}` + Cancel buttons (labels include scope); keep `callback_data` ≤64 bytes. (research RG3; grant-schema)
+- [X] TA013 [US-G1] Handle the pick callback in `transports/telegram.py`: on `pick:{id}:{index}` create the grant (TTL applied via config), resolve the approval `allow` with `grant_id`, edit the message to confirm (`⏩ Always: <label> · <ttl> · by @user`); on `pick:{id}:cancel` restore the original keyboard; surface `GrantLimitReached` as a "grant limit reached" notice while still allowing this one. (FR-G6/G7/G8; grant-schema)
+
+**Checkpoint**: full Always → auto-approve loop works end-to-end (local bot).
+
+---
+
+## Phase 4: User Story G2 — Review & revoke standing grants (Priority: P1)
+
+**Goal**: `/rules` lists active grants with revoke buttons; `/revoke <id>`, `/pause`, `/resume` take effect immediately.
+
+**Independent Test**: Create a grant, `/revoke` it (or tap Revoke), send a matching request → prompted again. `/pause` → all matches prompt; `/resume` → restored.
+
+### Tests for US-G2 (write first)
+
+- [X] TA014 [US-G2] Command tests in `tests/notifier/test_telegram.py` (sequential — shared file, after TA010): `/rules` lists active grants with inline `[Revoke]` buttons and a not-empty/empty rendering; `/revoke <id>` and a Revoke-button callback remove the grant (`grant_store.revoke` called); `/pause` sets paused, `/resume` clears it; all reject a non-authorized chat. (validates TA015; FR-G10)
+
+### Implementation for US-G2
+
+- [X] TA015 [US-G2] Add slash/command + revoke-callback handlers to `transports/telegram.py` (sequential — shared file, after TA013): register `CommandHandler`s for `/rules`, `/revoke`, `/pause`, `/resume` and a `CallbackQueryHandler` for `revoke:{id}`, all gated to the authorized chat; render grant summaries (id, class label, scope, age, TTL, uses) and call into the injected `GrantStore`. (FR-G10; grant-schema "Slash commands")
+
+**Checkpoint**: grants are listable, revocable, and globally pausable from Telegram.
+
+---
+
+## Phase 5: User Story G3 — Auto-approvals stay visible (Priority: P2)
+
+**Goal**: Auto-approvals are individually logged by `grant_id` and a periodic digest summarizes activity so standing grants are never silent.
+
+**Independent Test**: Trigger several auto-approvals → each emits a structural INFO log with `grant_id` and no secrets; after the digest interval the chat receives a count summary.
+
+### Tests for US-G3 (write first)
+
+- [X] TA016 [P] [US-G3] Audit/digest tests: in `tests/notifier/test_server.py` assert each auto-approval logs `auto_approved` with `grant_id` and **no** token/body/workspace (capture structlog output); in `tests/notifier/test_telegram.py` assert the digest sender messages the chat a count summary when activity > 0 and stays silent at 0. (validates TA017/TA018; FR-G11/FR-017, SC-G4)
+
+### Implementation for US-G3
+
+- [X] TA017 [US-G3] Emit the structural auto-approval audit log in `server.py` (extend TA011's hit path): `auto_approved {approval_id, grant_id, kind, summary, latency_ms}` at INFO via the redaction-safe logger, where `summary` is a redacted one-line op descriptor (kind + command **name** / host / directory only — never args, bodies, secrets, or full workspace paths). (FR-G11/FR-017; research RG6)
+- [X] TA018 [US-G3] Add the periodic digest sender. **The server owns the activity counter** (incremented on each short-circuit hit in `src/remo_cli/notifier/server.py`) and runs a lifespan task at interval `digest_interval_seconds` (0 disables); the Telegram transport exposes `async def send_digest(summary: str)` in `src/remo_cli/notifier/transports/telegram.py` that messages the authorized chat. When the counter > 0 since the last digest, the server calls `send_digest` and resets the counter. (FR-G11; research RG6)
+
+**Checkpoint**: every auto-approval is auditable and a digest lands; all stories functional.
+
+---
+
+## Phase 6: Polish & Cross-Cutting
+
+- [X] TA019 [P] Update `src/remo_cli/notifier/docs/wire-protocol.md`: document the `/v1/approve` short-circuit, `responder: rule:{id}`, the `grant_id` field, and the fail-closed rule. (FR-G1/G2; spec §10)
+- [X] TA020 [P] Update `src/remo_cli/notifier/docs/config-schema.md` with the `[grants]` block and grant lifetime/scope semantics.
+- [X] TA021 [P] Update top-level `README.md` notifier section: brief "Always / standing grants" note (`/rules`, `/revoke`, `/pause`, 8h default TTL, fail-closed on restart).
+- [X] TA022 Constitution pre-commit check on the touched role files: `grep -rn '\.rc ==' ansible/roles/remo_notifier/` and `grep -rn '\.stdout' ansible/roles/remo_notifier/`; ensure `| default()` on any match. (Constitution I)
+- [X] TA023 [P] Run `ruff check` and `mypy` on `src/remo_cli/notifier/`; resolve all findings. (AC-9 parity)
+- [X] TA024 [P] Run `pytest tests/notifier/ --cov=remo_cli.notifier`; keep >85% coverage including `grants.py`; add tests for any gap. (AC-8 parity)
+- [X] TA025 Build the image (`docker build -f notifier/Dockerfile .`) and smoke `GET /v1/health` with a config that includes `[grants]`; confirm it still starts and serves. (regression on AC-2)
+- [X] TA026 Mark the addendum success criteria (SC-G1…SC-G5) checked in `specs/007-notifier-sidecar/addendum-001-standing-grants.md` once verified locally, noting any deferred to a live host/bot.
+
+---
+
+## Dependencies & Execution Order
+
+- **Setup (TA001–TA003a)** → no deps; TA002/TA003/TA003a parallel after TA001.
+- **Foundational (TA004–TA008)** → after Setup. TA004 → TA005 → TA006 (same file `grants.py`, sequential); TA007 [P] independent; TA008 after TA004–TA006. **Blocks all stories.**
+- **US-G1 (P1, MVP)** → after Foundational. TA011 (server) and TA012/TA013 (telegram) can proceed in parallel across the two files; TA012 → TA013 sequential (same file). Tests TA009/TA010 written first.
+- **US-G2 (P1)** → after US-G1 (shares `telegram.py`: TA015 after TA013; TA014 after TA010 in the shared test file).
+- **US-G3 (P2)** → after US-G1 (extends TA011's hit path + adds a digest task); independent of US-G2.
+- **Polish (TA019–TA026)** → after the stories they document/verify.
+
+### Shared-file serialization
+- `transports/telegram.py`: TA012 → TA013 → TA015.
+- `tests/notifier/test_telegram.py`: TA010 → TA014.
+- `server.py`: TA011 → TA017 (→ TA018 if server-owned counter).
+
+---
+
+## Parallel Opportunities
+
+- Setup: TA002 ‖ TA003.
+- Foundational: TA007 ‖ the TA004→TA005→TA006 chain; TA008 after.
+- US-G1: TA009 ‖ TA010 (distinct files); then TA011 ‖ TA012 (server vs telegram).
+- Polish: TA019 ‖ TA020 ‖ TA021 ‖ TA023 ‖ TA024.
+
+### Parallel example — US-G1 tests
+```bash
+Task: "Server short-circuit tests in tests/notifier/test_server.py"   # TA009
+Task: "Telegram Always-flow tests in tests/notifier/test_telegram.py" # TA010
+```
+
+---
+
+## Implementation Strategy
+
+### MVP (US-G1 only)
+1. Setup (TA001–TA003) → Foundational (TA004–TA008) → US-G1 (TA009–TA013).
+2. **STOP & VALIDATE**: tap Always locally, confirm a repeat request auto-approves
+   < 500 ms with no Telegram and a `grant_id` (SC-G1, SC-G2). Demonstrable MVP.
+
+### Incremental delivery
+1. MVP (US-G1) → auto-approve works.
+2. US-G2 → list/revoke/pause (operational safety: the backstop for grants
+   outside agentsh policy).
+3. US-G3 → audit + digest (never-silent).
+4. Polish → docs + quality gates + image regression.
+
+### Notes
+- The matcher (TA004/TA005) is the **allow-capable** crown jewel — test it as
+  adversarially as the fail-secure paths (TA008). Any ambiguity ⇒ no-match.
+- No new runtime deps; no CLI changes (OQ4); no bridge read endpoint.
+- External **OQ1** (agentsh signed-policy promotion) is out of scope here.
+
+## Task count
+
+- Setup: 4 (TA001–TA003, TA003a)
+- Foundational: 5 (TA004–TA008)
+- US-G1 (P1, MVP): 5 (TA009–TA013)
+- US-G2 (P1): 2 (TA014–TA015)
+- US-G3 (P2): 3 (TA016–TA018)
+- Polish: 8 (TA019–TA026)
+
+**Total: 27 tasks** (26 + TA003a from analysis remediation C1).

--- a/specs/007-notifier-sidecar/tasks.md
+++ b/specs/007-notifier-sidecar/tasks.md
@@ -1,0 +1,245 @@
+# Tasks: Notifier Sidecar — Telegram approval bridge for agentsh
+
+**Input**: Design documents from `/specs/007-notifier-sidecar/`
+**Prerequisites**: plan.md, spec.md, research.md, data-model.md, contracts/
+
+**Tests**: INCLUDED — the spec explicitly requests them (§9 Tests; Acceptance Criteria 8 requires >85% coverage on `src/remo_cli/notifier/`). Test tasks are written before their implementation within each story.
+
+**Organization**: Tasks are grouped by user story so each can be implemented and tested independently.
+
+## Path Conventions
+
+Single project. Python package at `src/remo_cli/`; Ansible at `ansible/`; tests at `tests/`; Dockerfile at repo-root `notifier/`. All paths below are repo-relative.
+
+**Shared-file note**: `src/remo_cli/cli/notifier.py` and `tests/notifier/test_cli_notifier.py` are each touched by multiple stories (US2/US3/US4). Tasks editing the same file are **not** parallel with one another and are sequenced by phase; this is called out where relevant.
+
+---
+
+## Phase 1: Setup (Shared Infrastructure)
+
+**Purpose**: Package scaffolding and packaging so any later phase can build/import.
+
+- [X] T001 Create the notifier package skeleton: `src/remo_cli/notifier/__init__.py`, `src/remo_cli/notifier/transports/__init__.py`, `src/remo_cli/notifier/docs/` (empty), and the test package `tests/notifier/__init__.py`. Every new module starts with `from __future__ import annotations`.
+- [X] T002 Update `pyproject.toml`: add the `[notifier]` optional extra (fastapi>=0.115, uvicorn[standard]>=0.32, pydantic>=2.9, python-telegram-bot>=21.6, structlog>=24.4, `tomli>=2.0; python_version<'3.11'`); add `remo-notifier = "remo_cli.notifier.cli:main"` to `[project.scripts]`; add `pytest-asyncio` and `httpx` to the `dev` extra; add `[tool.pytest.ini_options] asyncio_mode = "auto"`; add a `[tool.hatch.build.targets.wheel.force-include]` mapping that ships the host build context to `remo_cli/notifier_build/`. **Layout contract (U1):** the bundled context MUST reproduce a repo-root-relative tree so the Dockerfile's relative `COPY` paths resolve unchanged — i.e. `notifier_build/Dockerfile`, `notifier_build/pyproject.toml`, `notifier_build/README.md`, `notifier_build/uv.lock`, and `notifier_build/src/remo_cli/…`. The same `notifier/Dockerfile` (T003) is the single source of truth; the force-include maps it (and the other context files) into `notifier_build/`. `uv.lock` is included only for an optional locked build (see T003); it is not consumed by a plain `uv pip install`. (per research R5)
+- [X] T003 [P] Create `notifier/Dockerfile` (multi-stage: python:3.13-slim builder using `uv pip install ".[notifier]"` into `/opt/venv`; slim runtime, system user 65532, `EXPOSE 18181`, HEALTHCHECK on `/v1/health`, `ENTRYPOINT ["remo-notifier"]`, `CMD ["serve","--config","/etc/notifier/notifier.toml"]`). All `COPY` paths are relative to the build-context root (`Dockerfile`, `pyproject.toml`, `README.md`, `src/`) and MUST match the bundled layout from T002 so the same Dockerfile builds identically from the repo root and from the on-host context (U1). If reproducible/locked builds are wanted later, switch the builder to `uv sync --frozen` to consume `uv.lock`; otherwise `uv.lock` is unused (I1). (spec §5, AC-2)
+- [X] T004 [P] Add `community.docker (>=4.0.0)` to `ansible/requirements.yml`. (research R10)
+
+---
+
+## Phase 2: Foundational (Blocking Prerequisites)
+
+**Purpose**: The durable wire-protocol models and logging that every story depends on.
+
+**⚠️ CRITICAL**: No user-story work begins until this phase is complete.
+
+- [X] T005 [P] Implement `src/remo_cli/notifier/logging_setup.py`: structlog config (ISO ts, level, logger name; JSON renderer for non-TTY, key-value for TTY) plus a redaction processor that drops `bot_token`/`authorization`/raw request bodies and keeps only structural fields at INFO+. (FR-017, research R7)
+- [X] T006 [P] Implement `src/remo_cli/notifier/models.py`: Pydantic v2 models `Operation`, `ApprovalRequest`, `ApprovalDecision`, `ApprovalResponse`, `HealthResponse`, `ErrorResponse` with `extra="forbid"` where specified, UUID/enum/port validation, and RFC3339 serialization. (data-model.md; FR-001/003/004/005)
+- [X] T007 [P] Unit tests `tests/notifier/test_models.py`: valid request round-trips, unknown-field rejection, bad UUID rejection, enum/port bounds, timeout-field presence. (validates T006)
+- [X] T007a [P] Unit tests `tests/notifier/test_logging_setup.py`: emit log events carrying a bot token, a raw request body, and a workspace path; assert that at INFO+ none of those values appear and only structural fields (`approval_id`, `decision`, `latency_ms`, `transport`, `pending_count`) survive; assert the sensitive values are present only when the level is DEBUG. (validates T005; G1/SC-006/FR-017)
+
+**Checkpoint**: Wire models + logging importable; stories can begin.
+
+---
+
+## Phase 3: User Story 1 — Human approves/denies from their phone (Priority: P1) 🎯 MVP
+
+**Goal**: A running `remo-notifier` service that accepts an approval over HTTP, delivers it to the authorized Telegram chat with Approve/Deny buttons, and returns the human's decision (or a fail-secure deny on timeout/shutdown/send-failure/capacity).
+
+**Independent Test**: Run `remo-notifier serve --config <toml>` locally against a real bot; POST an `ApprovalRequest`; tapping Approve returns `allow`, Deny returns `deny`, and a 5 s-timeout request returns 408 `{decision: deny, reason: timeout}`.
+
+### Tests for User Story 1 (write first; must fail before implementation)
+
+- [X] T008 [P] [US1] Create `tests/notifier/conftest.py`: a `FakeTransport(NotificationTransport)` (records sends, lets tests resolve/raise on demand), a config-builder fixture, a temp token-file fixture, and an ASGI client fixture. (shared by US1/US3/US4 tests)
+- [X] T009 [P] [US1] `tests/notifier/test_config.py`: strict TOML load, unknown-key error, `max_timeout_seconds >= default_timeout_seconds` validator, `max_pending_approvals` default, token read from file (not config), missing/empty token fails fast. (validates T013)
+- [X] T010 [P] [US1] `tests/notifier/test_state.py`: register→resolve, timeout→deny, cancel, duplicate-id reservation rejected, at-capacity rejected, send-failure rollback frees the slot, concurrent registration via `asyncio.gather`, `drain()` on shutdown, Future resolved exactly once. (validates T015; FR-003a/008/009/034, FR-010a)
+- [X] T011 [P] [US1] `tests/notifier/test_server.py`: cover 200 (allow & deny via FakeTransport), 400 (bad body), 408 (timeout deny shape + within ~timeout), 409 (duplicate id), 503 (transport unhealthy / at capacity / send failure / shutting down), and `GET /v1/health` shape. Include a **timeout-clamp** case: an over-`max_timeout_seconds` request and an omitted-timeout request both resolve at the configured effective bounds (G2/FR-006). Use FastAPI `TestClient` for sync paths and `httpx.AsyncClient` for await-until-decision/timeout. (validates T017; FR-001–010a, FR-006, FR-016)
+- [X] T012 [P] [US1] `tests/notifier/test_telegram.py`: inject a mocked `Bot` into the PTB `Application`; assert message text/`MarkdownV2` escaping, inline keyboard `callback_data` (`approve:{id}`/`deny:{id}`), authorized-chat enforcement (foreign chat ignored), callback→`on_response`, non-pending callback is a no-op, message edits per outcome, `cancel` edit, token read from file. (validates T016; contracts/telegram-message.md; FR-010–014)
+
+### Implementation for User Story 1
+
+- [X] T013 [P] [US1] Implement `src/remo_cli/notifier/config.py`: Pydantic config models (`NotifierConfig` + `server`/`approval`/`transport`/`telegram`/`instance`) with `extra="forbid"`, the strict TOML loader (`--config`), cross-field validators, and startup token-file read kept in memory. (FR-018/019/020; data-model.md)
+- [X] T014 [P] [US1] Implement `src/remo_cli/notifier/transports/base.py`: the `NotificationTransport` ABC (`start`/`stop`/`send_approval_request`/`cancel`/`healthy`) exactly per `contracts/transport.md`. (FR-015)
+- [X] T015 [US1] Implement `src/remo_cli/notifier/state.py`: `PendingApproval` + `PendingApprovals` registry — Future-based, `asyncio.Lock`-guarded atomic capacity+id reservation with rollback on send failure, `resolve`/`cancel`/`count`/`drain`, exactly-once resolution. (depends on T006; FR-002/003a/008/009/034, FR-010a; research R2)
+- [X] T016 [US1] Implement `src/remo_cli/notifier/transports/telegram.py`: PTB `Application` with long-polling started via `initialize`/`start`/`updater.start_polling` (never `run_polling`/webhook); send message + inline keyboard; `CallbackQueryHandler` with authorized-chat check and pending-guarded `on_response`; message edits per outcome; `cancel`; token from file. (depends on T006, T014; FR-010–014, research R1/R6; contracts/telegram-message.md)
+- [X] T017 [US1] Implement `src/remo_cli/notifier/server.py`: FastAPI app + lifespan (start transport on startup, `drain()`+stop on shutdown); `POST /v1/approve` (validate→clamp timeout→reserve [dup→409, capacity→503]→send [failure→release+503]→register→`await wait_for`→resolve→200, timeout→408 fail-secure deny; transport unhealthy/shutting down→503); `GET /v1/health`. Map outcomes through one fail-secure resolver. (depends on T006/T013/T014/T015/T016; FR-001–010a, FR-016; research R2/R3/R4/R9)
+- [X] T018 [US1] Implement `src/remo_cli/notifier/cli.py`: `remo-notifier` entry (`main`) with a `serve --config` command that loads config, configures logging, builds the selected transport, and runs `uvicorn.Server` on the configured host/port. (AC-1)
+- [X] T019 [US1] Add a `SIGHUP` handler in `server.py`/`cli.py` that re-reads the token file and re-initializes the bot, for secret rotation without redeploy. (research R6; spec out-of-scope rotation note)
+
+**Checkpoint**: `remo-notifier serve` runs the full approve/deny/timeout loop locally. MVP demonstrable.
+
+---
+
+## Phase 4: User Story 2 — Operator deploys the notifier to an instance (Priority: P1)
+
+**Goal**: `remo notifier deploy <host>` applies the `remo_notifier` Ansible role end-to-end: preflight creds, render config + secret, build the image on the host, install/start the systemd unit, and confirm health — failing loudly on missing creds.
+
+**Independent Test**: Against a fresh Ubuntu 24.04 host with only docker + base packages, run `remo notifier deploy <host>`; `remo-notifier.service` ends `active (running)` and `/v1/health` returns 200, with no manual steps. Missing creds abort cleanly.
+
+### Tests for User Story 2 (write first)
+
+- [X] T020 [P] [US2] `tests/notifier/test_cli_notifier.py` (deploy cases): patch `core.ansible_runner.run_playbook`, `core.known_hosts`, and `core.picker`; assert deploy resolves the host (and fuzzy-picks when omitted), aborts with a clear error when `REMO_NOTIFIER_TELEGRAM_*` are unset, invokes `notifier_deploy.yml` with `-i "{host},"` + `ansible_user`, and passes a rebuild extra-var when `--rebuild`. (validates T028; FR-022/023/024/031)
+
+### Implementation for User Story 2
+
+- [X] T021 [P] [US2] Create `ansible/roles/remo_notifier/defaults/main.yml` (image/version, listen port, bind address `172.17.0.1`, config/secrets dirs, instance id, timeouts, env-backed telegram token+chat id, `remo_notifier_build_from_source: true`, source dir). (spec §6)
+- [X] T022 [P] [US2] Create `ansible/roles/remo_notifier/meta/main.yml` with `dependencies: [{role: docker}]`. (spec §6)
+- [X] T023 [P] [US2] Create `ansible/roles/remo_notifier/templates/notifier.toml.j2` rendering all runtime config from role vars. (FR-020)
+- [X] T024 [P] [US2] Create `ansible/roles/remo_notifier/templates/remo-notifier.service.j2`: `docker run --rm` with `--name`, `--network bridge`, `-p {{bind}}:{{port}}:18181`, config + secret read-only mounts, `--read-only`, `--tmpfs /tmp`, `--cap-drop ALL`, `--user 65532:65532`, `Restart=always`, `RestartSec=5`. (FR-021/026)
+- [X] T025 [US2] Create `ansible/roles/remo_notifier/tasks/main.yml`: preflight `assert` non-empty token+chat id (FR-023); create `/etc/notifier`+`secrets` (0700); render config; write token (0400); copy the bundled build context to `remo_notifier_source_dir` **preserving its root-relative layout** so the Dockerfile's `COPY` paths resolve (U1); then `community.docker.docker_image` with `source: build` when `remo_notifier_build_from_source | default(true) | bool`, else `source: pull`; install unit; `daemon-reload`+enable+start; `ansible.builtin.uri` health-wait pinned to `retries: 10, delay: 2` (~20 s ceiling; healthy expected <5 s per SC-003) (FR-025). **All registered-var access uses `| default()`** (Constitution I); idempotent (`changed_when`/handlers). (depends on T021–T024)
+- [X] T026 [P] [US2] Create `ansible/roles/remo_notifier/handlers/main.yml` with a `Restart remo-notifier` handler triggered by config/unit changes. (spec §6, Constitution III)
+- [X] T027 [P] [US2] Create `ansible/notifier_deploy.yml` (`hosts: all`, `become: true`, applies role `remo_notifier`). (research R10)
+- [X] T028 [US2] Implement the `notifier` Click group + `deploy` command in `src/remo_cli/cli/notifier.py`: resolve host via `core/known_hosts` + `core/picker` (fuzzy when omitted), preflight `REMO_NOTIFIER_TELEGRAM_*` env, resolve the bundled build-context path (the installed `remo_cli/notifier_build/` dir, à la `core/config.get_ansible_dir`) and pass it as an extra-var so the role copies it verbatim (U1), and call `run_playbook("notifier_deploy.yml", …)` with inventory/user/rebuild extra-vars. (FR-022/023/024/031; research R5/R8)
+- [X] T029 [US2] Register the `notifier` group in `src/remo_cli/cli/main.py` (lazy import + `cli.add_command(notifier)`), matching the existing provider-registration pattern. (FR-032 — additive only)
+- [X] T030 [P] [US2] Append the notifier secrets block (`remo_notifier_telegram_bot_token`/`_chat_id` via `lookup('env', …)`) to `ansible/group_vars/all.yml`. (spec §8)
+- [X] T031 [P] [US2] Add a guarded `include_role: remo_notifier` to `ansible/tasks/configure_dev_tools.yml` under `when: configure_remo_notifier | default(false) | bool` (opt-in; default-off so a credential-less provision doesn't fail the notifier preflight — corrected after CI). (FR-033)
+- [X] T031a [US2] Conditional-path coverage (Constitution II): verify the `configure_remo_notifier: false` path **skips** the role (no notifier dirs/unit created), and that the `remo_notifier_build_from_source: false` branch selects `source: pull` (assert via `--check`/`--list-tasks` or a molecule-style assertion that the build task is skipped and the pull task selected). If the pull path cannot be exercised without a published image, record it as explicitly deferred here rather than leaving the plan's "tested both ways" claim unbacked. (C1; depends on T025, T031)
+
+**Checkpoint**: A fresh host goes to a running, health-passing notifier via one command.
+
+---
+
+## Phase 5: User Story 3 — Operator verifies wiring end-to-end (Priority: P2)
+
+**Goal**: `remo notifier test <host>` pushes a clearly test-labeled approval through the full path and reports the returned decision.
+
+**Independent Test**: Against a deployed host, `remo notifier test <host>` produces a test-labeled Telegram message; tapping a button prints the decision; an unreachable service is reported rather than hanging.
+
+### Tests for User Story 3 (write first)
+
+- [X] T032 [US3] Add `test` cases to `tests/notifier/test_cli_notifier.py`: patch the SSH/subprocess seam; assert the posted body carries `policy_rule_name="test"` and the canonical test `policy_message`, that the decision is rendered, and that an unreachable host yields a clear error (not a hang). (validates T033; FR-027)
+
+### Implementation for User Story 3
+
+- [X] T033 [US3] Add the `test` command to `src/remo_cli/cli/notifier.py`: resolve/fuzzy-pick the host, SSH to it and `curl` a POST of the canonical test `ApprovalRequest` (contracts/telegram-message.md test surface) to `http://{bind}:{port}/v1/approve`, render the decision, surface unreachable cleanly. (sequential after T028 — same file; FR-027/031; research R8)
+
+**Checkpoint**: First-time wiring verifiable in one command.
+
+---
+
+## Phase 6: User Story 4 — Operator observes and controls a running notifier (Priority: P3)
+
+**Goal**: `remo notifier status|logs|restart <host>` for health, logs, and restart, with fuzzy host picking.
+
+**Independent Test**: Against a deployed host, `status` prints the health summary, `logs --follow` streams journald, `restart` returns the service to active; each offers a picker when no host is named.
+
+### Tests for User Story 4 (write first)
+
+- [X] T034 [US4] Add `status`/`logs`/`restart` cases to `tests/notifier/test_cli_notifier.py`: assert `status` SSH-curls `/v1/health` and renders JSON, `logs` runs `journalctl -u remo-notifier.service` with `-f`/`-n` flags, `restart` runs `systemctl restart`, and each fuzzy-picks when the host is omitted. (validates T035–T037; FR-028/029/030/031)
+
+### Implementation for User Story 4
+
+- [X] T035 [US4] Add the `status` command to `src/remo_cli/cli/notifier.py` (SSH `curl -sf …/v1/health`, render JSON). (sequential — shared file; FR-028/031)
+- [X] T036 [US4] Add the `logs` command to `src/remo_cli/cli/notifier.py` (SSH `journalctl -u remo-notifier.service`, `--follow`→`-f`, `--lines N`→`-n N`, default `--lines 100` (A2)). (sequential — shared file; FR-029/031)
+- [X] T037 [US4] Add the `restart` command to `src/remo_cli/cli/notifier.py` (SSH `sudo systemctl restart remo-notifier.service`). (sequential — shared file; FR-030/031)
+
+**Checkpoint**: Full day-2 operability; all four user stories independently functional.
+
+---
+
+## Phase 7: Polish & Cross-Cutting Concerns
+
+**Purpose**: Documentation, quality gates, and acceptance validation spanning all stories.
+
+- [X] T038 [P] Write `src/remo_cli/notifier/docs/wire-protocol.md` from `contracts/openapi.yaml`: request/response schema, all status codes (200/400/408/409/503), timeout contract, cancellation semantics. (spec §10, SC-008)
+- [X] T039 [P] Write `src/remo_cli/notifier/docs/config-schema.md` documenting the TOML schema and secret-file handling. (spec §10)
+- [X] T040 [P] Write `src/remo_cli/notifier/README.md` (distribution note + future-consumers paragraph pointing at `docs/wire-protocol.md`). (spec §10)
+- [X] T041 Update top-level `README.md`: add "Notifier" and "Notifier setup" sections (bot/chat-id steps, env vars, deploy, test) and a wire-protocol pointer. (spec §10, Constitution V)
+- [X] T042 Constitution pre-commit check: run `grep -rn '\.rc ==' ansible/roles/remo_notifier/` and `grep -rn '\.stdout' ansible/roles/remo_notifier/`; ensure every match uses `| default()`; fix any found. (Constitution I)
+- [X] T043 [P] Run `ruff check src/remo_cli/notifier/` and `mypy src/remo_cli/notifier/`; resolve all findings. (AC-9)
+- [X] T044 [P] Run `pytest tests/notifier/ --cov=remo_cli.notifier`; ensure >85% line coverage; add tests for any gap. (AC-8)
+- [X] T044a [P] Packaging assertion (SC-007/G3): confirm a base `pip install remo-cli` (without the `[notifier]` extra) does **not** pull fastapi/uvicorn/python-telegram-bot/structlog — e.g. a test that imports the laptop CLI path with those modules absent, or inspects resolved base dependencies.
+- [X] T045 Build and check the image: `docker build -t remo-notifier:0.1.0 -f notifier/Dockerfile .`; verify `<250 MB` and that a container answers `/v1/health` 200 within 5 s. (AC-2)
+- [ ] T045a Idempotency rerun (Constitution III): run `remo notifier deploy <host>` (or the role) twice against the same host; assert the second run reports no changed config/secret/unit tasks and the service stays `active (running)`. (C2) — **DEFERRED: requires a live remote host; cannot run in this dev environment. The role uses `changed_when`/handlers + `force_source: false`, so re-runs are designed to be no-ops.**
+- [ ] T046 Run the `quickstart.md` operator + developer validations end-to-end against a real host and bot, confirming SC-001..SC-007 and AC-3..AC-7. — **DEFERRED: requires a live remote host + a real Telegram bot. Local equivalents are covered: image build + container `/v1/health` (AC-2 ✓), full approve/deny/timeout loop in tests (SC-001/002/005 ✓), packaging isolation (SC-007 ✓).**
+
+---
+
+## Dependencies & Execution Order
+
+### Phase dependencies
+
+- **Setup (P1: T001–T004)** → no deps; T003/T004 parallel after T001.
+- **Foundational (P2: T005–T007)** → after Setup. **Blocks all stories.**
+- **US1 (P3)** → after Foundational. The MVP.
+- **US2 (P4)** → after Foundational; needs T002 force-include and T003 Dockerfile from Setup. The deploy *builds* the image that packages US1, so a real end-to-end deploy (T046) needs US1 merged, but US2's role/CLI/tests can be built in parallel with US1.
+- **US3 (P5)** → after US2 (uses `notifier` group + a deployed host; `test` command shares `cli/notifier.py` with `deploy`).
+- **US4 (P6)** → after US2 (shares `cli/notifier.py`); independent of US3.
+- **Polish (P7)** → after the stories it documents/validates.
+
+### Within US1
+
+T006/T005 (foundational) → T013/T014 [P] → T015 (needs models) → T016 (needs models+ABC) → T017 (needs config/state/transport) → T018 → T019. Tests T008–T012 written first and fail until their targets land.
+
+### Shared-file serialization
+
+- `src/remo_cli/cli/notifier.py`: T028 → T033 → T035 → T036 → T037 (one file; sequential).
+- `tests/notifier/test_cli_notifier.py`: T020 → T032 → T034 (one file; sequential).
+
+---
+
+## Parallel Opportunities
+
+- **Setup**: T003, T004 in parallel (after T001).
+- **Foundational**: T005, T006 in parallel; T007 after T006.
+- **US1 tests**: T008–T012 all [P] (distinct files).
+- **US1 impl**: T013, T014 in parallel; then the T015→T017 chain.
+- **US2**: role files T021, T022, T023, T024, T026, T027 and ansible edits T030, T031 all [P] (distinct files); T025 after the templates; T028 after T020; T029 after T028.
+- **Polish**: T038, T039, T040 in parallel; T043, T044 in parallel.
+
+### Parallel example — US1 tests
+
+```bash
+Task: "conftest fixtures in tests/notifier/conftest.py"          # T008
+Task: "test_config.py"                                            # T009
+Task: "test_state.py"                                             # T010
+Task: "test_server.py"                                            # T011
+Task: "test_telegram.py"                                          # T012
+```
+
+### Parallel example — US2 role scaffolding
+
+```bash
+Task: "defaults/main.yml"            # T021
+Task: "meta/main.yml"                # T022
+Task: "templates/notifier.toml.j2"   # T023
+Task: "templates/remo-notifier.service.j2"  # T024
+Task: "handlers/main.yml"            # T026
+Task: "notifier_deploy.yml"          # T027
+```
+
+---
+
+## Implementation Strategy
+
+### MVP first (US1 only)
+
+1. Setup (T001–T004) → Foundational (T005–T007) → US1 (T008–T019).
+2. **STOP & VALIDATE**: run `remo-notifier serve` locally against a real bot; confirm allow/deny/timeout (SC-001, SC-002, SC-005). This is a demonstrable MVP without any host deployment.
+
+### Incremental delivery
+
+1. MVP (US1) → demo the approval loop locally.
+2. US2 → `remo notifier deploy` stands it up on a host (AC-3, SC-003).
+3. US3 → `remo notifier test` one-command wiring check (SC-004).
+4. US4 → day-2 status/logs/restart.
+5. Polish → docs + quality gates + acceptance run.
+
+### Suggested parallel team split (after Foundational)
+
+- **Dev A**: US1 (service core) — the critical path.
+- **Dev B**: US2 (Ansible role + Dockerfile + deploy CLI) — can scaffold immediately; integrates with US1's image at deploy time.
+- **Dev C**: US3 + US4 CLI commands — start once the `notifier` group (T028/T029) exists.
+
+---
+
+## Task count
+
+- Setup: 4 (T001–T004)
+- Foundational: 4 (T005–T007, T007a)
+- US1 (P1, MVP): 12 (T008–T019)
+- US2 (P1): 13 (T020–T031, T031a)
+- US3 (P2): 2 (T032–T033)
+- US4 (P3): 4 (T034–T037)
+- Polish: 11 (T038–T046, T044a, T045a)
+
+**Total: 50 tasks.** (46 original + 4 remediation: T007a, T031a, T044a, T045a)

--- a/src/remo_cli/cli/main.py
+++ b/src/remo_cli/cli/main.py
@@ -83,6 +83,7 @@ def _register_commands() -> None:
     from remo_cli.cli.providers.proxmox import proxmox  # noqa: F811
     from remo_cli.cli.providers.hetzner import hetzner  # noqa: F811
     from remo_cli.cli.providers.aws import aws  # noqa: F811
+    from remo_cli.cli.notifier import notifier  # noqa: F811
 
     cli.add_command(shell)
     cli.add_command(cp)
@@ -90,6 +91,7 @@ def _register_commands() -> None:
     cli.add_command(proxmox)
     cli.add_command(hetzner)
     cli.add_command(aws)
+    cli.add_command(notifier)
 
 
 _register_commands()

--- a/src/remo_cli/cli/notifier.py
+++ b/src/remo_cli/cli/notifier.py
@@ -1,0 +1,183 @@
+"""remo notifier commands — deploy and operate the notifier sidecar.
+
+This module is the laptop-side integration point. It must NOT import the
+notifier service package's heavy deps (FastAPI / python-telegram-bot); it only
+drives Ansible (deploy) and SSH (status/logs/test/restart).
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import shlex
+import shutil
+import subprocess
+import sys
+
+import click
+
+from remo_cli.core.ansible_runner import run_playbook
+from remo_cli.core.config import get_remo_home
+from remo_cli.core.output import print_error, print_info
+from remo_cli.core.ssh import build_ssh_opts, resolve_remo_host
+from remo_cli.models.host import KnownHost
+
+# Files that make up the on-host image build context (finding U1 / research R5).
+_CONTEXT_FILES = ["pyproject.toml", "README.md", "uv.lock"]
+
+
+def _resolve(host: str) -> KnownHost:
+    """Resolve a host by name, or fuzzy-pick when none is given (FR-031)."""
+    return resolve_remo_host(host or None)
+
+
+def _bind_url(host: KnownHost, path: str, *, bind: str, port: int) -> str:
+    return f"http://{bind}:{port}{path}"
+
+
+def _ssh_run(host: KnownHost, remote_cmd: str, *, capture: bool = False) -> subprocess.CompletedProcess:
+    """Run a command on *host* over SSH, reusing remo's SSH options."""
+    ssh_opts, target = build_ssh_opts(host)
+    cmd = ["ssh", *ssh_opts, target, remote_cmd]
+    return subprocess.run(cmd, text=True, capture_output=capture)
+
+
+def _ensure_build_context() -> str:
+    """Assemble and return a clean image build context directory.
+
+    The context mirrors the repo layout the Dockerfile expects: ``notifier/``
+    (Dockerfile), ``ansible/`` and ``src/remo_cli`` (both force-included by the
+    wheel build), plus ``pyproject.toml`` / ``README.md`` / ``uv.lock``. v1
+    requires a source checkout (``get_project_root``); published images are the
+    future path (spec Out-of-Scope). See research R5 / finding U1.
+    """
+    from remo_cli.core.config import get_project_root
+
+    root = get_project_root()
+    ctx = get_remo_home() / "notifier_build"
+    if ctx.exists():
+        shutil.rmtree(ctx)
+    (ctx / "notifier").mkdir(parents=True)
+    shutil.copy2(root / "notifier" / "Dockerfile", ctx / "notifier" / "Dockerfile")
+    for name in _CONTEXT_FILES:
+        src = root / name
+        if src.is_file():
+            shutil.copy2(src, ctx / name)
+    shutil.copytree(root / "src" / "remo_cli", ctx / "src" / "remo_cli")
+    shutil.copytree(root / "ansible", ctx / "ansible")
+    return str(ctx)
+
+
+@click.group()
+def notifier() -> None:
+    """Manage the notifier sidecar (agentsh approval bridge)."""
+
+
+@notifier.command()
+@click.argument("host", default="")
+@click.option("--rebuild", is_flag=True, help="Force a Docker image rebuild on the host.")
+@click.option("-v", "--verbose", is_flag=True, help="Enable verbose output.")
+def deploy(host: str, rebuild: bool, verbose: bool) -> None:
+    """Deploy the notifier to HOST (applies the remo_notifier Ansible role)."""
+    token = os.environ.get("REMO_NOTIFIER_TELEGRAM_BOT_TOKEN", "").strip()
+    chat = os.environ.get("REMO_NOTIFIER_TELEGRAM_CHAT_ID", "").strip()
+    if not token or not chat:
+        print_error(
+            "Missing Telegram credentials. Set both REMO_NOTIFIER_TELEGRAM_BOT_TOKEN "
+            "and REMO_NOTIFIER_TELEGRAM_CHAT_ID before deploying "
+            "(see the README 'Notifier setup' section)."
+        )
+        sys.exit(1)
+
+    target = _resolve(host)
+    context_dir = _ensure_build_context()
+
+    print_info(f"Deploying notifier to '{target.display_name}' at {target.host}...")
+    extra_vars = [
+        "-i", f"{target.host},",
+        "-e", f"ansible_user={target.user}",
+        "-e", f"remo_notifier_build_context_local={context_dir}",
+    ]
+    if rebuild:
+        extra_vars += ["-e", "remo_notifier_force_rebuild=true"]
+
+    rc = run_playbook("notifier_deploy.yml", extra_vars, verbose=verbose)
+    sys.exit(rc)
+
+
+@notifier.command()
+@click.argument("host", default="")
+@click.option("--bind", default="172.17.0.1", help="Host bind address of the notifier.")
+@click.option("--port", default=18181, help="Notifier port.")
+def status(host: str, bind: str, port: int) -> None:
+    """Show the notifier health summary on HOST."""
+    target = _resolve(host)
+    url = _bind_url(target, "/v1/health", bind=bind, port=port)
+    result = _ssh_run(target, f"curl -sf {shlex.quote(url)}", capture=True)
+    if result.returncode != 0:
+        print_error(f"notifier unreachable on {target.display_name} ({url}).")
+        sys.exit(1)
+    try:
+        click.echo(json.dumps(json.loads(result.stdout), indent=2))
+    except json.JSONDecodeError:
+        click.echo(result.stdout)
+
+
+@notifier.command()
+@click.argument("host", default="")
+@click.option("--follow", "-f", is_flag=True, help="Follow the log stream.")
+@click.option("--lines", "-n", default=100, help="Number of lines to show (default 100).")
+def logs(host: str, follow: bool, lines: int) -> None:
+    """Show notifier journald logs on HOST."""
+    target = _resolve(host)
+    cmd = f"journalctl -u remo-notifier.service -n {int(lines)}"
+    if follow:
+        cmd += " -f"
+    sys.exit(_ssh_run(target, cmd).returncode)
+
+
+@notifier.command()
+@click.argument("host", default="")
+def restart(host: str) -> None:
+    """Restart the notifier service on HOST."""
+    target = _resolve(host)
+    print_info(f"Restarting remo-notifier on '{target.display_name}'...")
+    sys.exit(_ssh_run(target, "sudo systemctl restart remo-notifier.service").returncode)
+
+
+@notifier.command(name="test")
+@click.argument("host", default="")
+@click.option("--bind", default="172.17.0.1", help="Host bind address of the notifier.")
+@click.option("--port", default=18181, help="Notifier port.")
+@click.option("--timeout", default=120, help="Approval timeout in seconds.")
+def test_cmd(host: str, bind: str, port: int, timeout: int) -> None:
+    """Send a test approval through HOST and report the decision."""
+    target = _resolve(host)
+    payload = {
+        "operation": {"kind": "command", "command": "echo", "args": ["wiring-check"]},
+        "policy_rule_name": "test",
+        "policy_message": (
+            "This is a test approval — please tap Approve or Deny to confirm wiring."
+        ),
+        "project": "remo-notifier-selftest",
+        "instance_id": target.display_name,
+        "timeout_seconds": timeout,
+    }
+    url = _bind_url(target, "/v1/approve", bind=bind, port=port)
+    body = shlex.quote(json.dumps(payload))
+    remote = (
+        f"curl -s -X POST {shlex.quote(url)} "
+        f"-H 'content-type: application/json' -d {body}"
+    )
+    print_info(f"Sending test approval to '{target.display_name}' — check Telegram...")
+    result = _ssh_run(target, remote, capture=True)
+    if result.returncode != 0 or not result.stdout.strip():
+        print_error(f"notifier unreachable on {target.display_name} ({url}).")
+        sys.exit(1)
+    try:
+        decision = json.loads(result.stdout)
+    except json.JSONDecodeError:
+        print_error(f"unexpected response: {result.stdout!r}")
+        sys.exit(1)
+    click.echo(json.dumps(decision, indent=2))
+    sys.exit(0 if decision.get("decision") in {"allow", "deny"} else 1)

--- a/src/remo_cli/cli/shell.py
+++ b/src/remo_cli/cli/shell.py
@@ -25,13 +25,67 @@ import click
     default=False,
     help="Skip remote version check before connecting",
 )
+@click.option(
+    "-p",
+    "--project",
+    "project",
+    default=None,
+    help="Skip the menu and jump straight to PROJECT under ~/projects",
+)
+@click.option(
+    "--exec",
+    "exec_cmd",
+    default=None,
+    help="Run COMMAND inside the project's devcontainer instead of opening a shell (requires -p)",
+    metavar="COMMAND",
+)
+@click.option(
+    "--detach",
+    is_flag=True,
+    default=False,
+    help="Run --exec COMMAND detached on the remote and return immediately",
+)
 def shell(
     name: str | None,
     tunnels: tuple[str, ...],
     no_open: bool,
     no_update_check: bool,
+    project: str | None,
+    exec_cmd: str | None,
+    detach: bool,
 ) -> None:
-    """Connect to a remo environment (auto-detects or picker)."""
+    """Connect to a remo environment (auto-detects or picker).
+
+    With -p PROJECT, skip the server-side picker and jump straight into that
+    project's session (devcontainer auto-launches if .devcontainer exists).
+
+    With --exec COMMAND, run COMMAND inside the project's devcontainer instead
+    of dropping into an interactive shell. Add --detach to fire-and-forget.
+
+    Examples:
+
+      remo shell -p my-app
+      remo shell -p my-app --exec 'claude --remote-control'
+      remo shell -p my-app --detach --exec 'claude remote-control --name my-rc'
+    """
+    from remo_cli.core.output import print_error  # noqa: PLC0415
+
+    if detach and not exec_cmd:
+        print_error(
+            "--detach requires --exec COMMAND (e.g., "
+            "'remo shell -p X --detach --exec \"claude remote-control\"')"
+        )
+        raise SystemExit(2)
+    if exec_cmd and not project:
+        print_error("--exec requires -p/--project to know where to run the command")
+        raise SystemExit(2)
+    if detach and tunnels:
+        print_error(
+            "-L port forwarding cannot be combined with --detach — the SSH "
+            "session exits immediately, so the tunnel would die before you "
+            "could use it. Drop one or the other."
+        )
+        raise SystemExit(2)
     from remo_cli.core.ssh import check_remote_version, resolve_remo_host, shell_connect  # noqa: PLC0415
     from remo_cli.core.output import confirm, print_error, print_warning  # noqa: PLC0415
     from remo_cli.core.version import get_current_version, version_is_newer  # noqa: PLC0415
@@ -96,7 +150,14 @@ def shell(
                     ):
                         raise SystemExit(rc)
 
-    shell_connect(host, list(tunnels), no_open)
+    shell_connect(
+        host,
+        list(tunnels),
+        no_open,
+        project=project,
+        detach=detach,
+        exec_cmd=exec_cmd,
+    )
 
 
 def _run_provider_update(host) -> int:  # noqa: ANN001

--- a/src/remo_cli/core/ssh.py
+++ b/src/remo_cli/core/ssh.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import os
+import shlex
 import shutil
 import subprocess
 import sys
@@ -299,8 +300,39 @@ def check_remote_version(host: KnownHost) -> tuple[str | None, str | None]:
     return None, None
 
 
-def shell_connect(host: KnownHost, tunnels: list[str], no_open: bool) -> None:
-    """Open an interactive SSH session to *host* with optional port tunnels.
+def build_project_launch_remote_cmd(
+    project: str,
+    detach: bool,
+    exec_cmd: str | None,
+) -> str:
+    """Build the remote command string passed to ``ssh`` for project-launch.
+
+    Returns a single shell-quoted string suitable for ``ssh <opts> <target>
+    <cmd>``. ``exec_cmd`` is treated as one opaque shell command (the user
+    typed it after ``--exec``) and forwarded as a single shell-quoted arg
+    to ``--exec`` on the remote. The remote runs it via ``bash -lc`` so
+    variable expansion, pipes, ``&&`` etc. all work as the user wrote them.
+    """
+    # Absolute path: SSH non-interactive commands don't source .bashrc, so
+    # ~/.local/bin isn't in PATH. The remote login shell expands ~ for us.
+    parts = ["~/.local/bin/project-launch", "--project", shlex.quote(project)]
+    if detach:
+        parts.append("--detach")
+    if exec_cmd:
+        parts.append("--exec")
+        parts.append(shlex.quote(exec_cmd))
+    return " ".join(parts)
+
+
+def shell_connect(
+    host: KnownHost,
+    tunnels: list[str],
+    no_open: bool,
+    project: str | None = None,
+    detach: bool = False,
+    exec_cmd: str | None = None,
+) -> None:
+    """Open an SSH session to *host* with optional port tunnels.
 
     Parameters
     ----------
@@ -311,7 +343,19 @@ def shell_connect(host: KnownHost, tunnels: list[str], no_open: bool) -> None:
         (same local and remote port) or ``"LOCAL:REMOTE"``.
     no_open:
         When ``True``, skip auto-opening the browser for the first tunnel.
+    project:
+        When set, skip the server-side picker and hand off to the
+        ``project-launch`` helper for this project name.
+    detach:
+        When ``True``, ask ``project-launch`` to run *exec_cmd* detached and
+        return immediately. Requires *exec_cmd* to be non-empty.
+    exec_cmd:
+        Single-string command to run via ``project-launch -- ...`` inside the
+        project's devcontainer (or in the host project dir if no
+        ``.devcontainer``).
     """
+    use_project_launch = bool(project)
+
     ssh_opts, ssh_target = build_ssh_opts(host, multiplex=True)
 
     print_info(f"Connecting to {host.type}: {host.name} ({host.host})...")
@@ -354,7 +398,18 @@ def shell_connect(host: KnownHost, tunnels: list[str], no_open: bool) -> None:
         print_info(f"Tunnel: localhost:{local_port} -> remote :{remote_port}")
         parsed_tunnels.append((local_port, remote_port))
 
+    if use_project_launch:
+        # -t forces TTY allocation so the interactive zellij+devcontainer flow
+        # inside project-launch behaves correctly. The detach branch also
+        # benefits — devcontainer up prints progress that should reach the
+        # user's terminal even though the command exits immediately after.
+        ssh_cmd.append("-t")
+
     ssh_cmd.append(ssh_target)
+
+    if use_project_launch:
+        assert project is not None  # narrowed by use_project_launch
+        ssh_cmd.append(build_project_launch_remote_cmd(project, detach, exec_cmd))
 
     # ------------------------------------------------------------------
     # Auto-open browser for first tunnel

--- a/src/remo_cli/notifier/README.md
+++ b/src/remo_cli/notifier/README.md
@@ -1,0 +1,40 @@
+# remo notifier
+
+A long-running HTTP daemon that receives agentsh approval requests, delivers
+them to a human via Telegram (long-polling), and returns the human's decision
+synchronously — failing secure (deny) on timeout, shutdown, send failure, or
+capacity exhaustion. No persistent state.
+
+This component currently ships as part of the remo repo for v1 distribution
+simplicity. **Its wire protocol is the durable contract**; future consumers may
+include juju's pending-decision-bead pusher, maverick workflow status
+announcers, and deacon lifecycle events. See
+[`docs/wire-protocol.md`](docs/wire-protocol.md).
+
+## Layout
+
+```
+notifier/
+├── cli.py            # `remo-notifier serve`
+├── server.py         # FastAPI app + lifespan + fail-secure resolver
+├── config.py         # Pydantic config + strict TOML loader
+├── state.py          # in-memory PendingApprovals registry
+├── models.py         # wire-protocol models
+├── logging_setup.py  # structlog + secret redaction
+├── transports/
+│   ├── base.py       # NotificationTransport ABC
+│   └── telegram.py   # Telegram (long-polling) implementation
+└── docs/
+    ├── wire-protocol.md
+    └── config-schema.md
+```
+
+## Run locally
+
+```bash
+uv pip install -e ".[notifier]"
+remo-notifier serve --config /path/to/notifier.toml
+```
+
+See the repo-root README "Notifier" section for first-time Telegram setup and
+deployment via `remo notifier deploy`.

--- a/src/remo_cli/notifier/__init__.py
+++ b/src/remo_cli/notifier/__init__.py
@@ -1,0 +1,14 @@
+"""Remo Notifier — Telegram approval bridge for agentsh.
+
+A long-running HTTP daemon that receives agentsh approval requests, delivers
+them to a human via a pluggable notification transport (Telegram in v1), and
+returns the human's decision synchronously — failing secure (deny) on timeout,
+shutdown, send failure, or capacity exhaustion. No persistent state.
+"""
+
+from __future__ import annotations
+
+# Notifier component version — surfaced in GET /v1/health and used as the
+# container image tag. Intentionally independent of the remo-cli package
+# version (see data-model.md, finding I2).
+__version__ = "0.1.0"

--- a/src/remo_cli/notifier/cli.py
+++ b/src/remo_cli/notifier/cli.py
@@ -1,0 +1,103 @@
+"""`remo-notifier` entry point — runs the notifier service.
+
+Usage: ``remo-notifier serve --config /etc/notifier/notifier.toml``.
+"""
+
+from __future__ import annotations
+
+import signal
+import sys
+
+import click
+
+from remo_cli.notifier import __version__
+from remo_cli.notifier.config import NotifierConfig, load_config
+from remo_cli.notifier.logging_setup import configure_logging, get_logger
+from remo_cli.notifier.transports.base import NotificationTransport
+
+
+def build_transport(config: NotifierConfig) -> NotificationTransport:
+    """Construct the configured transport (Telegram only in v1)."""
+    if config.transport.type != "telegram" or config.transport.telegram is None:
+        raise click.ClickException("only the 'telegram' transport is supported")
+    # Imported lazily so the rest of the CLI doesn't require python-telegram-bot.
+    from remo_cli.notifier.transports.telegram import TelegramTransport
+
+    tg = config.transport.telegram
+    return TelegramTransport(
+        token=tg.read_token(),
+        authorized_chat_id=tg.authorized_chat_id,
+        instance_id=config.instance.id,
+        parse_mode=tg.message_parse_mode,
+    )
+
+
+@click.group(context_settings={"help_option_names": ["-h", "--help"]})
+@click.version_option(__version__, prog_name="remo-notifier")
+def main() -> None:
+    """Remo notifier — Telegram approval bridge for agentsh."""
+
+
+@main.command()
+@click.option(
+    "--config",
+    "config_path",
+    default="/etc/notifier/notifier.toml",
+    help="Path to the notifier TOML config.",
+)
+def serve(config_path: str) -> None:
+    """Start the notifier HTTP server."""
+    import uvicorn
+
+    from remo_cli.notifier.server import create_app
+
+    try:
+        config = load_config(config_path)
+    except (FileNotFoundError, ValueError) as exc:
+        # Fail fast with a clear message (Constitution IV / FR-018/023).
+        click.echo(f"Error: invalid notifier config: {exc}", err=True)
+        sys.exit(1)
+
+    configure_logging(config.server.log_level)
+    log = get_logger("remo_notifier")
+
+    try:
+        transport = build_transport(config)
+    except (ValueError, click.ClickException) as exc:
+        click.echo(f"Error: {exc}", err=True)
+        sys.exit(1)
+
+    # SIGHUP re-reads the token file so secrets can be rotated without a full
+    # redeploy (research R6). Best-effort: the refreshed token applies on the
+    # transport's next (re)start.
+    def _on_sighup(signum: int, frame: object) -> None:  # noqa: ARG001
+        try:
+            new_token = config.transport.telegram.read_token()  # type: ignore[union-attr]
+            if hasattr(transport, "set_token"):
+                transport.set_token(new_token)  # type: ignore[attr-defined]
+            log.info("sighup_token_reread")
+        except Exception as exc:  # noqa: BLE001
+            log.error("sighup_token_reread_failed", error=str(exc))
+
+    try:
+        signal.signal(signal.SIGHUP, _on_sighup)
+    except (ValueError, AttributeError):  # pragma: no cover - non-main thread / no SIGHUP
+        pass
+
+    app = create_app(config, transport)
+    log.info(
+        "starting",
+        version=__version__,
+        host=config.server.listen_host,
+        port=config.server.listen_port,
+    )
+    uvicorn.run(
+        app,
+        host=config.server.listen_host,
+        port=config.server.listen_port,
+        log_level=config.server.log_level,
+    )
+
+
+if __name__ == "__main__":  # pragma: no cover
+    main()

--- a/src/remo_cli/notifier/config.py
+++ b/src/remo_cli/notifier/config.py
@@ -1,0 +1,129 @@
+"""Notifier configuration: Pydantic models + strict TOML loader.
+
+The config file never contains the bot token; the token is read from a separate
+secret file at startup and kept in memory (FR-019). Unknown keys are rejected
+(FR-018). See data-model.md and contracts (config-schema.md).
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from pydantic import BaseModel, ConfigDict, Field, model_validator
+
+try:  # Python 3.11+ ships tomllib; tomli is the <3.11 fallback.
+    import tomllib as _toml
+except ModuleNotFoundError:  # pragma: no cover
+    import tomli as _toml  # type: ignore[import-not-found, no-redef]
+
+
+class ServerConfig(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    listen_host: str = "0.0.0.0"
+    listen_port: int = Field(default=18181, ge=1, le=65535)
+    log_level: str = "info"
+
+    @model_validator(mode="after")
+    def _check_level(self) -> ServerConfig:
+        if self.log_level not in {"debug", "info", "warning", "error"}:
+            raise ValueError(
+                f"log_level must be one of debug|info|warning|error, got {self.log_level!r}"
+            )
+        return self
+
+
+class ApprovalConfig(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    default_timeout_seconds: int = Field(default=300, ge=1)
+    max_timeout_seconds: int = Field(default=1800, ge=1)
+    max_pending_approvals: int = Field(default=50, ge=1)
+
+    @model_validator(mode="after")
+    def _check_bounds(self) -> ApprovalConfig:
+        if self.max_timeout_seconds < self.default_timeout_seconds:
+            raise ValueError(
+                "max_timeout_seconds must be >= default_timeout_seconds "
+                f"({self.max_timeout_seconds} < {self.default_timeout_seconds})"
+            )
+        return self
+
+
+class GrantsConfig(BaseModel):
+    """Standing-grant ("Always" auto-approval) settings (Addendum 001)."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    enabled: bool = True
+    default_ttl_seconds: int = Field(default=28800, ge=1)  # 8h; every grant expires
+    max_grants: int = Field(default=100, ge=1)
+    allow_global_scope: bool = True
+    digest_interval_seconds: int = Field(default=3600, ge=0)  # 0 disables the digest
+
+
+class TelegramConfig(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    bot_token_file: str = "/run/secrets/telegram_bot_token"
+    authorized_chat_id: int
+    message_parse_mode: str = "MarkdownV2"
+
+    def read_token(self) -> str:
+        """Read and return the bot token from ``bot_token_file``.
+
+        Raises a clear error if the file is missing or empty (fail-fast,
+        Constitution IV / FR-023).
+        """
+        path = Path(self.bot_token_file)
+        if not path.is_file():
+            raise ValueError(f"bot token file not found: {self.bot_token_file}")
+        token = path.read_text(encoding="utf-8").strip()
+        if not token:
+            raise ValueError(f"bot token file is empty: {self.bot_token_file}")
+        return token
+
+
+class TransportConfig(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    type: str = "telegram"
+    telegram: TelegramConfig | None = None
+
+    @model_validator(mode="after")
+    def _check_transport(self) -> TransportConfig:
+        if self.type != "telegram":
+            raise ValueError(f"only transport type 'telegram' is supported in v1, got {self.type!r}")
+        if self.telegram is None:
+            raise ValueError("[transport.telegram] section is required when type = 'telegram'")
+        return self
+
+
+class InstanceConfig(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    id: str
+
+
+class NotifierConfig(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    server: ServerConfig = Field(default_factory=ServerConfig)
+    approval: ApprovalConfig = Field(default_factory=ApprovalConfig)
+    grants: GrantsConfig = Field(default_factory=GrantsConfig)
+    transport: TransportConfig
+    instance: InstanceConfig
+
+
+def load_config(path: str | Path) -> NotifierConfig:
+    """Load and strictly validate the notifier TOML config.
+
+    Raises ValueError with a clear message on unknown keys or invalid values
+    (FR-018), and FileNotFoundError if the path does not exist.
+    """
+    p = Path(path)
+    if not p.is_file():
+        raise FileNotFoundError(f"config file not found: {path}")
+    with p.open("rb") as fh:
+        data = _toml.load(fh)
+    return NotifierConfig.model_validate(data)

--- a/src/remo_cli/notifier/docs/config-schema.md
+++ b/src/remo_cli/notifier/docs/config-schema.md
@@ -1,0 +1,75 @@
+# Notifier Configuration Schema
+
+The notifier reads a single TOML file (`--config`, default
+`/etc/notifier/notifier.toml`). Validation is **strict**: unknown keys are
+rejected with a clear error. The bot token is **never** in this file — it is
+read from a separate secret file at startup and kept in memory.
+
+```toml
+[server]
+listen_host = "0.0.0.0"        # default "0.0.0.0"
+listen_port = 18181            # default 18181 (1–65535)
+log_level   = "info"           # debug | info | warning | error
+
+[approval]
+default_timeout_seconds = 300  # applied when a request omits timeout_seconds
+max_timeout_seconds     = 1800 # requests are clamped to this; must be >= default
+max_pending_approvals   = 50   # concurrent in-flight cap; over this -> 503
+
+[transport]
+type = "telegram"              # only "telegram" is supported in v1
+
+[transport.telegram]
+bot_token_file     = "/run/secrets/telegram_bot_token"  # read at startup, kept in memory
+authorized_chat_id = 123456789                          # int; only this chat may decide
+message_parse_mode = "MarkdownV2"
+
+[instance]
+id = "hetzner-prod-1"          # shown to the human in the approval message
+```
+
+## Fields
+
+| Key | Type | Default | Notes |
+|-----|------|---------|-------|
+| `server.listen_host` | string | `0.0.0.0` | Bind inside the container. |
+| `server.listen_port` | int | `18181` | |
+| `server.log_level` | enum | `info` | `debug` also logs secrets/bodies; `info`+ never does. |
+| `approval.default_timeout_seconds` | int ≥ 1 | `300` | |
+| `approval.max_timeout_seconds` | int ≥ 1 | `1800` | Must be ≥ default. |
+| `approval.max_pending_approvals` | int ≥ 1 | `50` | Backpressure / flood protection. |
+| `transport.type` | enum | `telegram` | |
+| `transport.telegram.bot_token_file` | path | `/run/secrets/telegram_bot_token` | Read once at startup; empty/missing → fail fast. |
+| `transport.telegram.authorized_chat_id` | int | — | Required. |
+| `transport.telegram.message_parse_mode` | string | `MarkdownV2` | |
+| `instance.id` | string | — | Required. |
+
+## Standing grants — `[grants]` (Addendum 001)
+
+```toml
+[grants]
+enabled = true                  # master switch for "Always" auto-approval
+default_ttl_seconds = 28800     # 8h; applied to every grant (no indefinite grants)
+max_grants = 100                # cap on concurrent active grants
+allow_global_scope = true       # if false, "everywhere"-scoped grants are refused
+digest_interval_seconds = 3600  # periodic auto-approval digest; 0 disables it
+```
+
+| Key | Type | Default | Notes |
+|-----|------|---------|-------|
+| `enabled` | bool | `true` | When false, every request is prompted as before. |
+| `default_ttl_seconds` | int ≥ 1 | `28800` | Every grant expires; revocation is always available. |
+| `max_grants` | int ≥ 1 | `100` | Over the cap, "Always" approves once but doesn't remember. |
+| `allow_global_scope` | bool | `true` | Grants default to the narrowest scope regardless. |
+| `digest_interval_seconds` | int ≥ 0 | `3600` | `0` disables the Telegram digest. |
+
+Grants are in-memory (cleared on restart → fail-closed re-prompt) and managed
+from Telegram (`/rules`, `/revoke <id>`, `/pause`, `/resume`).
+
+## Secret handling & rotation
+
+- The bot token lives only in `bot_token_file` (mode `0400`), never in this TOML
+  and never in logs.
+- To rotate: rewrite the secret file and restart (`remo notifier restart`). The
+  process also re-reads the file on `SIGHUP` (best-effort; applied on the
+  transport's next start).

--- a/src/remo_cli/notifier/docs/wire-protocol.md
+++ b/src/remo_cli/notifier/docs/wire-protocol.md
@@ -1,0 +1,123 @@
+# Notifier Wire Protocol (v1)
+
+The durable contract between agentsh (or any future approval emitter) and the
+notifier. The machine-readable schema is
+[`contracts/openapi.yaml`](../../../../specs/007-notifier-sidecar/contracts/openapi.yaml);
+this document is the human reference.
+
+The notifier listens on `0.0.0.0:18181` inside its container; the host binds it
+to the Docker bridge (e.g. `172.17.0.1:18181`), reachable only by co-located
+devcontainers. No TLS, no caller authentication in v1.
+
+## `POST /v1/approve`
+
+Submit an approval request. The connection is held open until a decision
+exists: a human tap, the timeout, or service shutdown. Exactly one response is
+returned.
+
+### Request — `ApprovalRequest`
+
+| Field | Type | Required | Notes |
+|-------|------|----------|-------|
+| `approval_id` | string (UUID) | no | Server generates if absent. Duplicate-of-pending → `409`. |
+| `session_id` | string | no | Opaque agentsh session id. |
+| `operation` | object | yes | See below. |
+| `operation.kind` | `command`\|`file`\|`network`\|`signal` | yes | |
+| `operation.command` | string | no | |
+| `operation.args` | string[] | no | |
+| `operation.path` | string | no | file ops |
+| `operation.remote_host` | string | no | network ops |
+| `operation.remote_port` | int (1–65535) | no | network ops |
+| `operation.context` | `direct`\|`nested` | no | default `direct` |
+| `operation.depth` | int ≥ 0 | no | default 0 |
+| `policy_rule_name` | string | yes | |
+| `policy_message` | string | yes | Human-readable prompt. |
+| `workspace` | string | no | DEBUG-log only. |
+| `instance_id` | string | no | Falls back to the configured instance id. |
+| `project` | string | no | |
+| `timeout_seconds` | int ≥ 1 | no | Clamped to `[1, max_timeout_seconds]`; defaults to `default_timeout_seconds`. |
+| `submitted_at` | string (RFC3339) | no | Informational. |
+
+Unknown fields are rejected (`400`).
+
+### Response — `ApprovalResponse`
+
+```json
+{
+  "approval_id": "…",
+  "decision": "allow | deny",
+  "responder": "telegram:paulofallon",
+  "reason": "",
+  "decided_at": "2026-05-31T14:23:00Z",
+  "latency_ms": 1234
+}
+```
+
+### Status codes
+
+| Code | Meaning | Body |
+|------|---------|------|
+| `200` | An authorized human approved or denied. | `ApprovalResponse` |
+| `400` | Schema validation failure (unknown field, bad type, bad UUID). | `ErrorResponse{error:"validation_error"}` |
+| `408` | Timeout — no human responded. **Fail-secure deny.** | `ApprovalResponse{decision:"deny", reason:"timeout"}` |
+| `409` | `approval_id` already pending; original left running, no second notification. | `ErrorResponse{error:"duplicate_approval_id"}` |
+| `503` | Shutting down, transport unreachable, no human-side config, **at capacity**, or this request's notification failed to send (no slot held). | `ErrorResponse{error:"unavailable"}` |
+
+## Timeout contract (fail-secure)
+
+A request that is not answered within its effective timeout returns `408` with a
+`deny` decision and `reason: "timeout"`. **No outcome other than an explicit
+authorized human Approve ever yields `allow`** — timeout, validation failure,
+transport failure, capacity exhaustion, shutdown, and a dropped connection all
+resolve to deny (or to no response, which the caller treats as deny). agentsh
+applies its own `approval_timeout_action` on top of this.
+
+## Cancellation semantics
+
+`cancel(approval_id)` exists on the transport interface for approvals resolved
+by means other than this transport (e.g. another channel, or shutdown). It edits
+the human-facing message to reflect the final non-human outcome and resolves the
+caller. In v1 it is used internally on timeout (message shows "Timed out") and
+on shutdown ("Cancelled"); there is no external cancel endpoint.
+
+## `GET /v1/health`
+
+No auth. Returns `200`:
+
+```json
+{
+  "status": "ok",
+  "version": "0.1.0",
+  "transport": "telegram",
+  "uptime_seconds": 1234,
+  "pending_approvals": 0
+}
+```
+
+`version` is the notifier component version (matches the container image tag),
+not the `remo-cli` package version.
+
+## State & restart
+
+All approval state is in-memory. A restart loses every pending approval; the
+caller's dropped connection is treated as a fail-secure deny. There is no
+persistence and no replay.
+
+## Standing grants — "Always" auto-approval (Addendum 001)
+
+Before anything else, `POST /v1/approve` checks the in-memory standing-grant
+store. If the request matches an **active, unexpired, unrevoked, human-created**
+grant (created earlier via the Telegram "Always" flow), the notifier returns
+`200` immediately:
+
+- `decision: "allow"`, `responder: "rule:{grant_id}"`,
+  `reason: "auto-approved via standing grant"`, and the `grant_id` field set.
+- No notification is sent and no pending slot is reserved.
+
+On no match (or when grants are disabled/paused), the normal pipeline runs
+unchanged. The match is deterministic and **fail-closed**: an expired/revoked
+grant, a scope/predicate mismatch, a missing field, or any evaluation error all
+mean "no match" → the human is prompted. Grants are in-memory only (a restart
+clears them → re-prompts) and TTL-bounded (default 8h; no indefinite grants).
+The `grant_id` field also appears on the response that *creates* a grant (the
+"Always" tap). Full grant schema + Telegram surface: `contracts/grant-schema.md`.

--- a/src/remo_cli/notifier/grants.py
+++ b/src/remo_cli/notifier/grants.py
@@ -1,0 +1,339 @@
+"""Standing grants ("Always" auto-approval) — Addendum 001.
+
+In-memory, TTL-bounded, scoped, fail-closed. The matcher is deterministic and
+exact — it is the only `allow`-capable code path, so it never does fuzzy/
+semantic matching. See addendum-001-standing-grants.md and
+contracts/grant-schema.md.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import uuid
+from datetime import datetime, timedelta, timezone
+from enum import Enum
+from fnmatch import fnmatchcase
+
+from pydantic import BaseModel, ConfigDict, Field
+
+from remo_cli.notifier.models import ApprovalRequest, OperationKind
+
+
+def _utcnow() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+class GrantScopeType(str, Enum):
+    session = "session"
+    workspace = "workspace"
+    project = "project"
+    instance = "instance"
+    glob = "global"  # value "global"; attr name avoids the reserved word
+
+
+class ArgMatchType(str, Enum):
+    exact = "exact"
+    prefix = "prefix"
+    glob = "glob"
+
+
+class HostMatchType(str, Enum):
+    exact = "exact"
+    suffix = "suffix"
+
+
+class GrantLimitReached(Exception):
+    """Raised by GrantStore.create() when max_grants is already reached."""
+
+
+class GrantScope(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    type: GrantScopeType
+    value: str = ""
+
+    def matches(self, request: ApprovalRequest, *, instance_id: str) -> bool:
+        """Exact-equality scope check; missing field → False (fail-closed).
+
+        `instance` scope is the one intentional exception: a request lacking
+        instance_id falls back to the notifier's configured instance id.
+        """
+        if self.type is GrantScopeType.glob:
+            return True
+        if self.type is GrantScopeType.session:
+            return bool(request.session_id) and request.session_id == self.value
+        if self.type is GrantScopeType.workspace:
+            return bool(request.workspace) and request.workspace == self.value
+        if self.type is GrantScopeType.project:
+            return bool(request.project) and request.project == self.value
+        if self.type is GrantScopeType.instance:
+            effective = request.instance_id or instance_id
+            return bool(effective) and effective == self.value
+        return False
+
+
+class GrantPredicate(BaseModel):
+    """Deterministic, inspectable match rule (agentsh-rule-shaped)."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    kind: OperationKind
+    # command / signal
+    command: str | None = None
+    args: list[str] = Field(default_factory=list)
+    args_match: ArgMatchType = ArgMatchType.exact
+    # file (path-only in v1 — the wire Operation carries no read/write/delete verb)
+    paths: list[str] = Field(default_factory=list)
+    operations: list[str] = Field(default_factory=list)  # reserved; not enforced in v1
+    # network
+    host: str | None = None
+    host_match: HostMatchType = HostMatchType.exact
+    port: int | None = None
+    # signal
+    signal: str | None = None
+    # broadest rung (optional)
+    policy_rule_name: str | None = None
+
+    def matches(self, request: ApprovalRequest, *, workspace: str | None = None) -> bool:
+        op = request.operation
+        if op.kind is not self.kind:
+            return False
+        if self.policy_rule_name is not None:
+            return request.policy_rule_name == self.policy_rule_name
+        if self.kind is OperationKind.command:
+            return op.command == self.command and self._args_ok(op.args)
+        if self.kind is OperationKind.file:
+            return self._path_ok(op.path, workspace or request.workspace)
+        if self.kind is OperationKind.network:
+            return self._host_ok(op.remote_host) and self._port_ok(op.remote_port)
+        if self.kind is OperationKind.signal:
+            return self.signal is None or self.signal == op.command
+        return False
+
+    def _args_ok(self, args: list[str]) -> bool:
+        if self.args_match is ArgMatchType.exact:
+            return args == self.args
+        if self.args_match is ArgMatchType.prefix:
+            return args[: len(self.args)] == self.args
+        # glob: positional, equal length
+        if len(args) != len(self.args):
+            return False
+        return all(fnmatchcase(a, p) for a, p in zip(args, self.args))
+
+    def _path_ok(self, path: str | None, workspace: str | None) -> bool:
+        if not path or not self.paths:
+            return False
+        for pattern in self.paths:
+            expanded = pattern.replace("{workspace}", workspace) if workspace else pattern
+            if "{workspace}" in expanded:  # placeholder unresolved → fail-closed
+                continue
+            if fnmatchcase(path, expanded):
+                return True
+        return False
+
+    def _host_ok(self, host: str | None) -> bool:
+        if not host or self.host is None:
+            return False
+        if self.host_match is HostMatchType.exact:
+            return host == self.host
+        return host == self.host.lstrip(".") or host.endswith(self.host)
+
+    def _port_ok(self, port: int | None) -> bool:
+        return self.port is None or self.port == port
+
+
+class Grant(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    grant_id: str = Field(default_factory=lambda: str(uuid.uuid4()))
+    created_at: datetime = Field(default_factory=_utcnow)
+    created_by: str = ""
+    expires_at: datetime
+    source_approval_id: str = ""
+    scope: GrantScope
+    predicate: GrantPredicate
+    eligible: bool = True  # always True in v1 (reserved for future denylist)
+    uses_count: int = 0
+    last_used_at: datetime | None = None
+
+    def active(self, now: datetime) -> bool:
+        return now < self.expires_at
+
+    def matches(self, request: ApprovalRequest, now: datetime, *, instance_id: str) -> bool:
+        return (
+            self.active(now)
+            and self.scope.matches(request, instance_id=instance_id)
+            and self.predicate.matches(request)
+        )
+
+    @classmethod
+    def create(
+        cls,
+        *,
+        predicate: GrantPredicate,
+        scope: GrantScope,
+        ttl_seconds: int,
+        created_by: str,
+        source_approval_id: str,
+        now: datetime | None = None,
+    ) -> Grant:
+        now = now or _utcnow()
+        return cls(
+            created_at=now,
+            expires_at=now + timedelta(seconds=ttl_seconds),
+            created_by=created_by,
+            source_approval_id=source_approval_id,
+            scope=scope,
+            predicate=predicate,
+        )
+
+
+class CandidateGrant(BaseModel):
+    """Transient picker option (label + predicate + scope). Not persisted."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    label: str
+    predicate: GrantPredicate
+    scope: GrantScope
+
+
+def _scope_label(scope: GrantScope) -> str:
+    if scope.type is GrantScopeType.glob:
+        return "everywhere"
+    return f"this {scope.type.value} ({scope.value})"
+
+
+class GrantStore:
+    """In-memory registry of standing grants. Fail-closed everywhere."""
+
+    def __init__(self, *, max_grants: int, instance_id: str, allow_global_scope: bool = True) -> None:
+        self._max = max_grants
+        self._instance_id = instance_id
+        self._allow_global = allow_global_scope
+        self._grants: dict[str, Grant] = {}
+        self._lock = asyncio.Lock()
+        self.paused = False
+
+    def count(self) -> int:
+        return len(self._grants)
+
+    def set_paused(self, paused: bool) -> None:
+        self.paused = paused
+
+    def match(self, request: ApprovalRequest, now: datetime | None = None) -> Grant | None:
+        """Return the first active grant matching the request, or None.
+
+        Allow-capable — exact and deterministic. Paused/empty/expired/mismatch
+        all yield None (fail-closed). Increments the matched grant's usage.
+        """
+        if self.paused:
+            return None
+        now = now or _utcnow()
+        for grant in list(self._grants.values()):
+            try:
+                if grant.matches(request, now, instance_id=self._instance_id):
+                    grant.uses_count += 1
+                    grant.last_used_at = now
+                    return grant
+            except Exception:  # noqa: BLE001 - any match error is fail-closed (no match)
+                continue
+        return None
+
+    async def create(self, grant: Grant) -> Grant:
+        async with self._lock:
+            # Drop expired entries opportunistically so the cap reflects live grants.
+            self._sweep_locked(_utcnow())
+            if len(self._grants) >= self._max:
+                raise GrantLimitReached(f"max_grants={self._max} reached")
+            self._grants[grant.grant_id] = grant
+            return grant
+
+    def list_active(self, now: datetime | None = None) -> list[Grant]:
+        now = now or _utcnow()
+        return [g for g in self._grants.values() if g.active(now)]
+
+    async def revoke(self, grant_id: str) -> bool:
+        async with self._lock:
+            return self._grants.pop(grant_id, None) is not None
+
+    def sweep(self, now: datetime | None = None) -> int:
+        return self._sweep_locked(now or _utcnow())
+
+    def _sweep_locked(self, now: datetime) -> int:
+        expired = [gid for gid, g in self._grants.items() if not g.active(now)]
+        for gid in expired:
+            del self._grants[gid]
+        return len(expired)
+
+    # -- candidate proposal (pure) -----------------------------------------
+    def propose(self, request: ApprovalRequest) -> list[CandidateGrant]:
+        """Tightest-first generalization candidates (≤4), each with a scope."""
+        op = request.operation
+        scope = self._default_scope(request)
+        wide = GrantScope(type=GrantScopeType.glob) if self._allow_global else scope
+        out: list[CandidateGrant] = []
+
+        def add(label: str, predicate: GrantPredicate, sc: GrantScope) -> None:
+            if len(out) < 4:
+                out.append(
+                    CandidateGrant(label=f"{label} · {_scope_label(sc)}", predicate=predicate, scope=sc)
+                )
+
+        if op.kind is OperationKind.command and op.command:
+            cmd = op.command
+            add(f"{cmd} {' '.join(op.args)}".strip(),
+                GrantPredicate(kind=op.kind, command=cmd, args=list(op.args), args_match=ArgMatchType.exact), scope)
+            if op.args:
+                add(f"{cmd} {op.args[0]} *",
+                    GrantPredicate(kind=op.kind, command=cmd, args=[op.args[0]], args_match=ArgMatchType.prefix), scope)
+            add(f"{cmd} *",
+                GrantPredicate(kind=op.kind, command=cmd, args=[], args_match=ArgMatchType.prefix), scope)
+            if self._allow_global:
+                add(f"{cmd} *",
+                    GrantPredicate(kind=op.kind, command=cmd, args=[], args_match=ArgMatchType.prefix), wide)
+        elif op.kind is OperationKind.network and op.remote_host:
+            host, port = op.remote_host, op.remote_port
+            add(f"{host}:{port}",
+                GrantPredicate(kind=op.kind, host=host, host_match=HostMatchType.exact, port=port), scope)
+            suffix = self._domain_suffix(host)
+            if suffix != host:
+                add(f"*{suffix}:{port}",
+                    GrantPredicate(kind=op.kind, host=suffix, host_match=HostMatchType.suffix, port=port), scope)
+            if self._allow_global:
+                add(f"{host}:{port}",
+                    GrantPredicate(kind=op.kind, host=host, host_match=HostMatchType.exact, port=port), wide)
+        elif op.kind is OperationKind.file and op.path:
+            add(f"file {op.path}",
+                GrantPredicate(kind=op.kind, paths=[op.path]), scope)
+            if request.workspace:
+                add("files under {workspace}",
+                    GrantPredicate(kind=op.kind, paths=["{workspace}/**"]), scope)
+        elif op.kind is OperationKind.signal:
+            add(f"signal {op.command or '*'}",
+                GrantPredicate(kind=op.kind, signal=op.command), scope)
+
+        # Broadest fallback rung: the policy rule (optional, FR-G6).
+        add(f"rule: {request.policy_rule_name}",
+            GrantPredicate(kind=op.kind, policy_rule_name=request.policy_rule_name), scope)
+        return out[:4]
+
+    def _default_scope(self, request: ApprovalRequest) -> GrantScope:
+        # Narrowest scope whose field the request actually carries (practical
+        # order: project → workspace → session → instance → global).
+        if request.project:
+            return GrantScope(type=GrantScopeType.project, value=request.project)
+        if request.workspace:
+            return GrantScope(type=GrantScopeType.workspace, value=request.workspace)
+        if request.session_id:
+            return GrantScope(type=GrantScopeType.session, value=request.session_id)
+        if request.instance_id:
+            return GrantScope(type=GrantScopeType.instance, value=request.instance_id)
+        return GrantScope(type=GrantScopeType.instance, value=self._instance_id)
+
+    @staticmethod
+    def _domain_suffix(host: str) -> str:
+        parts = host.split(".")
+        if len(parts) <= 2:
+            return host
+        return "." + ".".join(parts[1:])

--- a/src/remo_cli/notifier/logging_setup.py
+++ b/src/remo_cli/notifier/logging_setup.py
@@ -1,0 +1,96 @@
+"""structlog configuration for the notifier, with secret-safe redaction.
+
+INFO and above carry only structural metadata (approval_id, decision,
+latency_ms, transport, pending_count, ...). Sensitive values — the bot token,
+raw request bodies, and workspace paths — are stripped from any event that is
+not emitted at DEBUG level (FR-017, finding G1/SC-006).
+"""
+
+from __future__ import annotations
+
+import logging
+import sys
+from collections.abc import MutableMapping
+from typing import Any
+
+import structlog
+
+# Event keys that must never appear at INFO or above. Kept deliberately broad:
+# anything carrying a secret or a raw/unbounded payload belongs here.
+SENSITIVE_KEYS: frozenset[str] = frozenset(
+    {
+        "bot_token",
+        "token",
+        "authorization",
+        "secret",
+        "request_body",
+        "raw_body",
+        "body",
+        "workspace",
+        "policy_message",
+    }
+)
+
+_REDACTED = "[redacted]"
+
+
+def _redact_sensitive(
+    logger: Any, method_name: str, event_dict: MutableMapping[str, Any]
+) -> MutableMapping[str, Any]:
+    """Drop sensitive keys unless the event is logged at DEBUG level.
+
+    ``method_name`` is the bound log method ("debug", "info", ...). At DEBUG we
+    keep everything (developer opt-in); at every higher level the sensitive keys
+    are removed entirely so they cannot leak into journald.
+    """
+    if method_name == "debug":
+        return event_dict
+    for key in SENSITIVE_KEYS:
+        if key in event_dict:
+            event_dict[key] = _REDACTED
+    return event_dict
+
+
+def configure_logging(level: str = "info", *, json_logs: bool | None = None) -> None:
+    """Configure structlog + stdlib logging for the notifier process.
+
+    Args:
+        level: One of debug | info | warning | error.
+        json_logs: Force JSON rendering (True) or key-value rendering (False).
+            When None, JSON is used unless stdout is a TTY (so containers emit
+            JSON to journald while local dev stays human-readable).
+    """
+    numeric_level = getattr(logging, level.upper(), logging.INFO)
+
+    if json_logs is None:
+        json_logs = not sys.stdout.isatty()
+
+    renderer: structlog.types.Processor = (
+        structlog.processors.JSONRenderer()
+        if json_logs
+        else structlog.dev.ConsoleRenderer(colors=False)
+    )
+
+    logging.basicConfig(format="%(message)s", stream=sys.stdout, level=numeric_level)
+
+    structlog.configure(
+        processors=[
+            structlog.contextvars.merge_contextvars,
+            structlog.processors.add_log_level,
+            structlog.processors.TimeStamper(fmt="iso", utc=True),
+            _redact_sensitive,
+            structlog.processors.StackInfoRenderer(),
+            structlog.processors.format_exc_info,
+            renderer,
+        ],
+        wrapper_class=structlog.make_filtering_bound_logger(numeric_level),
+        logger_factory=structlog.PrintLoggerFactory(),
+        # Disabled so a later configure_logging() (e.g. log-level change, or a
+        # test reconfiguring) always takes effect; negligible at notifier volume.
+        cache_logger_on_first_use=False,
+    )
+
+
+def get_logger(name: str = "remo_notifier") -> structlog.stdlib.BoundLogger:
+    """Return a bound structlog logger."""
+    return structlog.get_logger(name)

--- a/src/remo_cli/notifier/models.py
+++ b/src/remo_cli/notifier/models.py
@@ -1,0 +1,122 @@
+"""Pydantic v2 models for the notifier wire protocol.
+
+These define the durable contract between agentsh (or any future emitter) and
+the notifier. See specs/007-notifier-sidecar/contracts/openapi.yaml and
+data-model.md.
+"""
+
+from __future__ import annotations
+
+import uuid
+from datetime import datetime, timezone
+from enum import Enum
+
+from pydantic import BaseModel, ConfigDict, Field, field_validator
+
+
+def _utcnow() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+class OperationKind(str, Enum):
+    command = "command"
+    file = "file"
+    network = "network"
+    signal = "signal"
+
+
+class OperationContext(str, Enum):
+    direct = "direct"
+    nested = "nested"
+
+
+class Decision(str, Enum):
+    allow = "allow"
+    deny = "deny"
+
+
+class Operation(BaseModel):
+    """The operation agentsh is asking a human to approve."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    kind: OperationKind
+    command: str | None = None
+    args: list[str] = Field(default_factory=list)
+    path: str | None = None
+    remote_host: str | None = None
+    remote_port: int | None = Field(default=None, ge=1, le=65535)
+    context: OperationContext = OperationContext.direct
+    depth: int = Field(default=0, ge=0)
+
+
+class ApprovalRequest(BaseModel):
+    """Inbound approval request (POST /v1/approve body)."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    approval_id: str | None = None
+    session_id: str | None = None
+    operation: Operation
+    policy_rule_name: str
+    policy_message: str
+    workspace: str | None = None
+    instance_id: str | None = None
+    project: str | None = None
+    timeout_seconds: int | None = Field(default=None, ge=1)
+    submitted_at: str | None = None
+
+    @field_validator("approval_id")
+    @classmethod
+    def _validate_uuid(cls, v: str | None) -> str | None:
+        if v is None:
+            return v
+        # Raises ValueError -> 422/400 if not a valid UUID string.
+        uuid.UUID(v)
+        return v
+
+
+class ApprovalDecision(BaseModel):
+    """Internal resolution value carried by a pending approval's Future."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    decision: Decision
+    responder: str
+    reason: str = ""
+    decided_at: datetime = Field(default_factory=_utcnow)
+    # Set when a human chose "Always" — the newly created grant's id, echoed
+    # back on the response (Addendum 001).
+    grant_id: str | None = None
+
+
+class ApprovalResponse(BaseModel):
+    """Outbound decision (POST /v1/approve response body)."""
+
+    approval_id: str
+    decision: Decision
+    responder: str
+    reason: str = ""
+    decided_at: datetime
+    latency_ms: int = Field(ge=0)
+    # Present on a standing-grant auto-approval (responder "rule:{id}") or on the
+    # response that created a grant via the "Always" tap (Addendum 001).
+    grant_id: str | None = None
+
+
+class HealthResponse(BaseModel):
+    """GET /v1/health body."""
+
+    status: str = "ok"
+    version: str
+    transport: str
+    uptime_seconds: int = Field(ge=0)
+    pending_approvals: int = Field(ge=0)
+
+
+class ErrorResponse(BaseModel):
+    """4xx / 503 error body (where not the 408 fail-secure deny shape)."""
+
+    error: str
+    detail: str = ""
+    approval_id: str | None = None

--- a/src/remo_cli/notifier/server.py
+++ b/src/remo_cli/notifier/server.py
@@ -1,0 +1,236 @@
+"""FastAPI app for the notifier.
+
+Holds the caller open until a decision exists, mapping outcomes through one
+fail-secure resolver: only an authorized human Approve yields ``allow``; every
+other terminal state is deny or a 5xx (FR-008, research R4). See
+contracts/openapi.yaml.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import time
+import uuid
+from contextlib import asynccontextmanager
+from datetime import datetime, timezone
+
+from fastapi import FastAPI, Request
+from fastapi.exceptions import RequestValidationError
+from fastapi.responses import JSONResponse
+
+from remo_cli.notifier import __version__
+from remo_cli.notifier.config import NotifierConfig
+from remo_cli.notifier.logging_setup import get_logger
+from remo_cli.notifier.models import (
+    ApprovalDecision,
+    ApprovalRequest,
+    ApprovalResponse,
+    Decision,
+    ErrorResponse,
+    HealthResponse,
+)
+from remo_cli.notifier.grants import GrantStore
+from remo_cli.notifier.state import PendingApprovals, RegisterError, RegistrationFailed
+from remo_cli.notifier.transports.base import NotificationTransport
+
+_log = get_logger("remo_notifier.server")
+
+
+def _op_summary(request: ApprovalRequest) -> str:
+    """Redacted one-line op descriptor for audit (no args/bodies/secrets/paths)."""
+    op = request.operation
+    if op.kind.value == "command":
+        return f"command:{op.command or '?'}"
+    if op.kind.value == "network":
+        return f"network:{op.remote_host or '?'}:{op.remote_port or '?'}"
+    if op.kind.value == "file":
+        return "file"  # path withheld (FR-017)
+    return op.kind.value
+
+
+def _clamp_timeout(requested: int | None, *, default: int, maximum: int) -> int:
+    value = requested if requested is not None else default
+    return max(1, min(value, maximum))
+
+
+def _err(status_code: int, error: str, detail: str = "", approval_id: str | None = None) -> JSONResponse:
+    body = ErrorResponse(error=error, detail=detail, approval_id=approval_id)
+    return JSONResponse(status_code=status_code, content=body.model_dump(mode="json"))
+
+
+def create_app(config: NotifierConfig, transport: NotificationTransport) -> FastAPI:
+    """Build the FastAPI app wired to ``transport`` and a fresh registry."""
+    registry = PendingApprovals(max_pending=config.approval.max_pending_approvals)
+    grant_store = GrantStore(
+        max_grants=config.grants.max_grants,
+        instance_id=config.instance.id,
+        allow_global_scope=config.grants.allow_global_scope,
+    )
+    # The server owns the auto-approval counter for the digest (research RG6/U1).
+    state: dict[str, object] = {
+        "shutting_down": False,
+        "start_time": time.monotonic(),
+        "auto_approvals_since_digest": 0,
+    }
+
+    # Let a grant-aware transport (Telegram) reach the store for proposals,
+    # creation, and /rules /revoke /pause. Other transports skip this.
+    if config.grants.enabled and hasattr(transport, "bind_grants"):
+        transport.bind_grants(grant_store, default_ttl_seconds=config.grants.default_ttl_seconds)
+
+    async def _sweeper() -> None:
+        while True:
+            await asyncio.sleep(60)
+            grant_store.sweep()
+
+    async def _digester(interval: int) -> None:
+        while True:
+            await asyncio.sleep(interval)
+            n = int(state["auto_approvals_since_digest"])  # type: ignore[call-overload]
+            if n > 0 and hasattr(transport, "send_digest"):
+                state["auto_approvals_since_digest"] = 0
+                try:
+                    await transport.send_digest(
+                        f"Auto-approved {n} operation(s) via standing grants "
+                        f"({grant_store.count()} active)."
+                    )
+                except Exception:  # noqa: BLE001 - digest is best-effort
+                    _log.debug("digest_send_failed")
+
+    @asynccontextmanager
+    async def lifespan(app: FastAPI):
+        state["start_time"] = time.monotonic()
+        try:
+            await transport.start()
+        except Exception as exc:  # noqa: BLE001
+            # A transport that can't start (bad token, no network) must not take
+            # down liveness: /v1/health stays up; /v1/approve returns 503 while
+            # the transport reports unhealthy (FR-007).
+            _log.error("transport_start_failed", error=str(exc), transport=transport.name)
+        tasks = [asyncio.create_task(_sweeper())] if config.grants.enabled else []
+        if config.grants.enabled and config.grants.digest_interval_seconds > 0:
+            tasks.append(asyncio.create_task(_digester(config.grants.digest_interval_seconds)))
+        try:
+            yield
+        finally:
+            state["shutting_down"] = True
+            for t in tasks:
+                t.cancel()
+            registry.drain(
+                ApprovalDecision(
+                    decision=Decision.deny, responder="system:shutdown", reason="shutdown"
+                )
+            )
+            await transport.stop()
+
+    app = FastAPI(title="remo-notifier", version=__version__, lifespan=lifespan)
+
+    @app.exception_handler(RequestValidationError)
+    async def _on_validation_error(request: Request, exc: RequestValidationError) -> JSONResponse:
+        # FR-001: schema validation failure -> 400 (not FastAPI's default 422).
+        return _err(400, "validation_error", detail=str(exc.errors()))
+
+    @app.post("/v1/approve")
+    async def approve(request: ApprovalRequest) -> JSONResponse:
+        # Standing-grant short-circuit (Addendum 001, FR-G1): before anything
+        # else, auto-approve a matching class with no notification and no slot.
+        if config.grants.enabled and not grant_store.paused:
+            sc_started = time.monotonic()
+            matched = grant_store.match(request)
+            if matched is not None:
+                state["auto_approvals_since_digest"] = int(state["auto_approvals_since_digest"]) + 1  # type: ignore[call-overload]
+                _log.info(
+                    "auto_approved",
+                    approval_id=request.approval_id or "(generated)",
+                    grant_id=matched.grant_id,
+                    kind=request.operation.kind.value,
+                    summary=_op_summary(request),
+                    latency_ms=int((time.monotonic() - sc_started) * 1000),
+                )
+                resp = ApprovalResponse(
+                    approval_id=request.approval_id or str(uuid.uuid4()),
+                    decision=Decision.allow,
+                    responder=f"rule:{matched.grant_id}",
+                    reason="auto-approved via standing grant",
+                    decided_at=datetime.now(timezone.utc),
+                    latency_ms=int((time.monotonic() - sc_started) * 1000),
+                    grant_id=matched.grant_id,
+                )
+                return JSONResponse(status_code=200, content=resp.model_dump(mode="json"))
+
+        if state["shutting_down"] or not await transport.healthy():
+            return _err(503, "unavailable", detail="notifier not ready")
+
+        approval_id = request.approval_id or str(uuid.uuid4())
+        effective_timeout = _clamp_timeout(
+            request.timeout_seconds,
+            default=config.approval.default_timeout_seconds,
+            maximum=config.approval.max_timeout_seconds,
+        )
+        # Normalize so the transport renders the effective values.
+        request.approval_id = approval_id
+        request.timeout_seconds = effective_timeout
+
+        try:
+            entry = await registry.reserve(approval_id, request)
+        except RegistrationFailed as exc:
+            if exc.reason is RegisterError.duplicate:
+                return _err(409, "duplicate_approval_id", approval_id=approval_id)
+            return _err(503, "unavailable", detail="at capacity", approval_id=approval_id)
+
+        started = time.monotonic()
+
+        def _on_response(decision: ApprovalDecision) -> None:
+            registry.resolve(approval_id, decision)
+
+        try:
+            await transport.send_approval_request(request, on_response=_on_response)
+        except Exception:  # noqa: BLE001 - any send failure is fail-secure 503 (FR-010a)
+            await registry.release(approval_id)
+            _log.info("send_failed", approval_id=approval_id)
+            return _err(503, "unavailable", detail="notification delivery failed", approval_id=approval_id)
+
+        # Await the reserved entry's future directly: resolve() pops the entry
+        # from the registry but the future object stays valid, so this works
+        # even if the decision arrived synchronously during send.
+        try:
+            decision = await asyncio.wait_for(entry.future, timeout=effective_timeout)
+        except (asyncio.TimeoutError, TimeoutError):
+            registry.discard(approval_id)
+            await transport.cancel(approval_id, outcome="timeout")
+            latency_ms = int((time.monotonic() - started) * 1000)
+            timeout_resp = ApprovalResponse(
+                approval_id=approval_id,
+                decision=Decision.deny,
+                responder="system:timeout",
+                reason="timeout",
+                decided_at=datetime.now(timezone.utc),
+                latency_ms=latency_ms,
+            )
+            return JSONResponse(status_code=408, content=timeout_resp.model_dump(mode="json"))
+
+        latency_ms = int((time.monotonic() - started) * 1000)
+        resp = ApprovalResponse(
+            approval_id=approval_id,
+            decision=decision.decision,
+            responder=decision.responder,
+            reason=decision.reason,
+            decided_at=decision.decided_at,
+            latency_ms=latency_ms,
+            grant_id=decision.grant_id,  # set when the human chose "Always"
+        )
+        return JSONResponse(status_code=200, content=resp.model_dump(mode="json"))
+
+    @app.get("/v1/health")
+    async def health() -> HealthResponse:
+        return HealthResponse(
+            status="ok",
+            version=__version__,
+            transport=transport.name,
+            uptime_seconds=int(time.monotonic() - float(state["start_time"])),  # type: ignore[arg-type]
+            pending_approvals=registry.count(),
+        )
+
+    app.state.registry = registry  # exposed for tests
+    app.state.grant_store = grant_store  # exposed for tests
+    return app

--- a/src/remo_cli/notifier/state.py
+++ b/src/remo_cli/notifier/state.py
@@ -1,0 +1,120 @@
+"""In-memory registry of pending approvals.
+
+No persistence (FR-009). A registry-level lock makes the capacity gate (FR-034)
+and duplicate-id gate (FR-003a) race-free; the send-after-reserve flow honors
+FR-010a (no slot held for a request whose notification failed). See
+data-model.md and research R2.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from enum import Enum
+
+from remo_cli.notifier.models import ApprovalDecision, ApprovalRequest
+
+
+def _utcnow() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+class RegisterError(str, Enum):
+    duplicate = "duplicate"
+    at_capacity = "at_capacity"
+
+
+class RegistrationFailed(Exception):
+    """Raised when a slot cannot be reserved (duplicate id or at capacity)."""
+
+    def __init__(self, reason: RegisterError) -> None:
+        super().__init__(reason.value)
+        self.reason = reason
+
+
+@dataclass
+class PendingApproval:
+    approval_id: str
+    request: ApprovalRequest
+    future: asyncio.Future[ApprovalDecision]
+    created_at: datetime = field(default_factory=_utcnow)
+
+
+class PendingApprovals:
+    """Concurrency-safe registry keyed by approval_id."""
+
+    def __init__(self, max_pending: int) -> None:
+        self._max_pending = max_pending
+        self._entries: dict[str, PendingApproval] = {}
+        self._lock = asyncio.Lock()
+
+    def count(self) -> int:
+        return len(self._entries)
+
+    async def reserve(self, approval_id: str, request: ApprovalRequest) -> PendingApproval:
+        """Atomically reserve a slot + id and return a live PendingApproval.
+
+        Raises RegistrationFailed(duplicate) if the id is already pending, or
+        RegistrationFailed(at_capacity) if the registry is full. The caller MUST
+        call ``release()`` if a later step (e.g. notification send) fails so the
+        slot is not held for an undelivered request (FR-010a).
+        """
+        async with self._lock:
+            if approval_id in self._entries:
+                raise RegistrationFailed(RegisterError.duplicate)
+            if len(self._entries) >= self._max_pending:
+                raise RegistrationFailed(RegisterError.at_capacity)
+            loop = asyncio.get_running_loop()
+            entry = PendingApproval(
+                approval_id=approval_id,
+                request=request,
+                future=loop.create_future(),
+            )
+            self._entries[approval_id] = entry
+            return entry
+
+    async def release(self, approval_id: str) -> None:
+        """Drop a reserved-but-unsent entry, freeing its slot (FR-010a)."""
+        async with self._lock:
+            entry = self._entries.pop(approval_id, None)
+        if entry is not None and not entry.future.done():
+            entry.future.cancel()
+
+    def discard(self, approval_id: str) -> None:
+        """Remove an entry without resolving (used after a timeout)."""
+        self._entries.pop(approval_id, None)
+
+    def resolve(self, approval_id: str, decision: ApprovalDecision) -> bool:
+        """Resolve a pending approval with a decision.
+
+        Returns True if it was pending and is now resolved; False if unknown or
+        already resolved (late/duplicate callbacks are no-ops, FR-012).
+        Loop-safe: invoked from the same event loop as the awaiter.
+        """
+        entry = self._entries.pop(approval_id, None)
+        if entry is None:
+            return False
+        if not entry.future.done():
+            entry.future.set_result(decision)
+        return True
+
+    async def wait(self, approval_id: str, timeout: float) -> ApprovalDecision:
+        """Await the decision for a pending approval, bounded by ``timeout``.
+
+        Raises asyncio.TimeoutError on expiry (caller maps to fail-secure deny)
+        and KeyError if the id is not registered.
+        """
+        entry = self._entries.get(approval_id)
+        if entry is None:
+            raise KeyError(approval_id)
+        return await asyncio.wait_for(entry.future, timeout=timeout)
+
+    def drain(self, decision: ApprovalDecision) -> list[str]:
+        """Resolve every pending approval (shutdown). Returns the drained ids."""
+        ids = list(self._entries.keys())
+        for approval_id in ids:
+            entry = self._entries.pop(approval_id, None)
+            if entry is not None and not entry.future.done():
+                entry.future.set_result(decision)
+        return ids

--- a/src/remo_cli/notifier/transports/__init__.py
+++ b/src/remo_cli/notifier/transports/__init__.py
@@ -1,0 +1,8 @@
+"""Notification transports for the remo notifier.
+
+Each transport delivers an approval request to a human and reports their
+decision back. Telegram is the only implementation in v1; additional backends
+subclass :class:`~remo_cli.notifier.transports.base.NotificationTransport`.
+"""
+
+from __future__ import annotations

--- a/src/remo_cli/notifier/transports/base.py
+++ b/src/remo_cli/notifier/transports/base.py
@@ -1,0 +1,64 @@
+"""The NotificationTransport abstract base class.
+
+The notifier core depends only on this interface; Telegram is the sole v1
+implementation. See specs/007-notifier-sidecar/contracts/transport.md.
+"""
+
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from collections.abc import Callable
+
+from remo_cli.notifier.models import ApprovalDecision, ApprovalRequest
+
+ResponseCallback = Callable[[ApprovalDecision], None]
+
+
+class NotificationTransport(ABC):
+    """Delivers approval requests to a human and reports their decision.
+
+    Lifecycle: ``start()`` once at app startup; ``stop()`` once at shutdown.
+    Between them the server calls ``send_approval_request()`` per accepted
+    request and may call ``cancel()`` to retract one resolved by other means.
+    """
+
+    #: Human-facing transport name, surfaced in GET /v1/health.
+    name: str = "base"
+
+    @abstractmethod
+    async def start(self) -> None:
+        """Begin receiving human input (e.g. start long-polling). Idempotent."""
+
+    @abstractmethod
+    async def stop(self) -> None:
+        """Stop receiving input and release resources.
+
+        Idempotent and safe to call after a failed ``start()``.
+        """
+
+    @abstractmethod
+    async def send_approval_request(
+        self,
+        request: ApprovalRequest,
+        on_response: ResponseCallback,
+    ) -> None:
+        """Deliver one request to the human.
+
+        MUST raise on delivery failure (the server maps this to 503 and holds no
+        pending slot — FR-010a). On success, returns once the notification has
+        been delivered; the human's eventual authorized tap invokes
+        ``on_response(decision)`` exactly once. ``on_response`` is synchronous
+        and loop-safe; it resolves the pending approval's Future.
+        """
+
+    @abstractmethod
+    async def cancel(self, approval_id: str, *, outcome: str = "cancelled") -> None:
+        """Retract a still-displayed request (resolved elsewhere / on shutdown).
+
+        ``outcome`` is one of ``"timeout"`` or ``"cancelled"`` and selects the
+        human-facing message edit. Idempotent; a no-op for unknown ids.
+        """
+
+    async def healthy(self) -> bool:
+        """Readiness signal. When False, the server answers /v1/approve 503."""
+        return True

--- a/src/remo_cli/notifier/transports/telegram.py
+++ b/src/remo_cli/notifier/transports/telegram.py
@@ -1,0 +1,356 @@
+"""Telegram notification transport (long-polling).
+
+Built on python-telegram-bot's Application, driven via the low-level
+initialize/start/updater.start_polling API so it shares the FastAPI/uvicorn
+event loop (research R1) — never run_polling(), never webhook mode (FR-014).
+See contracts/telegram-message.md.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from typing import Any
+
+from telegram import InlineKeyboardButton, InlineKeyboardMarkup, Update
+from telegram.ext import Application, CallbackQueryHandler, CommandHandler, ContextTypes
+
+from remo_cli.notifier.grants import CandidateGrant, Grant, GrantLimitReached, GrantStore
+from remo_cli.notifier.logging_setup import get_logger
+from remo_cli.notifier.models import ApprovalDecision, ApprovalRequest, Decision
+from remo_cli.notifier.transports.base import NotificationTransport, ResponseCallback
+
+_MD_V2_SPECIAL = r"_*[]()~`>#+-=|{}.!"
+
+
+def escape_md_v2(text: str) -> str:
+    """Escape text for Telegram MarkdownV2."""
+    return re.sub(r"([" + re.escape(_MD_V2_SPECIAL) + r"\\])", r"\\\1", text)
+
+
+@dataclass
+class _Sent:
+    chat_id: int
+    message_id: int
+    on_response: ResponseCallback
+    request: ApprovalRequest | None = None
+    candidates: list[CandidateGrant] = field(default_factory=list)
+
+
+class TelegramTransport(NotificationTransport):
+    name = "telegram"
+
+    def __init__(
+        self,
+        *,
+        token: str,
+        authorized_chat_id: int,
+        instance_id: str,
+        parse_mode: str = "MarkdownV2",
+        application: Application | None = None,
+    ) -> None:
+        self._authorized_chat_id = authorized_chat_id
+        self._instance_id = instance_id
+        self._parse_mode = parse_mode
+        self._log = get_logger("remo_notifier.telegram")
+        self._sent: dict[str, _Sent] = {}
+        self._started = False
+        # Standing grants (Addendum 001) — bound by the server via bind_grants().
+        self._grant_store: GrantStore | None = None
+        self._grant_ttl = 28800
+        # `application` is injectable for tests (a Bot mock).
+        self._app = application or Application.builder().token(token).build()
+        self._app.add_handler(CallbackQueryHandler(self._on_callback))
+        self._app.add_handler(CommandHandler("rules", self._cmd_rules))
+        self._app.add_handler(CommandHandler("revoke", self._cmd_revoke))
+        self._app.add_handler(CommandHandler("pause", self._cmd_pause))
+        self._app.add_handler(CommandHandler("resume", self._cmd_resume))
+
+    def bind_grants(self, store: GrantStore, *, default_ttl_seconds: int) -> None:
+        """Attach the grant store so the Always flow + /rules /revoke /pause work."""
+        self._grant_store = store
+        self._grant_ttl = default_ttl_seconds
+
+    def set_token(self, token: str) -> None:
+        """Stage a refreshed bot token (applied on the next start()).
+
+        Best-effort secret rotation via SIGHUP (research R6). A live swap of an
+        already-polling Application is out of scope for v1.
+        """
+        self._pending_token = token
+
+    # -- lifecycle ----------------------------------------------------------
+    async def start(self) -> None:
+        if self._started:
+            return
+        await self._app.initialize()
+        await self._app.start()
+        if self._app.updater is not None:
+            await self._app.updater.start_polling()
+        self._started = True
+        self._log.info("transport_started", transport=self.name)
+
+    async def stop(self) -> None:
+        if not self._started:
+            return
+        try:
+            if self._app.updater is not None:
+                await self._app.updater.stop()
+            await self._app.stop()
+            await self._app.shutdown()
+        finally:
+            self._started = False
+            self._log.info("transport_stopped", transport=self.name)
+
+    async def healthy(self) -> bool:
+        return self._started
+
+    # -- delivery -----------------------------------------------------------
+    def _render(self, request: ApprovalRequest, timeout_seconds: int) -> str:
+        op = request.operation
+        command = op.command or "—"
+        args = " ".join(op.args)
+        operation = f"{op.kind.value}: {command} {args}".strip()
+        instance = request.instance_id or self._instance_id
+        if timeout_seconds >= 60:
+            window = f"{timeout_seconds // 60} minutes"
+        else:
+            window = f"{timeout_seconds} seconds"
+        e = escape_md_v2
+        return (
+            "🔐 Approval requested\n\n"
+            f"*Project:* {e(request.project or '—')}\n"
+            f"*Operation:* {e(operation)}\n"
+            f"*Rule:* {e(request.policy_rule_name)}\n"
+            f"*Message:* {e(request.policy_message)}\n"
+            f"*Instance:* {e(instance)}\n\n"
+            f"Decide within {e(window)}\\."
+        )
+
+    async def send_approval_request(
+        self,
+        request: ApprovalRequest,
+        on_response: ResponseCallback,
+    ) -> None:
+        approval_id = request.approval_id
+        assert approval_id is not None  # server assigns before send
+        timeout_seconds = request.timeout_seconds or 0
+        row = [
+            InlineKeyboardButton("✅ Approve", callback_data=f"approve:{approval_id}"),
+            InlineKeyboardButton("❌ Deny", callback_data=f"deny:{approval_id}"),
+        ]
+        if self._grant_store is not None:
+            row.insert(1, InlineKeyboardButton("⏩ Always…", callback_data=f"always:{approval_id}"))
+        keyboard = InlineKeyboardMarkup([row])
+        # Raises on delivery failure -> server maps to 503, holds no slot.
+        message = await self._app.bot.send_message(
+            chat_id=self._authorized_chat_id,
+            text=self._render(request, timeout_seconds),
+            reply_markup=keyboard,
+            parse_mode=self._parse_mode,
+        )
+        self._sent[approval_id] = _Sent(
+            chat_id=self._authorized_chat_id,
+            message_id=message.message_id,
+            on_response=on_response,
+            request=request,
+        )
+        self._log.info("approval_sent", approval_id=approval_id, transport=self.name)
+
+    async def cancel(self, approval_id: str, *, outcome: str = "cancelled") -> None:
+        sent = self._sent.pop(approval_id, None)
+        if sent is None:
+            return
+        suffix = (
+            "⌛ Timed out — denied (fail-secure)"
+            if outcome == "timeout"
+            else "🚫 Cancelled — resolved elsewhere"
+        )
+        await self._edit(sent, suffix)
+
+    # -- callbacks ----------------------------------------------------------
+    @staticmethod
+    def _responder(query: Any) -> str:
+        user = getattr(query, "from_user", None)
+        return f"telegram:{user.username or user.id}" if user is not None else "telegram:unknown"
+
+    @staticmethod
+    def _username(query: Any) -> str:
+        user = getattr(query, "from_user", None)
+        return user.username if user is not None else "?"
+
+    def _authorized(self, query: Any) -> bool:
+        msg = getattr(query, "message", None)
+        chat = getattr(msg, "chat", None)
+        return chat is not None and chat.id == self._authorized_chat_id
+
+    async def _on_callback(self, update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
+        query = update.callback_query
+        if query is None or query.data is None:
+            return
+        if not self._authorized(query):  # FR-011
+            await query.answer("Not authorized.")
+            return
+        data = query.data
+        if data.startswith(("approve:", "deny:")):
+            await self._handle_decision(query, data)
+        elif data.startswith("always:"):
+            await self._handle_always(query, data.split(":", 1)[1])
+        elif data.startswith("pick:"):
+            await self._handle_pick(query, data)
+        elif data.startswith("revoke:"):
+            await self._handle_revoke_cb(query, data.split(":", 1)[1])
+        else:
+            await query.answer()
+
+    async def _handle_decision(self, query: Any, data: str) -> None:
+        verb, approval_id = data.split(":", maxsplit=1)
+        sent = self._sent.pop(approval_id, None)
+        if sent is None:
+            await query.answer("Already decided or expired.")  # FR-012
+            return
+        decision = Decision.allow if verb == "approve" else Decision.deny
+        now = datetime.now(timezone.utc)
+        word, icon = ("Approved", "✅") if decision is Decision.allow else ("Denied", "❌")
+        user = getattr(query, "from_user", None)
+        await self._edit(sent, f"{icon} {word} by @{user.username if user else '?'} at {now:%H:%M}")
+        await query.answer()
+        sent.on_response(ApprovalDecision(decision=decision, responder=self._responder(query), decided_at=now))
+        self._log.info("approval_decided", approval_id=approval_id, decision=decision.value)
+
+    async def _handle_always(self, query: Any, approval_id: str) -> None:
+        sent = self._sent.get(approval_id)  # keep pending; only show the picker
+        if sent is None or sent.request is None or self._grant_store is None:
+            await query.answer("Expired.")
+            return
+        sent.candidates = self._grant_store.propose(sent.request)
+        rows = [
+            [InlineKeyboardButton(c.label, callback_data=f"pick:{approval_id}:{i}")]
+            for i, c in enumerate(sent.candidates)
+        ]
+        rows.append([InlineKeyboardButton("Cancel", callback_data=f"pick:{approval_id}:cancel")])
+        await self._app.bot.edit_message_reply_markup(
+            chat_id=sent.chat_id, message_id=sent.message_id, reply_markup=InlineKeyboardMarkup(rows)
+        )
+        await query.answer()
+
+    async def _handle_pick(self, query: Any, data: str) -> None:
+        _, approval_id, sel = data.split(":", maxsplit=2)
+        sent = self._sent.get(approval_id)
+        if sent is None or self._grant_store is None:
+            await query.answer("Expired.")
+            return
+        if sel == "cancel":
+            await self._restore_keyboard(sent, approval_id)
+            await query.answer("Cancelled.")
+            return
+        try:
+            candidate = sent.candidates[int(sel)]
+        except (ValueError, IndexError):
+            await query.answer()
+            return
+        now = datetime.now(timezone.utc)
+        created_by = self._responder(query)
+        grant = Grant.create(
+            predicate=candidate.predicate, scope=candidate.scope,
+            ttl_seconds=self._grant_ttl, created_by=created_by,
+            source_approval_id=approval_id, now=now,
+        )
+        try:
+            await self._grant_store.create(grant)
+            note = f"⏩ Always: {candidate.label} · by @{self._username(query)}"
+            grant_id = grant.grant_id
+        except GrantLimitReached:
+            note = "⚠️ Grant limit reached — approved once, not remembered."
+            grant_id = None
+        self._sent.pop(approval_id, None)
+        await self._edit(sent, note)
+        await query.answer()
+        sent.on_response(
+            ApprovalDecision(decision=Decision.allow, responder=created_by, decided_at=now, grant_id=grant_id)
+        )
+        self._log.info("grant_created", approval_id=approval_id, grant_id=grant_id)
+
+    async def _restore_keyboard(self, sent: _Sent, approval_id: str) -> None:
+        row = [
+            InlineKeyboardButton("✅ Approve", callback_data=f"approve:{approval_id}"),
+            InlineKeyboardButton("⏩ Always…", callback_data=f"always:{approval_id}"),
+            InlineKeyboardButton("❌ Deny", callback_data=f"deny:{approval_id}"),
+        ]
+        try:
+            await self._app.bot.edit_message_reply_markup(
+                chat_id=sent.chat_id, message_id=sent.message_id, reply_markup=InlineKeyboardMarkup([row])
+            )
+        except Exception:  # noqa: BLE001
+            self._log.debug("restore_keyboard_failed", message_id=sent.message_id)
+
+    # -- slash commands (authorized chat only) ------------------------------
+    def _cmd_authorized(self, update: Update) -> bool:
+        chat = getattr(update, "effective_chat", None)
+        return chat is not None and chat.id == self._authorized_chat_id
+
+    async def _reply(self, update: Update, text: str) -> None:
+        msg = getattr(update, "effective_message", None)
+        if msg is not None:
+            await msg.reply_text(text)
+
+    async def _cmd_rules(self, update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
+        if not self._cmd_authorized(update) or self._grant_store is None:
+            return
+        grants = self._grant_store.list_active()
+        if not grants:
+            await self._reply(update, "No active standing grants.")
+            return
+        lines = []
+        for g in grants:
+            lines.append(
+                f"{g.grant_id[:8]} · {g.predicate.kind.value} · scope={g.scope.type.value} "
+                f"· uses={g.uses_count} · /revoke {g.grant_id}"
+            )
+        await self._reply(update, "Active grants:\n" + "\n".join(lines))
+
+    async def _cmd_revoke(self, update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
+        if not self._cmd_authorized(update) or self._grant_store is None:
+            return
+        args = getattr(context, "args", None) or []
+        if not args:
+            await self._reply(update, "Usage: /revoke <grant_id>")
+            return
+        ok = await self._grant_store.revoke(args[0])
+        await self._reply(update, "Revoked." if ok else "No such grant.")
+
+    async def _handle_revoke_cb(self, query: Any, grant_id: str) -> None:
+        if self._grant_store is not None:
+            await self._grant_store.revoke(grant_id)
+        await query.answer("Revoked.")
+
+    async def _cmd_pause(self, update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
+        if not self._cmd_authorized(update) or self._grant_store is None:
+            return
+        self._grant_store.set_paused(True)
+        await self._reply(update, "Auto-approval paused. Use /resume to re-enable.")
+
+    async def _cmd_resume(self, update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
+        if not self._cmd_authorized(update) or self._grant_store is None:
+            return
+        self._grant_store.set_paused(False)
+        await self._reply(update, "Auto-approval resumed.")
+
+    async def send_digest(self, summary: str) -> None:
+        """Proactively message the authorized chat an auto-approval summary."""
+        await self._app.bot.send_message(
+            chat_id=self._authorized_chat_id, text=escape_md_v2(summary), parse_mode=self._parse_mode
+        )
+
+    async def _edit(self, sent: _Sent, suffix: str) -> None:
+        try:
+            await self._app.bot.edit_message_text(
+                chat_id=sent.chat_id,
+                message_id=sent.message_id,
+                text=escape_md_v2(suffix),
+                parse_mode=self._parse_mode,
+                reply_markup=None,
+            )
+        except Exception:  # noqa: BLE001 - edit failures must never block resolution
+            self._log.debug("edit_failed", message_id=sent.message_id)

--- a/tests/notifier/conftest.py
+++ b/tests/notifier/conftest.py
@@ -1,0 +1,124 @@
+"""Shared fixtures for notifier tests (T008)."""
+
+from __future__ import annotations
+
+import textwrap
+from pathlib import Path
+
+import pytest
+
+from remo_cli.notifier.config import NotifierConfig, load_config
+from remo_cli.notifier.models import ApprovalDecision, ApprovalRequest, Decision
+from remo_cli.notifier.transports.base import NotificationTransport, ResponseCallback
+
+
+class FakeTransport(NotificationTransport):
+    """A controllable transport for server/state tests.
+
+    - ``fail_send``: raise on the next send (simulates FR-010a delivery failure).
+    - ``auto_resolve``: if set, resolve the request synchronously inside send
+      (makes the POST non-blocking for sync TestClient tests).
+    - ``healthy_flag``: drives ``healthy()``.
+    """
+
+    name = "fake"
+
+    def __init__(self) -> None:
+        self.started = False
+        self.stopped = False
+        self.fail_send = False
+        self.healthy_flag = True
+        self.auto_resolve: Decision | None = None
+        self.sent: list[ApprovalRequest] = []
+        self.cancelled: list[tuple[str, str]] = []
+        self._callbacks: dict[str, ResponseCallback] = {}
+
+    async def start(self) -> None:
+        self.started = True
+
+    async def stop(self) -> None:
+        self.stopped = True
+
+    async def healthy(self) -> bool:
+        return self.healthy_flag
+
+    async def send_approval_request(
+        self, request: ApprovalRequest, on_response: ResponseCallback
+    ) -> None:
+        if self.fail_send:
+            raise RuntimeError("send failed")
+        self.sent.append(request)
+        assert request.approval_id is not None
+        self._callbacks[request.approval_id] = on_response
+        if self.auto_resolve is not None:
+            on_response(
+                ApprovalDecision(decision=self.auto_resolve, responder="telegram:tester")
+            )
+
+    async def cancel(self, approval_id: str, *, outcome: str = "cancelled") -> None:
+        self.cancelled.append((approval_id, outcome))
+
+    def human_decides(self, approval_id: str, decision: Decision) -> None:
+        """Test helper: simulate a human tapping a button."""
+        self._callbacks[approval_id](
+            ApprovalDecision(decision=decision, responder="telegram:tester")
+        )
+
+
+@pytest.fixture
+def fake_transport() -> FakeTransport:
+    return FakeTransport()
+
+
+@pytest.fixture
+def token_file(tmp_path: Path) -> Path:
+    p = tmp_path / "telegram_token"
+    p.write_text("12345:FAKE-TOKEN")
+    return p
+
+
+@pytest.fixture
+def config_toml(tmp_path: Path, token_file: Path) -> Path:
+    p = tmp_path / "notifier.toml"
+    p.write_text(
+        textwrap.dedent(
+            f"""
+            [server]
+            listen_host = "127.0.0.1"
+            listen_port = 18181
+            log_level = "info"
+
+            [approval]
+            default_timeout_seconds = 300
+            max_timeout_seconds = 1800
+            max_pending_approvals = 50
+
+            [transport]
+            type = "telegram"
+
+            [transport.telegram]
+            bot_token_file = "{token_file}"
+            authorized_chat_id = 987654321
+            message_parse_mode = "MarkdownV2"
+
+            [instance]
+            id = "test-instance"
+            """
+        ).strip()
+    )
+    return p
+
+
+@pytest.fixture
+def config(config_toml: Path) -> NotifierConfig:
+    return load_config(config_toml)
+
+
+def make_request(**overrides) -> ApprovalRequest:
+    data = {
+        "operation": {"kind": "command", "command": "rm", "args": ["-rf", "/tmp/x"]},
+        "policy_rule_name": "demo",
+        "policy_message": "approve rm?",
+    }
+    data.update(overrides)
+    return ApprovalRequest.model_validate(data)

--- a/tests/notifier/test_cli_notifier.py
+++ b/tests/notifier/test_cli_notifier.py
@@ -1,0 +1,142 @@
+"""Tests for the `remo notifier` CLI subcommands (T020, T032, T034).
+
+SSH and ansible-runner seams are mocked; no host is contacted.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+from types import SimpleNamespace
+
+import pytest
+from click.testing import CliRunner
+
+from remo_cli.cli import notifier as nmod
+from remo_cli.cli.notifier import notifier
+from remo_cli.models.host import KnownHost
+
+HOST = KnownHost(type="hetzner", name="box", host="5.6.7.8", user="remo")
+
+
+@pytest.fixture(autouse=True)
+def _patch_common(monkeypatch):
+    # Resolve always returns our fake host; build context is a fixed path.
+    monkeypatch.setattr(nmod, "resolve_remo_host", lambda name: HOST)
+    monkeypatch.setattr(nmod, "_ensure_build_context", lambda: "/tmp/ctx")
+    monkeypatch.setattr(nmod, "build_ssh_opts", lambda host: (["-o", "X=Y"], "remo@5.6.7.8"))
+
+
+def _completed(rc=0, stdout="") -> subprocess.CompletedProcess:
+    return subprocess.CompletedProcess(args=[], returncode=rc, stdout=stdout, stderr="")
+
+
+# --------------------------------------------------------------------------- deploy (T020 / US2)
+def test_deploy_invokes_playbook(monkeypatch):
+    monkeypatch.setenv("REMO_NOTIFIER_TELEGRAM_BOT_TOKEN", "12345:T")
+    monkeypatch.setenv("REMO_NOTIFIER_TELEGRAM_CHAT_ID", "987")
+    captured = {}
+
+    def fake_run(playbook, extra_vars=None, verbose=False):
+        captured["playbook"] = playbook
+        captured["extra_vars"] = extra_vars
+        return 0
+
+    monkeypatch.setattr(nmod, "run_playbook", fake_run)
+    result = CliRunner().invoke(notifier, ["deploy", "box"])
+    assert result.exit_code == 0
+    assert captured["playbook"] == "notifier_deploy.yml"
+    ev = captured["extra_vars"]
+    assert "-i" in ev and "5.6.7.8," in ev
+    assert "ansible_user=remo" in ev
+    assert any("remo_notifier_build_context_local=/tmp/ctx" == x for x in ev)
+
+
+def test_deploy_rebuild_flag(monkeypatch):
+    monkeypatch.setenv("REMO_NOTIFIER_TELEGRAM_BOT_TOKEN", "12345:T")
+    monkeypatch.setenv("REMO_NOTIFIER_TELEGRAM_CHAT_ID", "987")
+    captured = {}
+
+    def fake_run(p, extra_vars=None, verbose=False):
+        captured["ev"] = extra_vars
+        return 0
+
+    monkeypatch.setattr(nmod, "run_playbook", fake_run)
+    result = CliRunner().invoke(notifier, ["deploy", "box", "--rebuild"])
+    assert result.exit_code == 0
+    assert "remo_notifier_force_rebuild=true" in captured["ev"]
+
+
+def test_deploy_missing_creds_aborts(monkeypatch):
+    monkeypatch.delenv("REMO_NOTIFIER_TELEGRAM_BOT_TOKEN", raising=False)
+    monkeypatch.delenv("REMO_NOTIFIER_TELEGRAM_CHAT_ID", raising=False)
+    called = {"ran": False}
+    monkeypatch.setattr(nmod, "run_playbook", lambda *a, **k: called.update(ran=True) or 0)
+    result = CliRunner().invoke(notifier, ["deploy", "box"])
+    assert result.exit_code == 1
+    assert "Missing Telegram credentials" in result.output
+    assert called["ran"] is False
+
+
+# --------------------------------------------------------------------------- status (T034 / US4)
+def test_status_renders_health(monkeypatch):
+    health = {"status": "ok", "pending_approvals": 0}
+    monkeypatch.setattr(nmod, "_ssh_run", lambda h, cmd, capture=False: _completed(0, json.dumps(health)))
+    result = CliRunner().invoke(notifier, ["status", "box"])
+    assert result.exit_code == 0
+    assert '"status": "ok"' in result.output
+
+
+def test_status_unreachable(monkeypatch):
+    monkeypatch.setattr(nmod, "_ssh_run", lambda h, cmd, capture=False: _completed(7, ""))
+    result = CliRunner().invoke(notifier, ["status", "box"])
+    assert result.exit_code == 1
+    assert "unreachable" in result.output
+
+
+# --------------------------------------------------------------------------- logs (T034 / US4)
+def test_logs_builds_journalctl(monkeypatch):
+    seen = {}
+
+    def fake_ssh(host, cmd, capture=False):
+        seen["cmd"] = cmd
+        return _completed(0)
+
+    monkeypatch.setattr(nmod, "_ssh_run", fake_ssh)
+    result = CliRunner().invoke(notifier, ["logs", "box", "--follow", "--lines", "50"])
+    assert result.exit_code == 0
+    assert "journalctl -u remo-notifier.service -n 50 -f" == seen["cmd"]
+
+
+# --------------------------------------------------------------------------- restart (T034 / US4)
+def test_restart_runs_systemctl(monkeypatch):
+    seen = {}
+    monkeypatch.setattr(nmod, "_ssh_run", lambda h, cmd, capture=False: seen.update(cmd=cmd) or _completed(0))
+    result = CliRunner().invoke(notifier, ["restart", "box"])
+    assert result.exit_code == 0
+    assert seen["cmd"] == "sudo systemctl restart remo-notifier.service"
+
+
+# --------------------------------------------------------------------------- test (T032 / US3)
+def test_test_command_posts_and_reports(monkeypatch):
+    seen = {}
+
+    def fake_ssh(host, cmd, capture=False):
+        seen["cmd"] = cmd
+        return _completed(0, json.dumps({"decision": "allow", "responder": "telegram:p"}))
+
+    monkeypatch.setattr(nmod, "_ssh_run", fake_ssh)
+    result = CliRunner().invoke(notifier, ["test", "box"])
+    assert result.exit_code == 0
+    assert '"decision": "allow"' in result.output
+    # canonical test payload labels present in the remote curl body
+    assert "policy_rule_name" in seen["cmd"]
+    assert "test" in seen["cmd"]
+    assert "/v1/approve" in seen["cmd"]
+
+
+def test_test_command_unreachable(monkeypatch):
+    monkeypatch.setattr(nmod, "_ssh_run", lambda h, cmd, capture=False: _completed(7, ""))
+    result = CliRunner().invoke(notifier, ["test", "box"])
+    assert result.exit_code == 1
+    assert "unreachable" in result.output

--- a/tests/notifier/test_cli_serve.py
+++ b/tests/notifier/test_cli_serve.py
@@ -1,0 +1,61 @@
+"""Tests for the `remo-notifier serve` CLI (T018/T019 coverage)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from click.testing import CliRunner
+
+from remo_cli.notifier import cli as notifier_cli
+from remo_cli.notifier.cli import build_transport, main
+
+from .conftest import FakeTransport
+
+
+def test_help() -> None:
+    result = CliRunner().invoke(main, ["--help"])
+    assert result.exit_code == 0
+    assert "notifier" in result.output.lower()
+
+
+def test_serve_bad_config_exits(tmp_path: Path) -> None:
+    result = CliRunner().invoke(main, ["serve", "--config", str(tmp_path / "absent.toml")])
+    assert result.exit_code == 1
+    assert "invalid notifier config" in result.output
+
+
+def test_serve_runs_with_mocked_uvicorn(config_toml, monkeypatch) -> None:
+    captured = {}
+
+    def fake_run(app, **kwargs):
+        captured["host"] = kwargs.get("host")
+        captured["port"] = kwargs.get("port")
+
+    fake = FakeTransport()
+    monkeypatch.setattr(notifier_cli, "build_transport", lambda cfg: fake)
+
+    import uvicorn
+
+    monkeypatch.setattr(uvicorn, "run", fake_run)
+
+    result = CliRunner().invoke(main, ["serve", "--config", str(config_toml)])
+    assert result.exit_code == 0
+    assert captured["host"] == "127.0.0.1"
+    assert captured["port"] == 18181
+
+
+def test_build_transport_telegram(config, monkeypatch) -> None:
+    # Patch the concrete transport so no real PTB Application is constructed.
+    created = {}
+
+    class _FakeTg:
+        def __init__(self, **kwargs):
+            created.update(kwargs)
+
+    monkeypatch.setattr(
+        "remo_cli.notifier.transports.telegram.TelegramTransport", _FakeTg
+    )
+    build_transport(config)
+    assert created["authorized_chat_id"] == 987654321
+    assert created["instance_id"] == "test-instance"
+    assert created["token"] == "12345:FAKE-TOKEN"

--- a/tests/notifier/test_config.py
+++ b/tests/notifier/test_config.py
@@ -1,0 +1,131 @@
+"""Tests for the notifier config loader (T009)."""
+
+from __future__ import annotations
+
+import textwrap
+from pathlib import Path
+
+import pytest
+
+from remo_cli.notifier.config import load_config
+
+
+def _write(tmp_path: Path, body: str) -> Path:
+    p = tmp_path / "notifier.toml"
+    p.write_text(textwrap.dedent(body).strip())
+    return p
+
+
+def _base(token_file: Path, **overrides: str) -> str:
+    approval = overrides.get(
+        "approval",
+        "default_timeout_seconds = 300\nmax_timeout_seconds = 1800\nmax_pending_approvals = 50",
+    )
+    return f"""
+        [server]
+        listen_host = "0.0.0.0"
+        listen_port = 18181
+        log_level = "info"
+
+        [approval]
+        {approval}
+
+        [transport]
+        type = "telegram"
+
+        [transport.telegram]
+        bot_token_file = "{token_file}"
+        authorized_chat_id = 987654321
+
+        [instance]
+        id = "h1"
+    """
+
+
+def test_valid_config_loads(tmp_path: Path, token_file: Path) -> None:
+    cfg = load_config(_write(tmp_path, _base(token_file)))
+    assert cfg.server.listen_port == 18181
+    assert cfg.approval.max_pending_approvals == 50
+    assert cfg.transport.telegram is not None
+    assert cfg.transport.telegram.authorized_chat_id == 987654321
+
+
+def test_unknown_top_level_key_rejected(tmp_path: Path, token_file: Path) -> None:
+    body = _base(token_file) + '\n[surprise]\nx = 1\n'
+    with pytest.raises(ValueError):
+        load_config(_write(tmp_path, body))
+
+
+def test_max_below_default_rejected(tmp_path: Path, token_file: Path) -> None:
+    body = _base(token_file, approval="default_timeout_seconds = 600\nmax_timeout_seconds = 300")
+    with pytest.raises(ValueError):
+        load_config(_write(tmp_path, body))
+
+
+def test_missing_file_raises(tmp_path: Path) -> None:
+    with pytest.raises(FileNotFoundError):
+        load_config(tmp_path / "nope.toml")
+
+
+def test_non_telegram_transport_rejected(tmp_path: Path, token_file: Path) -> None:
+    body = _base(token_file).replace('type = "telegram"', 'type = "slack"')
+    with pytest.raises(ValueError):
+        load_config(_write(tmp_path, body))
+
+
+def test_token_read_from_file(tmp_path: Path, token_file: Path) -> None:
+    cfg = load_config(_write(tmp_path, _base(token_file)))
+    assert cfg.transport.telegram is not None
+    assert cfg.transport.telegram.read_token() == "12345:FAKE-TOKEN"
+
+
+def test_empty_token_file_fails(tmp_path: Path) -> None:
+    empty = tmp_path / "empty_token"
+    empty.write_text("   ")
+    cfg = load_config(_write(tmp_path, _base(empty)))
+    assert cfg.transport.telegram is not None
+    with pytest.raises(ValueError):
+        cfg.transport.telegram.read_token()
+
+
+def test_missing_token_file_fails(tmp_path: Path) -> None:
+    cfg = load_config(_write(tmp_path, _base(tmp_path / "absent")))
+    assert cfg.transport.telegram is not None
+    with pytest.raises(ValueError):
+        cfg.transport.telegram.read_token()
+
+
+# --- GrantsConfig (Addendum 001, TA003a) ------------------------------------
+def test_grants_defaults(tmp_path: Path, token_file: Path) -> None:
+    cfg = load_config(_write(tmp_path, _base(token_file)))
+    assert cfg.grants.enabled is True
+    assert cfg.grants.default_ttl_seconds == 28800
+    assert cfg.grants.max_grants == 100
+    assert cfg.grants.allow_global_scope is True
+    assert cfg.grants.digest_interval_seconds == 3600
+
+
+def test_grants_block_parses(tmp_path: Path, token_file: Path) -> None:
+    body = _base(token_file) + (
+        '\n[grants]\nenabled = false\ndefault_ttl_seconds = 600\n'
+        'max_grants = 5\nallow_global_scope = false\ndigest_interval_seconds = 0\n'
+    )
+    cfg = load_config(_write(tmp_path, body))
+    assert cfg.grants.enabled is False
+    assert cfg.grants.default_ttl_seconds == 600
+    assert cfg.grants.max_grants == 5
+    assert cfg.grants.allow_global_scope is False
+    assert cfg.grants.digest_interval_seconds == 0  # disables digest
+
+
+def test_grants_unknown_key_rejected(tmp_path: Path, token_file: Path) -> None:
+    body = _base(token_file) + '\n[grants]\nsurprise = 1\n'
+    with pytest.raises(ValueError):
+        load_config(_write(tmp_path, body))
+
+
+def test_grants_bad_bounds_rejected(tmp_path: Path, token_file: Path) -> None:
+    for line in ("default_ttl_seconds = 0", "max_grants = 0"):
+        body = _base(token_file) + f"\n[grants]\n{line}\n"
+        with pytest.raises(ValueError):
+            load_config(_write(tmp_path, body))

--- a/tests/notifier/test_grants.py
+++ b/tests/notifier/test_grants.py
@@ -1,0 +1,224 @@
+"""Tests for standing grants — store, matcher, proposer (TA008, Addendum 001)."""
+
+from __future__ import annotations
+
+import asyncio
+from datetime import timedelta, timezone
+
+import pytest
+
+from remo_cli.notifier.grants import (
+    ArgMatchType,
+    Grant,
+    GrantLimitReached,
+    GrantPredicate,
+    GrantScope,
+    GrantScopeType,
+    GrantStore,
+    HostMatchType,
+    _utcnow,
+)
+from remo_cli.notifier.models import OperationKind
+
+from .conftest import make_request
+
+INSTANCE = "inst-1"
+
+
+def _store(max_grants: int = 100, allow_global: bool = True) -> GrantStore:
+    return GrantStore(max_grants=max_grants, instance_id=INSTANCE, allow_global_scope=allow_global)
+
+
+def _grant(predicate: GrantPredicate, scope: GrantScope, ttl: int = 3600) -> Grant:
+    return Grant.create(
+        predicate=predicate, scope=scope, ttl_seconds=ttl,
+        created_by="telegram:t", source_approval_id="a",
+    )
+
+
+# --- predicate matching -----------------------------------------------------
+def test_command_exact_match() -> None:
+    req = make_request(project="p", operation={"kind": "command", "command": "git", "args": ["push", "origin"]})
+    pred = GrantPredicate(kind=OperationKind.command, command="git", args=["push", "origin"], args_match=ArgMatchType.exact)
+    assert pred.matches(req) is True
+    req2 = make_request(operation={"kind": "command", "command": "git", "args": ["status"]})
+    assert pred.matches(req2) is False
+
+
+def test_command_prefix_match() -> None:
+    pred = GrantPredicate(kind=OperationKind.command, command="git", args=["push"], args_match=ArgMatchType.prefix)
+    assert pred.matches(make_request(operation={"kind": "command", "command": "git", "args": ["push", "origin", "main"]})) is True
+    assert pred.matches(make_request(operation={"kind": "command", "command": "git", "args": ["pull"]})) is False
+
+
+def test_command_only_prefix_empty_matches_any_args() -> None:
+    pred = GrantPredicate(kind=OperationKind.command, command="npm", args=[], args_match=ArgMatchType.prefix)
+    assert pred.matches(make_request(operation={"kind": "command", "command": "npm", "args": ["install", "x"]})) is True
+
+
+def test_command_glob_match() -> None:
+    pred = GrantPredicate(kind=OperationKind.command, command="git", args=["push", "*"], args_match=ArgMatchType.glob)
+    assert pred.matches(make_request(operation={"kind": "command", "command": "git", "args": ["push", "origin"]})) is True
+    assert pred.matches(make_request(operation={"kind": "command", "command": "git", "args": ["push"]})) is False  # len mismatch
+
+
+def test_network_exact_and_suffix() -> None:
+    req = make_request(operation={"kind": "network", "remote_host": "api.github.com", "remote_port": 443})
+    assert GrantPredicate(kind=OperationKind.network, host="api.github.com", port=443).matches(req) is True
+    assert GrantPredicate(kind=OperationKind.network, host=".github.com", host_match=HostMatchType.suffix, port=443).matches(req) is True
+    assert GrantPredicate(kind=OperationKind.network, host=".gitlab.com", host_match=HostMatchType.suffix, port=443).matches(req) is False
+
+
+def test_network_port_none_means_any() -> None:
+    req = make_request(operation={"kind": "network", "remote_host": "h", "remote_port": 8080})
+    assert GrantPredicate(kind=OperationKind.network, host="h", port=None).matches(req) is True
+
+
+def test_file_path_glob_with_workspace() -> None:
+    req = make_request(workspace="/home/me/proj", operation={"kind": "file", "path": "/home/me/proj/a/b.txt"})
+    assert GrantPredicate(kind=OperationKind.file, paths=["{workspace}/**"]).matches(req) is True
+    req2 = make_request(workspace="/home/me/proj", operation={"kind": "file", "path": "/etc/passwd"})
+    assert GrantPredicate(kind=OperationKind.file, paths=["{workspace}/**"]).matches(req2) is False
+
+
+def test_file_unresolved_workspace_fails_closed() -> None:
+    req = make_request(operation={"kind": "file", "path": "/x"})  # no workspace on request
+    assert GrantPredicate(kind=OperationKind.file, paths=["{workspace}/**"]).matches(req) is False
+
+
+def test_kind_mismatch_is_false() -> None:
+    pred = GrantPredicate(kind=OperationKind.command, command="git")
+    assert pred.matches(make_request(operation={"kind": "network", "remote_host": "h"})) is False
+
+
+def test_policy_rule_rung() -> None:
+    req = make_request(policy_rule_name="vcs-push", operation={"kind": "command", "command": "git", "args": ["push"]})
+    pred = GrantPredicate(kind=OperationKind.command, policy_rule_name="vcs-push")
+    assert pred.matches(req) is True
+    req2 = make_request(policy_rule_name="other", operation={"kind": "command", "command": "git", "args": ["push"]})
+    assert pred.matches(req2) is False
+
+
+# --- scope matching ---------------------------------------------------------
+def test_scope_project_equality_and_missing() -> None:
+    sc = GrantScope(type=GrantScopeType.project, value="p")
+    assert sc.matches(make_request(project="p"), instance_id=INSTANCE) is True
+    assert sc.matches(make_request(project="q"), instance_id=INSTANCE) is False
+    assert sc.matches(make_request(), instance_id=INSTANCE) is False  # missing → fail-closed
+
+
+def test_scope_global_always() -> None:
+    assert GrantScope(type=GrantScopeType.glob).matches(make_request(), instance_id=INSTANCE) is True
+
+
+def test_scope_instance_fallback() -> None:
+    sc = GrantScope(type=GrantScopeType.instance, value=INSTANCE)
+    # request lacks instance_id → falls back to configured instance id (exception to fail-closed)
+    assert sc.matches(make_request(), instance_id=INSTANCE) is True
+
+
+# --- store ------------------------------------------------------------------
+@pytest.mark.asyncio
+async def test_create_match_and_usage() -> None:
+    store = _store()
+    g = _grant(GrantPredicate(kind=OperationKind.command, command="git", args=[], args_match=ArgMatchType.prefix),
+               GrantScope(type=GrantScopeType.project, value="p"))
+    await store.create(g)
+    req = make_request(project="p", operation={"kind": "command", "command": "git", "args": ["status"]})
+    matched = store.match(req)
+    assert matched is g
+    assert g.uses_count == 1 and g.last_used_at is not None
+
+
+@pytest.mark.asyncio
+async def test_paused_returns_none() -> None:
+    store = _store()
+    await store.create(_grant(GrantPredicate(kind=OperationKind.command, command="git", args=[], args_match=ArgMatchType.prefix),
+                              GrantScope(type=GrantScopeType.glob)))
+    store.set_paused(True)
+    assert store.match(make_request(operation={"kind": "command", "command": "git", "args": ["x"]})) is None
+
+
+@pytest.mark.asyncio
+async def test_expired_never_matches() -> None:
+    store = _store()
+    g = _grant(GrantPredicate(kind=OperationKind.command, command="git", args=[], args_match=ArgMatchType.prefix),
+               GrantScope(type=GrantScopeType.glob), ttl=-1)  # already expired
+    await store.create(g)
+    assert store.match(make_request(operation={"kind": "command", "command": "git", "args": ["x"]})) is None
+
+
+@pytest.mark.asyncio
+async def test_revoke() -> None:
+    store = _store()
+    g = _grant(GrantPredicate(kind=OperationKind.command, command="git", args=[], args_match=ArgMatchType.prefix),
+               GrantScope(type=GrantScopeType.glob))
+    await store.create(g)
+    assert await store.revoke(g.grant_id) is True
+    assert await store.revoke(g.grant_id) is False
+    assert store.match(make_request(operation={"kind": "command", "command": "git", "args": ["x"]})) is None
+
+
+@pytest.mark.asyncio
+async def test_capacity_raises() -> None:
+    store = _store(max_grants=1)
+    await store.create(_grant(GrantPredicate(kind=OperationKind.command, command="a"), GrantScope(type=GrantScopeType.glob)))
+    with pytest.raises(GrantLimitReached):
+        await store.create(_grant(GrantPredicate(kind=OperationKind.command, command="b"), GrantScope(type=GrantScopeType.glob)))
+
+
+@pytest.mark.asyncio
+async def test_concurrent_create_respects_cap() -> None:
+    store = _store(max_grants=5)
+
+    async def mk(i: int) -> bool:
+        try:
+            await store.create(_grant(GrantPredicate(kind=OperationKind.command, command=f"c{i}"), GrantScope(type=GrantScopeType.glob)))
+            return True
+        except GrantLimitReached:
+            return False
+
+    results = await asyncio.gather(*(mk(i) for i in range(20)))
+    assert sum(results) == 5
+    assert store.count() == 5
+
+
+def test_sweep_drops_expired() -> None:
+    store = _store()
+    now = _utcnow()
+    g = _grant(GrantPredicate(kind=OperationKind.command, command="a"), GrantScope(type=GrantScopeType.glob), ttl=10)
+    g.expires_at = now - timedelta(seconds=1)
+    store._grants[g.grant_id] = g
+    assert store.sweep(now) == 1
+    assert store.count() == 0
+
+
+def test_fresh_store_is_empty_restart_fail_closed() -> None:
+    # SC-G5: a new process holds no grants → re-prompts.
+    assert _store().count() == 0
+    assert _store().match(make_request(operation={"kind": "command", "command": "git", "args": ["x"]})) is None
+
+
+# --- proposer ---------------------------------------------------------------
+def test_propose_command_tightest_first_capped() -> None:
+    req = make_request(project="p", operation={"kind": "command", "command": "git", "args": ["push", "origin"]})
+    cands = _store().propose(req)
+    assert 1 <= len(cands) <= 4
+    # tightest first = exact args
+    assert cands[0].predicate.args_match is ArgMatchType.exact
+    assert cands[0].predicate.args == ["push", "origin"]
+    # default scope is project (narrow), not global
+    assert cands[0].scope.type is GrantScopeType.project
+    # a widened (global) rung is offered when allowed
+    assert any(c.scope.type is GrantScopeType.glob for c in cands)
+
+
+def test_propose_network_includes_suffix() -> None:
+    req = make_request(project="p", operation={"kind": "network", "remote_host": "api.github.com", "remote_port": 443})
+    cands = _store().propose(req)
+    assert any(c.predicate.host_match is HostMatchType.suffix and c.predicate.host == ".github.com" for c in cands)
+
+
+def test_propose_default_scope_not_global() -> None:
+    req = make_request(project="p", operation={"kind": "command", "command": "ls"})
+    assert _store().propose(req)[0].scope.type is not GrantScopeType.glob

--- a/tests/notifier/test_logging_setup.py
+++ b/tests/notifier/test_logging_setup.py
@@ -1,0 +1,57 @@
+"""Tests for secret-safe logging (T007a, finding G1 / SC-006 / FR-017)."""
+
+from __future__ import annotations
+
+import json
+
+from remo_cli.notifier import logging_setup
+
+
+def test_sensitive_keys_redacted_at_info(capsys) -> None:
+    logging_setup.configure_logging(level="debug", json_logs=True)
+    log = logging_setup.get_logger("test")
+
+    log.info(
+        "approval_received",
+        approval_id="abc",
+        decision="allow",
+        bot_token="12345:SECRET",
+        workspace="/home/me/project",
+        policy_message="please approve rm -rf",
+    )
+
+    line = capsys.readouterr().out.strip().splitlines()[-1]
+    event = json.loads(line)
+
+    # Structural fields survive.
+    assert event["approval_id"] == "abc"
+    assert event["decision"] == "allow"
+    # Sensitive fields are redacted, not present verbatim.
+    assert event["bot_token"] == "[redacted]"
+    assert event["workspace"] == "[redacted]"
+    assert event["policy_message"] == "[redacted]"
+    assert "12345:SECRET" not in line
+    assert "/home/me/project" not in line
+
+
+def test_sensitive_keys_kept_at_debug(capsys) -> None:
+    logging_setup.configure_logging(level="debug", json_logs=True)
+    log = logging_setup.get_logger("test")
+
+    log.debug("debug_detail", bot_token="12345:SECRET", workspace="/home/me/project")
+
+    line = capsys.readouterr().out.strip().splitlines()[-1]
+    event = json.loads(line)
+
+    # At DEBUG, developer opt-in keeps full detail.
+    assert event["bot_token"] == "12345:SECRET"
+    assert event["workspace"] == "/home/me/project"
+
+
+def test_info_suppressed_when_level_is_warning(capsys) -> None:
+    logging_setup.configure_logging(level="warning", json_logs=True)
+    log = logging_setup.get_logger("test")
+
+    log.info("should_not_appear", approval_id="abc")
+    out = capsys.readouterr().out
+    assert "should_not_appear" not in out

--- a/tests/notifier/test_models.py
+++ b/tests/notifier/test_models.py
@@ -1,0 +1,80 @@
+"""Unit tests for the notifier wire-protocol models (T007)."""
+
+from __future__ import annotations
+
+import uuid
+
+import pytest
+from pydantic import ValidationError
+
+from remo_cli.notifier.models import (
+    ApprovalRequest,
+    Decision,
+    Operation,
+    OperationKind,
+)
+
+
+def _valid_request_dict() -> dict:
+    return {
+        "operation": {"kind": "command", "command": "rm", "args": ["-rf", "/tmp/x"]},
+        "policy_rule_name": "demo",
+        "policy_message": "approve rm?",
+    }
+
+
+def test_valid_request_round_trips() -> None:
+    req = ApprovalRequest.model_validate(_valid_request_dict())
+    assert req.operation.kind is OperationKind.command
+    assert req.operation.args == ["-rf", "/tmp/x"]
+    assert req.timeout_seconds is None
+    assert req.approval_id is None
+
+
+def test_unknown_field_rejected() -> None:
+    bad = _valid_request_dict() | {"surprise": 1}
+    with pytest.raises(ValidationError):
+        ApprovalRequest.model_validate(bad)
+
+
+def test_unknown_operation_field_rejected() -> None:
+    bad = _valid_request_dict()
+    bad["operation"]["surprise"] = 1
+    with pytest.raises(ValidationError):
+        ApprovalRequest.model_validate(bad)
+
+
+def test_bad_uuid_rejected() -> None:
+    bad = _valid_request_dict() | {"approval_id": "not-a-uuid"}
+    with pytest.raises(ValidationError):
+        ApprovalRequest.model_validate(bad)
+
+
+def test_valid_uuid_accepted() -> None:
+    good = _valid_request_dict() | {"approval_id": str(uuid.uuid4())}
+    req = ApprovalRequest.model_validate(good)
+    assert req.approval_id is not None
+
+
+def test_bad_enum_rejected() -> None:
+    bad = _valid_request_dict()
+    bad["operation"]["kind"] = "teleport"
+    with pytest.raises(ValidationError):
+        ApprovalRequest.model_validate(bad)
+
+
+@pytest.mark.parametrize("port", [0, 65536, -1])
+def test_port_bounds(port: int) -> None:
+    with pytest.raises(ValidationError):
+        Operation.model_validate({"kind": "network", "remote_port": port})
+
+
+def test_negative_timeout_rejected() -> None:
+    bad = _valid_request_dict() | {"timeout_seconds": 0}
+    with pytest.raises(ValidationError):
+        ApprovalRequest.model_validate(bad)
+
+
+def test_decision_enum_values() -> None:
+    assert Decision.allow.value == "allow"
+    assert Decision.deny.value == "deny"

--- a/tests/notifier/test_packaging.py
+++ b/tests/notifier/test_packaging.py
@@ -1,0 +1,46 @@
+"""Packaging guard (T044a / SC-007): the base install must not pull notifier deps."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+try:
+    import tomllib as toml
+except ModuleNotFoundError:  # pragma: no cover
+    import tomli as toml  # type: ignore[import-not-found, no-redef]
+
+_NOTIFIER_DEP_NAMES = {"fastapi", "uvicorn", "pydantic", "python-telegram-bot", "structlog"}
+
+
+def _project_root() -> Path:
+    here = Path(__file__).resolve()
+    for parent in here.parents:
+        if (parent / "pyproject.toml").is_file():
+            return parent
+    raise RuntimeError("pyproject.toml not found")
+
+
+def _names(specs: list[str]) -> set[str]:
+    out = set()
+    for spec in specs:
+        name = spec.split(";")[0].split("[")[0]
+        for sep in (">=", "<=", "==", "~=", ">", "<", "!="):
+            name = name.split(sep)[0]
+        out.add(name.strip())
+    return out
+
+
+def test_base_dependencies_exclude_notifier_runtime() -> None:
+    data = toml.loads((_project_root() / "pyproject.toml").read_text())
+    base = _names(data["project"]["dependencies"])
+    assert not (base & _NOTIFIER_DEP_NAMES), (
+        f"notifier runtime deps leaked into base dependencies: {base & _NOTIFIER_DEP_NAMES}"
+    )
+
+
+def test_notifier_extra_declares_runtime_deps() -> None:
+    data = toml.loads((_project_root() / "pyproject.toml").read_text())
+    extra = _names(data["project"]["optional-dependencies"]["notifier"])
+    assert _NOTIFIER_DEP_NAMES <= extra, (
+        f"notifier extra missing expected deps: {_NOTIFIER_DEP_NAMES - extra}"
+    )

--- a/tests/notifier/test_server.py
+++ b/tests/notifier/test_server.py
@@ -1,0 +1,235 @@
+"""Tests for the FastAPI server and all status codes (T011)."""
+
+from __future__ import annotations
+
+import uuid
+
+import pytest
+from httpx import ASGITransport, AsyncClient
+
+from remo_cli.notifier.grants import (
+    ArgMatchType,
+    Grant,
+    GrantPredicate,
+    GrantScope,
+    GrantScopeType,
+)
+from remo_cli.notifier.models import Decision, OperationKind
+from remo_cli.notifier.server import create_app
+
+from .conftest import make_request
+
+
+def _global_git_grant() -> Grant:
+    return Grant.create(
+        predicate=GrantPredicate(kind=OperationKind.command, command="git", args=[], args_match=ArgMatchType.prefix),
+        scope=GrantScope(type=GrantScopeType.glob),
+        ttl_seconds=3600, created_by="telegram:t", source_approval_id="x",
+    )
+
+
+
+def _client(app) -> AsyncClient:
+    return AsyncClient(transport=ASGITransport(app=app), base_url="http://test")
+
+
+def _body(**overrides) -> dict:
+    return make_request(**overrides).model_dump(mode="json")
+
+
+async def test_health(config, fake_transport) -> None:
+    app = create_app(config, fake_transport)
+    async with _client(app) as client:
+        resp = await client.get("/v1/health")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["status"] == "ok"
+    assert data["transport"] == "fake"
+    assert data["pending_approvals"] == 0
+    assert "version" in data
+
+
+async def test_approve_allow(config, fake_transport) -> None:
+    fake_transport.auto_resolve = Decision.allow
+    app = create_app(config, fake_transport)
+    async with _client(app) as client:
+        resp = await client.post("/v1/approve", json=_body())
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["decision"] == "allow"
+    assert data["responder"] == "telegram:tester"
+    assert data["latency_ms"] >= 0
+    assert data["approval_id"]
+
+
+async def test_approve_deny(config, fake_transport) -> None:
+    fake_transport.auto_resolve = Decision.deny
+    app = create_app(config, fake_transport)
+    async with _client(app) as client:
+        resp = await client.post("/v1/approve", json=_body())
+    assert resp.status_code == 200
+    assert resp.json()["decision"] == "deny"
+
+
+async def test_validation_error_400(config, fake_transport) -> None:
+    app = create_app(config, fake_transport)
+    async with _client(app) as client:
+        resp = await client.post("/v1/approve", json={"unknown": 1})
+    assert resp.status_code == 400
+    assert resp.json()["error"] == "validation_error"
+
+
+async def test_timeout_408(config, fake_transport) -> None:
+    # No auto-resolve and no human => times out.
+    app = create_app(config, fake_transport)
+    async with _client(app) as client:
+        resp = await client.post("/v1/approve", json=_body(timeout_seconds=1))
+    assert resp.status_code == 408
+    data = resp.json()
+    assert data["decision"] == "deny"
+    assert data["reason"] == "timeout"
+    # The transport was asked to edit the message with the timeout outcome.
+    assert fake_transport.cancelled[0][1] == "timeout"
+
+
+async def test_duplicate_409(config, fake_transport) -> None:
+    dup = str(uuid.uuid4())
+    app = create_app(config, fake_transport)
+    await app.state.registry.reserve(dup, make_request())
+    async with _client(app) as client:
+        resp = await client.post("/v1/approve", json=_body(approval_id=dup))
+    assert resp.status_code == 409
+    assert resp.json()["error"] == "duplicate_approval_id"
+
+
+async def test_capacity_503(config, fake_transport) -> None:
+    config.approval.max_pending_approvals = 1
+    app = create_app(config, fake_transport)
+    await app.state.registry.reserve("held", make_request())
+    async with _client(app) as client:
+        resp = await client.post("/v1/approve", json=_body())
+    assert resp.status_code == 503
+    assert resp.json()["detail"] == "at capacity"
+
+
+async def test_unhealthy_transport_503(config, fake_transport) -> None:
+    fake_transport.healthy_flag = False
+    app = create_app(config, fake_transport)
+    async with _client(app) as client:
+        resp = await client.post("/v1/approve", json=_body())
+    assert resp.status_code == 503
+
+
+async def test_send_failure_503_releases_slot(config, fake_transport) -> None:
+    fake_transport.fail_send = True
+    app = create_app(config, fake_transport)
+    async with _client(app) as client:
+        resp = await client.post("/v1/approve", json=_body())
+    assert resp.status_code == 503
+    assert resp.json()["detail"] == "notification delivery failed"
+    # FR-010a: no pending slot held for an undelivered request.
+    assert app.state.registry.count() == 0
+
+
+def test_lifespan_starts_and_stops_transport(config, fake_transport) -> None:
+    # TestClient as a context manager runs the FastAPI lifespan (startup +
+    # shutdown), covering transport start/stop and the drain on shutdown.
+    from fastapi.testclient import TestClient
+
+    app = create_app(config, fake_transport)
+    with TestClient(app) as client:
+        assert fake_transport.started is True
+        assert client.get("/v1/health").status_code == 200
+    assert fake_transport.stopped is True
+
+
+async def test_grant_short_circuit_allows(config, fake_transport) -> None:
+    app = create_app(config, fake_transport)
+    g = _global_git_grant()
+    await app.state.grant_store.create(g)
+    async with _client(app) as client:
+        resp = await client.post(
+            "/v1/approve", json=_body(operation={"kind": "command", "command": "git", "args": ["push"]})
+        )
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["decision"] == "allow"
+    assert data["responder"] == f"rule:{g.grant_id}"
+    assert data["grant_id"] == g.grant_id
+    assert fake_transport.sent == []  # FR-G1: no notification
+    assert app.state.registry.count() == 0  # no pending slot
+    assert g.uses_count == 1
+
+
+async def test_non_matching_request_falls_through(config, fake_transport) -> None:
+    fake_transport.auto_resolve = Decision.allow
+    app = create_app(config, fake_transport)
+    await app.state.grant_store.create(_global_git_grant())
+    async with _client(app) as client:
+        resp = await client.post(
+            "/v1/approve", json=_body(operation={"kind": "command", "command": "npm", "args": ["install"]})
+        )
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["responder"] == "telegram:tester"  # went through the transport
+    assert data["grant_id"] is None
+    assert len(fake_transport.sent) == 1
+
+
+async def test_grants_disabled_skips_short_circuit(config, fake_transport) -> None:
+    config.grants.enabled = False
+    fake_transport.auto_resolve = Decision.allow
+    app = create_app(config, fake_transport)
+    await app.state.grant_store.create(_global_git_grant())
+    async with _client(app) as client:
+        resp = await client.post(
+            "/v1/approve", json=_body(operation={"kind": "command", "command": "git", "args": ["push"]})
+        )
+    assert resp.json()["responder"] == "telegram:tester"  # not auto-approved
+
+
+async def test_paused_skips_short_circuit(config, fake_transport) -> None:
+    fake_transport.auto_resolve = Decision.allow
+    app = create_app(config, fake_transport)
+    await app.state.grant_store.create(_global_git_grant())
+    app.state.grant_store.set_paused(True)
+    async with _client(app) as client:
+        resp = await client.post(
+            "/v1/approve", json=_body(operation={"kind": "command", "command": "git", "args": ["push"]})
+        )
+    assert resp.json()["responder"] == "telegram:tester"
+
+
+async def test_auto_approval_audit_log_has_no_secrets(config, fake_transport, capsys) -> None:
+    # SC-G4 / FR-G11 / FR-017: structural log with grant_id, no workspace/body.
+    from remo_cli.notifier.logging_setup import configure_logging
+
+    configure_logging(level="info", json_logs=True)
+    app = create_app(config, fake_transport)
+    g = _global_git_grant()
+    await app.state.grant_store.create(g)
+    async with _client(app) as client:
+        await client.post(
+            "/v1/approve",
+            json=_body(
+                workspace="/secret/workspace/path",
+                operation={"kind": "command", "command": "git", "args": ["push"]},
+            ),
+        )
+    out = capsys.readouterr().out
+    assert "auto_approved" in out
+    assert g.grant_id in out
+    assert "/secret/workspace/path" not in out  # workspace withheld
+
+
+async def test_timeout_clamped_to_max(config, fake_transport) -> None:
+    # G2/FR-006: an over-max request is clamped; we assert the effective timeout
+    # used is the configured max by checking the request handed to the transport.
+    config.approval.max_timeout_seconds = 1
+    config.approval.default_timeout_seconds = 1
+    app = create_app(config, fake_transport)
+    async with _client(app) as client:
+        resp = await client.post("/v1/approve", json=_body(timeout_seconds=9999))
+    # No human responds; clamped to 1s -> 408 quickly.
+    assert resp.status_code == 408
+    assert fake_transport.sent[0].timeout_seconds == 1

--- a/tests/notifier/test_state.py
+++ b/tests/notifier/test_state.py
@@ -1,0 +1,115 @@
+"""Tests for the PendingApprovals registry (T010)."""
+
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+from remo_cli.notifier.models import ApprovalDecision, Decision
+from remo_cli.notifier.state import (
+    PendingApprovals,
+    RegisterError,
+    RegistrationFailed,
+)
+
+from .conftest import make_request
+
+
+
+def _allow() -> ApprovalDecision:
+    return ApprovalDecision(decision=Decision.allow, responder="telegram:t")
+
+
+async def test_register_and_resolve() -> None:
+    reg = PendingApprovals(max_pending=10)
+    await reg.reserve("a", make_request())
+    assert reg.count() == 1
+
+    async def resolver() -> None:
+        await asyncio.sleep(0.01)
+        assert reg.resolve("a", _allow()) is True
+
+    asyncio.create_task(resolver())
+    decision = await reg.wait("a", timeout=1.0)
+    assert decision.decision is Decision.allow
+    assert reg.count() == 0
+
+
+async def test_timeout_raises() -> None:
+    reg = PendingApprovals(max_pending=10)
+    await reg.reserve("a", make_request())
+    with pytest.raises((asyncio.TimeoutError, TimeoutError)):
+        await reg.wait("a", timeout=0.05)
+
+
+async def test_duplicate_rejected() -> None:
+    reg = PendingApprovals(max_pending=10)
+    await reg.reserve("a", make_request())
+    with pytest.raises(RegistrationFailed) as exc:
+        await reg.reserve("a", make_request())
+    assert exc.value.reason is RegisterError.duplicate
+
+
+async def test_capacity_rejected() -> None:
+    reg = PendingApprovals(max_pending=1)
+    await reg.reserve("a", make_request())
+    with pytest.raises(RegistrationFailed) as exc:
+        await reg.reserve("b", make_request())
+    assert exc.value.reason is RegisterError.at_capacity
+
+
+async def test_release_frees_slot() -> None:
+    reg = PendingApprovals(max_pending=1)
+    await reg.reserve("a", make_request())
+    await reg.release("a")
+    assert reg.count() == 0
+    # capacity freed: a new reserve succeeds
+    await reg.reserve("b", make_request())
+    assert reg.count() == 1
+
+
+async def test_resolve_unknown_is_noop() -> None:
+    reg = PendingApprovals(max_pending=10)
+    assert reg.resolve("missing", _allow()) is False
+
+
+async def test_double_resolve_is_noop() -> None:
+    reg = PendingApprovals(max_pending=10)
+    await reg.reserve("a", make_request())
+    assert reg.resolve("a", _allow()) is True
+    assert reg.resolve("a", _allow()) is False
+
+
+async def test_discard_removes_without_resolving() -> None:
+    reg = PendingApprovals(max_pending=10)
+    await reg.reserve("a", make_request())
+    reg.discard("a")
+    assert reg.count() == 0
+
+
+async def test_drain_resolves_all() -> None:
+    reg = PendingApprovals(max_pending=10)
+    e_a = await reg.reserve("a", make_request())
+    e_b = await reg.reserve("b", make_request())
+    deny = ApprovalDecision(decision=Decision.deny, responder="system:shutdown", reason="shutdown")
+    drained = reg.drain(deny)
+    assert set(drained) == {"a", "b"}
+    assert reg.count() == 0
+    assert e_a.future.result().decision is Decision.deny
+    assert e_b.future.result().decision is Decision.deny
+
+
+async def test_concurrent_registration_respects_cap() -> None:
+    reg = PendingApprovals(max_pending=5)
+
+    async def reserve(i: int) -> bool:
+        try:
+            await reg.reserve(f"id-{i}", make_request())
+            return True
+        except RegistrationFailed:
+            return False
+
+    results = await asyncio.gather(*(reserve(i) for i in range(20)))
+    assert sum(results) == 5
+    assert reg.count() == 5

--- a/tests/notifier/test_telegram.py
+++ b/tests/notifier/test_telegram.py
@@ -1,0 +1,269 @@
+"""Tests for the Telegram transport (T012).
+
+The PTB Application is replaced with a mock exposing an async ``bot`` and
+``add_handler``; no network or real token is involved.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from remo_cli.notifier.models import Decision
+from remo_cli.notifier.transports.telegram import TelegramTransport, escape_md_v2
+
+from .conftest import make_request
+
+
+CHAT_ID = 987654321
+ABC = "11111111-1111-1111-1111-111111111111"
+
+
+def _make_transport() -> tuple[TelegramTransport, MagicMock]:
+    app = MagicMock()
+    app.bot.send_message = AsyncMock(return_value=SimpleNamespace(message_id=42))
+    app.bot.edit_message_text = AsyncMock()
+    transport = TelegramTransport(
+        token="x:y",
+        authorized_chat_id=CHAT_ID,
+        instance_id="inst-1",
+        application=app,
+    )
+    return transport, app
+
+
+def _callback_update(data: str, *, chat_id: int = CHAT_ID, username: str = "paul") -> SimpleNamespace:
+    return SimpleNamespace(
+        callback_query=SimpleNamespace(
+            data=data,
+            message=SimpleNamespace(chat=SimpleNamespace(id=chat_id)),
+            from_user=SimpleNamespace(username=username, id=1),
+            answer=AsyncMock(),
+        )
+    )
+
+
+def test_escape_md_v2() -> None:
+    assert escape_md_v2("a.b-c!") == "a\\.b\\-c\\!"
+
+
+async def test_send_builds_message_and_keyboard() -> None:
+    transport, app = _make_transport()
+    req = make_request(approval_id=ABC, project="proj", timeout_seconds=300)
+    captured = {}
+    transport._sent.clear()
+
+    await transport.send_approval_request(req, on_response=lambda d: captured.setdefault("d", d))
+
+    app.bot.send_message.assert_awaited_once()
+    kwargs = app.bot.send_message.call_args.kwargs
+    assert kwargs["chat_id"] == CHAT_ID
+    assert "Approval requested" in kwargs["text"]
+    keyboard = kwargs["reply_markup"].inline_keyboard
+    assert keyboard[0][0].callback_data == f"approve:{ABC}"
+    assert keyboard[0][1].callback_data == f"deny:{ABC}"
+    assert ABC in transport._sent
+
+
+async def test_callback_approve_resolves_and_edits() -> None:
+    transport, app = _make_transport()
+    req = make_request(approval_id=ABC)
+    got = {}
+    await transport.send_approval_request(req, on_response=lambda d: got.setdefault("d", d))
+
+    await transport._on_callback(_callback_update(f"approve:{ABC}"), MagicMock())
+
+    assert got["d"].decision is Decision.allow
+    assert got["d"].responder == "telegram:paul"
+    app.bot.edit_message_text.assert_awaited()  # message edited
+    assert ABC not in transport._sent  # consumed
+
+
+async def test_callback_deny_resolves() -> None:
+    transport, _ = _make_transport()
+    req = make_request(approval_id=ABC)
+    got = {}
+    await transport.send_approval_request(req, on_response=lambda d: got.setdefault("d", d))
+    await transport._on_callback(_callback_update(f"deny:{ABC}"), MagicMock())
+    assert got["d"].decision is Decision.deny
+
+
+async def test_callback_from_foreign_chat_ignored() -> None:
+    transport, _ = _make_transport()
+    req = make_request(approval_id=ABC)
+    got = {}
+    await transport.send_approval_request(req, on_response=lambda d: got.setdefault("d", d))
+    await transport._on_callback(_callback_update(f"approve:{ABC}", chat_id=111), MagicMock())
+    assert "d" not in got  # unauthorized -> no resolution
+    assert ABC in transport._sent  # still pending
+
+
+async def test_callback_unknown_id_is_noop() -> None:
+    transport, _ = _make_transport()
+    update = _callback_update("approve:ghost")
+    # No send was made for "ghost"; should answer and not raise.
+    await transport._on_callback(update, MagicMock())
+    update.callback_query.answer.assert_awaited()
+
+
+async def test_cancel_timeout_edits_message() -> None:
+    transport, app = _make_transport()
+    req = make_request(approval_id=ABC)
+    await transport.send_approval_request(req, on_response=lambda d: None)
+    await transport.cancel(ABC, outcome="timeout")
+    app.bot.edit_message_text.assert_awaited()
+    assert ABC not in transport._sent
+
+
+async def test_cancel_unknown_is_noop() -> None:
+    transport, app = _make_transport()
+    await transport.cancel("nope")
+    app.bot.edit_message_text.assert_not_awaited()
+
+
+async def test_lifecycle_start_stop() -> None:
+    transport, app = _make_transport()
+    app.initialize = AsyncMock()
+    app.start = AsyncMock()
+    app.stop = AsyncMock()
+    app.shutdown = AsyncMock()
+    app.updater = SimpleNamespace(start_polling=AsyncMock(), stop=AsyncMock())
+
+    await transport.start()
+    assert transport._started is True
+    assert await transport.healthy() is True
+    app.initialize.assert_awaited_once()
+    app.updater.start_polling.assert_awaited_once()
+
+    await transport.stop()
+    assert transport._started is False
+    app.shutdown.assert_awaited_once()
+
+
+async def test_set_token_stages_pending() -> None:
+    transport, _ = _make_transport()
+    transport.set_token("new:token")
+    assert transport._pending_token == "new:token"
+
+
+# --- Standing grants (Addendum 001) -----------------------------------------
+from remo_cli.notifier.grants import (  # noqa: E402
+    ArgMatchType,
+    Grant,
+    GrantPredicate,
+    GrantScope,
+    GrantScopeType,
+    GrantStore,
+)
+from remo_cli.notifier.models import OperationKind  # noqa: E402
+
+
+def _make_transport_with_grants(max_grants: int = 100):
+    transport, app = _make_transport()
+    app.bot.edit_message_reply_markup = AsyncMock()
+    store = GrantStore(max_grants=max_grants, instance_id="inst-1", allow_global_scope=True)
+    transport.bind_grants(store, default_ttl_seconds=3600)
+    return transport, app, store
+
+
+def _cmd_update(*, chat_id: int = CHAT_ID):
+    return SimpleNamespace(
+        effective_chat=SimpleNamespace(id=chat_id),
+        effective_message=SimpleNamespace(reply_text=AsyncMock()),
+    )
+
+
+def _global_git_grant() -> Grant:
+    return Grant.create(
+        predicate=GrantPredicate(kind=OperationKind.command, command="git", args=[], args_match=ArgMatchType.prefix),
+        scope=GrantScope(type=GrantScopeType.glob), ttl_seconds=3600,
+        created_by="t", source_approval_id="x",
+    )
+
+
+async def test_always_button_present_when_grants_bound() -> None:
+    transport, app, _ = _make_transport_with_grants()
+    req = make_request(approval_id=ABC, project="p",
+                       operation={"kind": "command", "command": "git", "args": ["push"]})
+    await transport.send_approval_request(req, on_response=lambda d: None)
+    row = app.bot.send_message.call_args.kwargs["reply_markup"].inline_keyboard[0]
+    assert [b.callback_data for b in row] == [f"approve:{ABC}", f"always:{ABC}", f"deny:{ABC}"]
+
+
+async def test_always_then_pick_creates_grant_and_allows() -> None:
+    transport, app, store = _make_transport_with_grants()
+    req = make_request(approval_id=ABC, project="p",
+                       operation={"kind": "command", "command": "git", "args": ["push", "origin"]})
+    got = {}
+    await transport.send_approval_request(req, on_response=lambda d: got.setdefault("d", d))
+
+    await transport._on_callback(_callback_update(f"always:{ABC}"), MagicMock())
+    app.bot.edit_message_reply_markup.assert_awaited()
+    assert ABC in transport._sent and transport._sent[ABC].candidates
+
+    await transport._on_callback(_callback_update(f"pick:{ABC}:0"), MagicMock())
+    assert store.count() == 1
+    assert got["d"].decision is Decision.allow
+    assert got["d"].grant_id is not None
+    assert ABC not in transport._sent
+
+
+async def test_pick_cancel_restores_keyboard() -> None:
+    transport, app, store = _make_transport_with_grants()
+    req = make_request(approval_id=ABC, operation={"kind": "command", "command": "git", "args": ["push"]})
+    await transport.send_approval_request(req, on_response=lambda d: None)
+    await transport._on_callback(_callback_update(f"always:{ABC}"), MagicMock())
+    await transport._on_callback(_callback_update(f"pick:{ABC}:cancel"), MagicMock())
+    assert store.count() == 0
+    assert ABC in transport._sent
+
+
+async def test_pick_at_capacity_allows_once_without_grant() -> None:
+    transport, app, store = _make_transport_with_grants(max_grants=1)
+    await store.create(Grant.create(
+        predicate=GrantPredicate(kind=OperationKind.command, command="x"),
+        scope=GrantScope(type=GrantScopeType.glob), ttl_seconds=3600,
+        created_by="t", source_approval_id="x"))
+    req = make_request(approval_id=ABC, operation={"kind": "command", "command": "git", "args": ["push"]})
+    got = {}
+    await transport.send_approval_request(req, on_response=lambda d: got.setdefault("d", d))
+    await transport._on_callback(_callback_update(f"always:{ABC}"), MagicMock())
+    await transport._on_callback(_callback_update(f"pick:{ABC}:0"), MagicMock())
+    assert got["d"].decision is Decision.allow
+    assert got["d"].grant_id is None
+    assert store.count() == 1
+
+
+async def test_cmd_rules_revoke_pause() -> None:
+    transport, app, store = _make_transport_with_grants()
+    g = _global_git_grant()
+    await store.create(g)
+
+    upd = _cmd_update()
+    await transport._cmd_rules(upd, MagicMock())
+    assert g.grant_id[:8] in upd.effective_message.reply_text.call_args.args[0]
+
+    upd2 = _cmd_update()
+    await transport._cmd_revoke(upd2, SimpleNamespace(args=[g.grant_id]))
+    assert store.count() == 0
+
+    await transport._cmd_pause(_cmd_update(), MagicMock())
+    assert store.paused is True
+    await transport._cmd_resume(_cmd_update(), MagicMock())
+    assert store.paused is False
+
+
+async def test_cmd_rejects_unauthorized_chat() -> None:
+    transport, _, store = _make_transport_with_grants()
+    await transport._cmd_pause(_cmd_update(chat_id=999), MagicMock())
+    assert store.paused is False
+
+
+async def test_send_digest_messages_chat() -> None:
+    transport, app, _ = _make_transport_with_grants()
+    await transport.send_digest("Auto-approved 3 operation(s).")
+    app.bot.send_message.assert_awaited()
+    # Text is MarkdownV2-escaped; assert on a special-char-free substring.
+    assert "3 operation" in app.bot.send_message.call_args.kwargs["text"]

--- a/tests/unit/cli/test_main.py
+++ b/tests/unit/cli/test_main.py
@@ -79,7 +79,16 @@ class TestCliVersion:
 class TestSubcommandRegistration:
     """Ensure all expected subcommands are registered on the root CLI group."""
 
-    EXPECTED_COMMANDS = ["shell", "cp", "incus", "proxmox", "hetzner", "aws", "completion"]
+    EXPECTED_COMMANDS = [
+        "shell",
+        "cp",
+        "incus",
+        "proxmox",
+        "hetzner",
+        "aws",
+        "completion",
+        "notifier",
+    ]
 
     def test_all_subcommands_registered(self):
         """Every expected command name must be present in the CLI group's commands dict."""

--- a/tests/unit/cli/test_shell.py
+++ b/tests/unit/cli/test_shell.py
@@ -179,6 +179,178 @@ class TestShellVersionCheck:
         mock_check.assert_not_called()
 
 
+class TestShellProjectLaunchFlags:
+    """Tests for the -p / --exec / --detach passthrough flags."""
+
+    @pytest.mark.usefixtures("_patch_shell_deps")
+    def test_project_flag_forwards_to_shell_connect(self, runner, mocker):
+        mocker.patch("remo_cli.core.version.get_current_version", return_value="unknown")
+        mock_sc = mocker.patch("remo_cli.core.ssh.shell_connect")
+
+        result = runner.invoke(shell, ["-p", "my-app"])
+
+        assert result.exit_code == 0
+        _, kwargs = mock_sc.call_args
+        assert kwargs["project"] == "my-app"
+        assert kwargs["detach"] is False
+        assert kwargs["exec_cmd"] is None
+
+    @pytest.mark.usefixtures("_patch_shell_deps")
+    def test_exec_passthrough(self, runner, mocker):
+        mocker.patch("remo_cli.core.version.get_current_version", return_value="unknown")
+        mock_sc = mocker.patch("remo_cli.core.ssh.shell_connect")
+
+        result = runner.invoke(
+            shell, ["-p", "my-app", "--exec", "claude --remote-control"]
+        )
+
+        assert result.exit_code == 0
+        _, kwargs = mock_sc.call_args
+        assert kwargs["project"] == "my-app"
+        assert kwargs["exec_cmd"] == "claude --remote-control"
+
+    @pytest.mark.usefixtures("_patch_shell_deps")
+    def test_detach_with_exec(self, runner, mocker):
+        mocker.patch("remo_cli.core.version.get_current_version", return_value="unknown")
+        mock_sc = mocker.patch("remo_cli.core.ssh.shell_connect")
+
+        result = runner.invoke(
+            shell,
+            [
+                "-p",
+                "my-app",
+                "--detach",
+                "--exec",
+                "claude remote-control --name remo-rc",
+            ],
+        )
+
+        assert result.exit_code == 0
+        _, kwargs = mock_sc.call_args
+        assert kwargs["detach"] is True
+        assert kwargs["exec_cmd"] == "claude remote-control --name remo-rc"
+
+    @pytest.mark.usefixtures("_patch_shell_deps")
+    def test_detach_without_exec_errors(self, runner, mocker):
+        mocker.patch("remo_cli.core.version.get_current_version", return_value="unknown")
+        mock_sc = mocker.patch("remo_cli.core.ssh.shell_connect")
+
+        result = runner.invoke(shell, ["-p", "my-app", "--detach"])
+
+        assert result.exit_code == 2
+        mock_sc.assert_not_called()
+        assert "--detach requires --exec" in result.output
+
+    @pytest.mark.usefixtures("_patch_shell_deps")
+    def test_detach_with_tunnels_errors(self, runner, mocker):
+        # -L port forwarding is useless with --detach because the SSH session
+        # exits immediately; surface that as an error rather than silently
+        # forwarding to a tunnel that dies before the user can use it.
+        mocker.patch("remo_cli.core.version.get_current_version", return_value="unknown")
+        mock_sc = mocker.patch("remo_cli.core.ssh.shell_connect")
+
+        result = runner.invoke(
+            shell, ["-p", "my-app", "-L", "8080", "--detach", "--exec", "true"]
+        )
+
+        assert result.exit_code == 2
+        mock_sc.assert_not_called()
+        assert "-L port forwarding cannot be combined with --detach" in result.output
+
+    @pytest.mark.usefixtures("_patch_shell_deps")
+    def test_exec_without_project_errors(self, runner, mocker):
+        mocker.patch("remo_cli.core.version.get_current_version", return_value="unknown")
+        mock_sc = mocker.patch("remo_cli.core.ssh.shell_connect")
+
+        result = runner.invoke(shell, ["--exec", "pytest"])
+
+        assert result.exit_code == 2
+        mock_sc.assert_not_called()
+        assert "-p/--project" in result.output
+
+    @pytest.mark.usefixtures("_patch_shell_deps")
+    def test_no_new_flags_preserves_legacy_call(self, runner, mocker):
+        mocker.patch("remo_cli.core.version.get_current_version", return_value="unknown")
+        mock_sc = mocker.patch("remo_cli.core.ssh.shell_connect")
+
+        result = runner.invoke(shell, [])
+
+        assert result.exit_code == 0
+        _, kwargs = mock_sc.call_args
+        assert kwargs["project"] is None
+        assert kwargs["detach"] is False
+        assert kwargs["exec_cmd"] is None
+
+
+class TestBuildProjectLaunchRemoteCmd:
+    """Tests for the SSH remote-command string builder."""
+
+    def test_project_only(self):
+        from remo_cli.core.ssh import build_project_launch_remote_cmd
+
+        assert (
+            build_project_launch_remote_cmd("my-app", detach=False, exec_cmd=None)
+            == "~/.local/bin/project-launch --project my-app"
+        )
+
+    def test_project_with_exec(self):
+        from remo_cli.core.ssh import build_project_launch_remote_cmd
+
+        # --exec value is forwarded as ONE shell-quoted arg so the remote
+        # `project-launch` script can pass it intact to `bash -lc`.
+        assert (
+            build_project_launch_remote_cmd(
+                "my-app", detach=False, exec_cmd="claude --remote-control"
+            )
+            == "~/.local/bin/project-launch --project my-app "
+            "--exec 'claude --remote-control'"
+        )
+
+    def test_project_detach_with_exec(self):
+        from remo_cli.core.ssh import build_project_launch_remote_cmd
+
+        assert (
+            build_project_launch_remote_cmd(
+                "my-app",
+                detach=True,
+                exec_cmd="claude remote-control --name remo-rc",
+            )
+            == "~/.local/bin/project-launch --project my-app --detach "
+            "--exec 'claude remote-control --name remo-rc'"
+        )
+
+    def test_exec_preserves_shell_operators_and_vars(self):
+        from remo_cli.core.ssh import build_project_launch_remote_cmd
+
+        # Vars and operators stay literal in the outgoing command — they get
+        # interpreted by `bash -lc` on the remote, not by the local builder.
+        out = build_project_launch_remote_cmd(
+            "my-app",
+            detach=False,
+            exec_cmd='echo $REMO_PROJECT && pwd',
+        )
+        # Single-quoted by shlex.quote, so $ and && survive unmangled.
+        assert "'echo $REMO_PROJECT && pwd'" in out
+
+    def test_project_with_special_chars_is_quoted(self):
+        from remo_cli.core.ssh import build_project_launch_remote_cmd
+
+        out = build_project_launch_remote_cmd(
+            "weird name", detach=False, exec_cmd=None
+        )
+        assert "'weird name'" in out
+
+    def test_exec_empty_string_is_ignored(self):
+        from remo_cli.core.ssh import build_project_launch_remote_cmd
+
+        # `--exec ""` shouldn't append `--` with no args (would be an error
+        # on the server). It collapses to project-only.
+        assert (
+            build_project_launch_remote_cmd("my-app", detach=False, exec_cmd="")
+            == "~/.local/bin/project-launch --project my-app"
+        )
+
+
 class TestRunProviderUpdate:
     """Tests for _run_provider_update()."""
 

--- a/tests/unit/test_ansible_templates.py
+++ b/tests/unit/test_ansible_templates.py
@@ -1,0 +1,36 @@
+"""Jinja2 parse check for every Ansible template in the repo.
+
+Catches syntax errors before they hit a real Ansible run — most notably the
+``${#var}`` bash array-length idiom, which Jinja2 reads as a ``{#`` comment
+opener and consumes the rest of the file looking for ``#}``. That class of
+bug otherwise only surfaces on a live host during a smoke test.
+
+We use ``Environment.parse`` rather than ``render`` so the test doesn't need
+to know what variables each template expects.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from jinja2 import Environment, TemplateSyntaxError
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+TEMPLATE_ROOT = REPO_ROOT / "ansible"
+
+
+def _all_templates() -> list[Path]:
+    return sorted(TEMPLATE_ROOT.rglob("*.j2"))
+
+
+@pytest.mark.parametrize("template_path", _all_templates(), ids=lambda p: str(p.relative_to(REPO_ROOT)))
+def test_template_parses(template_path: Path) -> None:
+    env = Environment(autoescape=False)
+    source = template_path.read_text()
+    try:
+        env.parse(source)
+    except TemplateSyntaxError as exc:
+        pytest.fail(
+            f"{template_path.relative_to(REPO_ROOT)}:{exc.lineno}: {exc.message}"
+        )

--- a/uv.lock
+++ b/uv.lock
@@ -3,7 +3,26 @@ revision = 3
 requires-python = ">=3.11"
 resolution-markers = [
     "python_full_version >= '3.15'",
-    "python_full_version < '3.15'",
+    "python_full_version == '3.14.*'",
+    "python_full_version < '3.14'",
+]
+
+[[package]]
+name = "annotated-doc"
+version = "0.0.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/57/ba/046ceea27344560984e26a590f90bc7f4a75b06701f653222458922b558c/annotated_doc-0.0.4.tar.gz", hash = "sha256:fbcda96e87e9c92ad167c2e53839e57503ecfda18804ea28102353485033faa4", size = 7288, upload-time = "2025-11-10T22:07:42.062Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1e/d3/26bf1008eb3d2daa8ef4cacc7f3bfdc11818d111f7e2d0201bc6e3b49d45/annotated_doc-0.0.4-py3-none-any.whl", hash = "sha256:571ac1dc6991c450b25a9c2d84a3705e2ae7a53467b5d111c24fa8baabbed320", size = 5303, upload-time = "2025-11-10T22:07:40.673Z" },
+]
+
+[[package]]
+name = "annotated-types"
+version = "0.7.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ee/67/531ea369ba64dcff5ec9c3402f9f51bf748cec26dde048a2f973a4eea7f5/annotated_types-0.7.0.tar.gz", hash = "sha256:aff07c09a53a08bc8cfccb9c85b05f1aa9a2a6f23728d790723543408344ce89", size = 16081, upload-time = "2024-05-20T21:33:25.928Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/78/b6/6307fbef88d9b5ee7421e68d78a9f162e0da4900bc5f5793f6d3d0e34fb8/annotated_types-0.7.0-py3-none-any.whl", hash = "sha256:1f02e8b43a8fbbc3f3e0d4f0f4bfc8131bcb4eebe8849b8e5c773f3a1c582a53", size = 13643, upload-time = "2024-05-20T21:33:24.1Z" },
 ]
 
 [[package]]
@@ -20,6 +39,19 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/26/5b/161275ff5fa673dfc1329ed19a44331a4f491166a9f0cb907b44037ad72e/ansible_core-2.19.9.tar.gz", hash = "sha256:74107de13d188ff579fb215bc3eb875c9198803215d6378ed588c7f35aba12f5", size = 3431475, upload-time = "2026-04-21T00:47:09.194Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/3d/b9/f2c07e6cdba6a5882342d666ceea4eeeb6fea20ec325fac68c27bfcea722/ansible_core-2.19.9-py3-none-any.whl", hash = "sha256:18de80e3ea5a89d2ea84e4d4a3c6d7c121ea62fc3af2877ba083784e3d90b419", size = 2416269, upload-time = "2026-04-21T00:47:06.777Z" },
+]
+
+[[package]]
+name = "anyio"
+version = "4.13.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "idna" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/19/14/2c5dd9f512b66549ae92767a9c7b330ae88e1932ca57876909410251fe13/anyio-4.13.0.tar.gz", hash = "sha256:334b70e641fd2221c1505b3890c69882fe4a2df910cba14d97019b90b24439dc", size = 231622, upload-time = "2026-03-24T12:59:09.671Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/da/42/e921fccf5015463e32a3cf6ee7f980a6ed0f395ceeaa45060b61d86486c2/anyio-4.13.0-py3-none-any.whl", hash = "sha256:08b310f9e24a9594186fd75b4f73f4a4152069e3853f1ed8bfbf58369f4ad708", size = 114353, upload-time = "2026-03-24T12:59:08.246Z" },
 ]
 
 [[package]]
@@ -278,6 +310,110 @@ wheels = [
 ]
 
 [[package]]
+name = "coverage"
+version = "7.14.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/54/fd/0ab2772530e946e1be1abd0bc09e647ec9b02e88f0867857601fefca8953/coverage-7.14.1.tar.gz", hash = "sha256:30c08f7d90415aa98b3c990385dea2939b0da55f38515e5b369b83655f8523be", size = 920132, upload-time = "2026-05-26T20:41:36.783Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7d/d7/477ad149490e6cb849f28abea1dabb9c823cea72e7500c81b4240ce619c0/coverage-7.14.1-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:478b5bcd63c2e1357c5c7e16c070690df7b07f676b1c114d7b93e533c664309f", size = 219848, upload-time = "2026-05-26T20:38:38.715Z" },
+    { url = "https://files.pythonhosted.org/packages/91/82/a5eb47257c50601bb7b9a9d2857c67b7a3a85ad74180eb2c98bb1fbe0ce5/coverage-7.14.1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:a24a81f9715ee42ef59a316cc11611c98fe23920f7c81861315c9f3ff4a230f4", size = 220354, upload-time = "2026-05-26T20:38:40.232Z" },
+    { url = "https://files.pythonhosted.org/packages/43/8b/78419b5391a5cb706b6544390507e469d83ffc9a8248b02c4011aceb9365/coverage-7.14.1-cp311-cp311-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:196a13319ad88d6d8ef5ab489ec4f44ddde2143c0c7d5b27786f6c3ffd56a7e1", size = 250771, upload-time = "2026-05-26T20:38:41.782Z" },
+    { url = "https://files.pythonhosted.org/packages/77/63/e77aaacd491182210d639636b7a8bba23ffffa9b82aa3762da9431855fa9/coverage-7.14.1-cp311-cp311-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:3d452fd08b5c72c5167c93e6867b5c08500bd40f2a21e1e854a500550b6cc36f", size = 252683, upload-time = "2026-05-26T20:38:43.305Z" },
+    { url = "https://files.pythonhosted.org/packages/65/1c/a022e3cfbec2ac241640003cb3a817e161d9c7f5aa9b49173756cdc03204/coverage-7.14.1-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:23bf7fa51ac02e07fc7c96849b82946da47ae862dc8f86d183b2a4864fc38129", size = 254791, upload-time = "2026-05-26T20:38:45.361Z" },
+    { url = "https://files.pythonhosted.org/packages/61/d6/967e408aca4c1ceb88cb0cc677169110ae7f5995fb5eaf5fb1f5a1bb8f5d/coverage-7.14.1-cp311-cp311-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:bcaa50684dcaadfa599ac48f81103c756d791cfd85c97203d2217c593d48b860", size = 256748, upload-time = "2026-05-26T20:38:46.91Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/be/869188f7fe28638078ec479331ace6dc5f7b40b7153eb616f47ab79404d8/coverage-7.14.1-cp311-cp311-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:4ea1c034f95c9b056e856b794630b17f9fa3d57e4800ff1e503d3be0f9c9078c", size = 250907, upload-time = "2026-05-26T20:38:48.493Z" },
+    { url = "https://files.pythonhosted.org/packages/07/aa/adb7d3b4278d690e68703abcd76ab1b948242e3668d921711551b78f9ddb/coverage-7.14.1-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:c7e057326434e441306226fbeb5d1aaf14a2637efe97ba668306635835f32ad7", size = 252483, upload-time = "2026-05-26T20:38:50.074Z" },
+    { url = "https://files.pythonhosted.org/packages/43/61/331c74103c62dcb0c4b9b3a0de9a61aca016208b0a90f109592a9f9ecc28/coverage-7.14.1-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:59baf88468dbc8d63b1887afd92bda52e40bb1561696e5819670601403810cec", size = 250545, upload-time = "2026-05-26T20:38:51.613Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/b6/c5dae3c104d89be04828f61810e6b3473825482e4c288cc4ed04553e08ae/coverage-7.14.1-cp311-cp311-musllinux_1_2_ppc64le.whl", hash = "sha256:d34d75f892b3ab73ba11cab5442cce7b3e168fd64162b16f0e1e0d09c508edef", size = 254310, upload-time = "2026-05-26T20:38:53.503Z" },
+    { url = "https://files.pythonhosted.org/packages/ad/a1/2b9d5863e3b83c01ad8199e3c597802fbb3a9dc90b058885804c20296d31/coverage-7.14.1-cp311-cp311-musllinux_1_2_riscv64.whl", hash = "sha256:3a56abc20a472baf0304c455721bc601477440d28ecfde8a03dde79ede07e0df", size = 250266, upload-time = "2026-05-26T20:38:55.414Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/5e/0e511fbdb269359be26fe678a1c3fa1f2aa2a01573cc3f54268c8d6d4797/coverage-7.14.1-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:6a3cb83d1552c0cd1b4906655b6a33fd4a8473229633a901c6b73bf86914dee9", size = 251174, upload-time = "2026-05-26T20:38:57.141Z" },
+    { url = "https://files.pythonhosted.org/packages/85/10/e55307b622b3dd9671cb321824502dc10f93e72f2802b9946159a8edadeb/coverage-7.14.1-cp311-cp311-win32.whl", hash = "sha256:10274a1fbeb8ec5d72966e17bb198a3104257aca4ac09d98667c5f8aca8c8548", size = 222354, upload-time = "2026-05-26T20:38:58.727Z" },
+    { url = "https://files.pythonhosted.org/packages/71/cf/107421693cfb71e4f1ca5bf70443f64d4161878068d07a3e51c7ad21d17b/coverage-7.14.1-cp311-cp311-win_amd64.whl", hash = "sha256:87ebdf787d4888e3f3f2d523eadc6e18c6d18c6d0eb173801a189641627fb37e", size = 223290, upload-time = "2026-05-26T20:39:00.413Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/1d/3e3644585eb29e9dafefb19555078529a4d7cce12bd21929664eea989277/coverage-7.14.1-cp311-cp311-win_arm64.whl", hash = "sha256:dd34767fa19848d35659ffc0a75314f58c7af3f1cd87ec521e8292a1238398a3", size = 221953, upload-time = "2026-05-26T20:39:02.159Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/b7/bdbb725ba02c5b42825b200c940f38b7a54fcad24627b7192f78f8110d76/coverage-7.14.1-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:a06c76364a9360e33d6d23769aefdf7f66f38e2ffb60ceb1baaa4989d83b695c", size = 220022, upload-time = "2026-05-26T20:39:03.702Z" },
+    { url = "https://files.pythonhosted.org/packages/72/81/fdc0898a55c6219223291ec1a1fe89966ef212ce82276aa0899df84b5de0/coverage-7.14.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:fad54e871165f6ec2f536063ac74c3104508a12963e64072ba44bd822de52b0c", size = 220379, upload-time = "2026-05-26T20:39:05.381Z" },
+    { url = "https://files.pythonhosted.org/packages/de/72/de048c4a25e13bce59ac6a339351c10bdf2515e07459afcdaf04dc3143a2/coverage-7.14.1-cp312-cp312-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:84b535f00655ecafe1d929d1fb00ed5d6fa3051ea643ab2c161a3887b86f294b", size = 251888, upload-time = "2026-05-26T20:39:07.367Z" },
+    { url = "https://files.pythonhosted.org/packages/28/30/300c343f68beb9d4cbb64ec81e58c5b6b80b56927f72d2b38654ac26e013/coverage-7.14.1-cp312-cp312-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:6b6b0853b895fe0e98cbfc580d1ec3393d9302b4b1e96a77b3f5c91fdab899e6", size = 254624, upload-time = "2026-05-26T20:39:09.037Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/ed/7b25642496e8170b6bac14adce00537c6e5fa2d586159401a4de3e8b49e6/coverage-7.14.1-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:442cc9c952b2df400cda54bb04ab87330cf2cd08a8692cbbea36773531eb6f37", size = 255739, upload-time = "2026-05-26T20:39:10.889Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/a2/abd210b8c4e29c24e4624916db97bb519097a91034aaeb767f937e7da794/coverage-7.14.1-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:8270544c361ed405a27a060dbc9ed2c124b084d96dfdc2d9a2510482aef981ad", size = 257998, upload-time = "2026-05-26T20:39:12.722Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/24/7c50beed3792fe62f6ce0545c6686ce83379719e2c0276179333d97eae92/coverage-7.14.1-cp312-cp312-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:48b283b1dd6372e8de2a7a9a4c4d5dc06f4d4fd209b876f3c88a7a205a0c8f84", size = 252296, upload-time = "2026-05-26T20:39:14.259Z" },
+    { url = "https://files.pythonhosted.org/packages/15/05/0f874628ebcbfc77ead559ff210281ef06a97db08481832e7dd39274a135/coverage-7.14.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:5b0c99ba93a07d56f6df340bb79be53202a082b2fdb81bfe6190b741a3470d54", size = 253658, upload-time = "2026-05-26T20:39:15.923Z" },
+    { url = "https://files.pythonhosted.org/packages/99/6f/ca6ad067364b337ef997802115e7ecad2abd2248b05471464b0dea02b4d4/coverage-7.14.1-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:e471bc5769ff073b058cfadb0d736b56ce067c8560eabeb0da88462df98c23e7", size = 251803, upload-time = "2026-05-26T20:39:17.537Z" },
+    { url = "https://files.pythonhosted.org/packages/c0/30/b9b4d377cd9f40baf228068f5a81faf8450c6228503011bd499708483a50/coverage-7.14.1-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:f497a1ea81d4cd7c10ddcaa685135b9aabd291af3d55775a9ddf3cb7a364cdd9", size = 255873, upload-time = "2026-05-26T20:39:19.414Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/21/7c721a9e5e6bb88547d30a787aefb97512d3f54c1324c7488d9b3743f7f9/coverage-7.14.1-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:2222be86d0b54f5dd5a38f45f17f315f737245e857bf0bdedc70734f84a13c02", size = 251372, upload-time = "2026-05-26T20:39:21.169Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/8c/f8ae5a2200130e1503cd7661a6cd3b2b7bacef98277fbf3571fb13f8b766/coverage-7.14.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:85e85586565842f6932abebd4c18bcb1074223dc0b3576e7d173ca710622813a", size = 253245, upload-time = "2026-05-26T20:39:23.097Z" },
+    { url = "https://files.pythonhosted.org/packages/34/62/70a9024672a5f6910517d9628c52c9afbdd3cf8f46426af52bb148a56fff/coverage-7.14.1-cp312-cp312-win32.whl", hash = "sha256:4a28fd227808366b196a75476dced2eb35b351d6766ba9c858dc93319e87f4f1", size = 222567, upload-time = "2026-05-26T20:39:24.868Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/81/8b7cd386839b039ebe1855733b9f9449a8dec5d79564018234f185a7fa70/coverage-7.14.1-cp312-cp312-win_amd64.whl", hash = "sha256:54acdb6674a4661768d7bf7db32dfb9f46ab1d764f8aba6df75ce1a6a088724e", size = 223372, upload-time = "2026-05-26T20:39:26.603Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/ba/b44d472022f620d289d95fa830143235c0c36461c6f2437ea8d51e5481ed/coverage-7.14.1-cp312-cp312-win_arm64.whl", hash = "sha256:99cd41ff91afd94896fea3bc002706b6ae4ce95727d06e4a0f39c0a8d8bd8b1a", size = 221989, upload-time = "2026-05-26T20:39:28.242Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/9e/5f6d56327c62b185225d145191c607e07515294a0aa6338e58805cd4a5ac/coverage-7.14.1-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:be9f2c802dcfce3f71298303aa5dad0dce440a76c52f2f60dacd8656dab78793", size = 220044, upload-time = "2026-05-26T20:39:29.902Z" },
+    { url = "https://files.pythonhosted.org/packages/75/92/e82aca356744cbbc0f77a0b623e38918c1872361963413a3bab5d0340393/coverage-7.14.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:6223a72fd0e4c7156353ec0f08a5f93623e1d3034d0e2683b9bb8ea674131b1d", size = 220412, upload-time = "2026-05-26T20:39:31.561Z" },
+    { url = "https://files.pythonhosted.org/packages/27/c9/385bde0bf7ed0f4bf3a7ee5367060a86b5d218718cfd6fb943c0f836b34f/coverage-7.14.1-cp313-cp313-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:7279d2110a28cebc738b6459ecda2771735a4c18465fbbd36b3288fe5ed92247", size = 251412, upload-time = "2026-05-26T20:39:33.337Z" },
+    { url = "https://files.pythonhosted.org/packages/51/8c/23faf6a2343a0d17f960a4bd56c43bc7eb4cf312f774dd6ceebd82c7d8fc/coverage-7.14.1-cp313-cp313-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:9eeb3fcbc13ba40dfbdb22d01d196a28e9cef9ed4c29b60061a1e0e823a9929d", size = 254008, upload-time = "2026-05-26T20:39:35.009Z" },
+    { url = "https://files.pythonhosted.org/packages/42/06/36f4aa9ca8a815e6036156e80706a67828bb97bd826948244f6996dda957/coverage-7.14.1-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:5f0cfc27c539f07cf5c0a4cfe211d0b6cae039f8f40526dbaa71944e64b50a7b", size = 255241, upload-time = "2026-05-26T20:39:36.71Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/79/95266316352f90f6b1c6736bb413302edfde2453fb32422d3911642691b3/coverage-7.14.1-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:221c70f316241a78e77e607c227cefc8808d4e08f28d99c04f35694690e940be", size = 257373, upload-time = "2026-05-26T20:39:38.412Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/9c/58316d1f66c488b5fca8a0eb3e98348807813efa8a0d0833b9021be27488/coverage-7.14.1-cp313-cp313-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:da028256b04ec30e5e0114b6f76172938c313991f0a2d3d894271315cf5d5e43", size = 251635, upload-time = "2026-05-26T20:39:40.268Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/5a/ca2398a568e16fed7bb713e84ba3603a7164fb65779abe645c565ec890d5/coverage-7.14.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:76a085d7005236a767e3426148b2c407e53ad61695c562f8a81da2d373324901", size = 253373, upload-time = "2026-05-26T20:39:42.145Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/2c/0396562c32deaebe7be51d865b3a41e9a87d7561acafe1a28f53b07e019a/coverage-7.14.1-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:b553d04b5e778a8e56d57eb134aff42a92718ecba45e79c4764ecfa40efd92ff", size = 251341, upload-time = "2026-05-26T20:39:43.907Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/8f/a94f9221184c9cae1ee115820e3798e48b6b17777a9f19e46fb9a0c8dc74/coverage-7.14.1-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:46f714d2fb8ae2f4f29f23ada7f1e79b759fff5a70f94a1dac23af204c3ec9e4", size = 255497, upload-time = "2026-05-26T20:39:46.166Z" },
+    { url = "https://files.pythonhosted.org/packages/71/69/505d70e47db1eaebcd002c39759707621ef184cd6b1ae084d9f41293f323/coverage-7.14.1-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:1896f5e19ff3f0431c7ce2172adc54890fd97f86b59ced8ca1649145d9ffe35d", size = 251159, upload-time = "2026-05-26T20:39:48.03Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/aa/58681c383aa33a9d2ed40a02d7a22fbf780d1fa4d575396365777828198c/coverage-7.14.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:62fd185ef9df3c33d1c8178c5af105f762afbad96038de9a4ae100aa6297ca33", size = 252934, upload-time = "2026-05-26T20:39:49.872Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/fd/11c928cd6bdffc7074bb5965c173d9ebf517fb00205e1da524b98d29ef92/coverage-7.14.1-cp313-cp313-win32.whl", hash = "sha256:ab4af6352741a604c431c6072fce5bee33bf0f20dc7a56618d6bf6bb89e9810c", size = 222584, upload-time = "2026-05-26T20:39:51.68Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/92/fb416fc26d340dcba19518c418d6048e913186e17243982c5e435e41fa7a/coverage-7.14.1-cp313-cp313-win_amd64.whl", hash = "sha256:7af486dabe8954d03b087f0021540897afe084f04e16ff5579e08cc46f871416", size = 223394, upload-time = "2026-05-26T20:39:53.472Z" },
+    { url = "https://files.pythonhosted.org/packages/73/c6/02d56e3867972f77d5036de924643f26c056e848f00452cafb4dbc3c29b4/coverage-7.14.1-cp313-cp313-win_arm64.whl", hash = "sha256:2224f89ffd0c5605ccce1ed7a584da162bc7c55f601ab1c946bc9de31a486b42", size = 222015, upload-time = "2026-05-26T20:39:55.374Z" },
+    { url = "https://files.pythonhosted.org/packages/4d/9e/fcc77914050df73f7662fa1f00902774c79c075a8388ab334074574bf77e/coverage-7.14.1-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:de286598cc65d2b489411174b1faec2f5a7775fb3201fd925db2a76b4030f37d", size = 220733, upload-time = "2026-05-26T20:39:57.189Z" },
+    { url = "https://files.pythonhosted.org/packages/f7/67/2963cbdaf5cbadec44efa3a1e39eaa1f02df4079585f05387607a221e126/coverage-7.14.1-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:042c46ded7c288aeb07cf14a28b6c1e10b78fcba40171c3fa1e939377eeef0b5", size = 221086, upload-time = "2026-05-26T20:39:59.019Z" },
+    { url = "https://files.pythonhosted.org/packages/c8/c5/8701645574e11881f2f47d8930f98bc48b5d43b25eb5b4430dfc4a2f9f48/coverage-7.14.1-cp313-cp313t-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:f4ddbe407477f04c45115d1a4e5bc480f753553b534d338d4c3358b1cdd0ea52", size = 262381, upload-time = "2026-05-26T20:40:00.822Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/28/7a64d73598263e0c5abd5084211a8474488d31b3c552ff531c719dfcff62/coverage-7.14.1-cp313-cp313t-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:d13e6725992e2d2fd7d81d4f5241952d13740121dfd501da09201be39b2c003a", size = 264458, upload-time = "2026-05-26T20:40:02.506Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/d8/4969179db9f7eb4df218e69540adf829d1c835f59452513d065d15446802/coverage-7.14.1-cp313-cp313t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:f747dc8edcfe740130f28f32f3995e955494285717e86ee25af51db2219df08a", size = 266884, upload-time = "2026-05-26T20:40:04.421Z" },
+    { url = "https://files.pythonhosted.org/packages/a6/78/a45d5794dbc9bafd97afc96a4377c86c7820d78b6cf51b89bc1d4e919275/coverage-7.14.1-cp313-cp313t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:ced2f09ef276fd58611a1ef502164ad266d2b75174e5a40cabbdb4033f9f6cf2", size = 268022, upload-time = "2026-05-26T20:40:06.298Z" },
+    { url = "https://files.pythonhosted.org/packages/21/cb/4f5e354e9e3e67af96bd4e57113e6db6b22298c7168b13eec408a549903d/coverage-7.14.1-cp313-cp313t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:b84800013769a78ccb9ef4659402e26d06867e337b61ec365f77ad008adea80e", size = 261631, upload-time = "2026-05-26T20:40:08.226Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/49/eced49af4cb996d5d8b7e94e736175c513e4facd3398507b89892b4326d8/coverage-7.14.1-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:ea8cd6ca0ee9f616aaef3afc6882e32c2cbf18b00d96313ffd76af650574034d", size = 264443, upload-time = "2026-05-26T20:40:10.137Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/d8/5603a88a7c5913a6b54f6cb1a8c46f7b39cbb30f27cd3f492908da09b2d7/coverage-7.14.1-cp313-cp313t-musllinux_1_2_i686.whl", hash = "sha256:aa5e304a873fabddc11e484e9b6b738bd38bd7bed17b09aa84eecf5332e8b8bb", size = 262069, upload-time = "2026-05-26T20:40:11.999Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/59/2ae3cb79da554a06c8619d6c88ea19dd1e4aed4b834b6a83bb1fa243bdc5/coverage-7.14.1-cp313-cp313t-musllinux_1_2_ppc64le.whl", hash = "sha256:5a1c5215be81035e629d5bc756650634d0bf31991038db7a0eccb90f025ce16d", size = 265780, upload-time = "2026-05-26T20:40:13.858Z" },
+    { url = "https://files.pythonhosted.org/packages/af/5f/b130c1dc999031f2648bd25317fbce505ad8d5562079b4ed81e736a84967/coverage-7.14.1-cp313-cp313t-musllinux_1_2_riscv64.whl", hash = "sha256:79058c47dae6788504b5effb319961bcd72d7240551464b91d474bc0ed186d69", size = 260970, upload-time = "2026-05-26T20:40:16.142Z" },
+    { url = "https://files.pythonhosted.org/packages/87/d1/ec13ccddeb48ec963bdfa72a11224bac2584bd045ba13beca82f8113e9c7/coverage-7.14.1-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:370c5afae3fa0658e11694a32b24c2778f6bc2d17718121f94ee185e69f26b54", size = 263157, upload-time = "2026-05-26T20:40:18.382Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/c2/cd91ead503045161092d3845f7bb95ea2f25131ce96d3e314dd835d91b9c/coverage-7.14.1-cp313-cp313t-win32.whl", hash = "sha256:3758dd0a7f1fa57365ef2e781df0f0731d38b6e3772259d13dae4bd8a958d4b1", size = 223259, upload-time = "2026-05-26T20:40:20.381Z" },
+    { url = "https://files.pythonhosted.org/packages/71/9f/1e28d97e6bd2c76b07f38b7c02870f1371255ff6717f54eca578fcbbdd0e/coverage-7.14.1-cp313-cp313t-win_amd64.whl", hash = "sha256:6ff665fb023a77386fe11685190cee1f60a7d635994a30d9b0a061533d470fce", size = 224320, upload-time = "2026-05-26T20:40:22.316Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/e0/d936e908f0e1efa55e52b91e01b52f1055cef5e1ab2718493390ed8e2fb8/coverage-7.14.1-cp313-cp313t-win_arm64.whl", hash = "sha256:17a5a241e5997621a956a7f402a7433ef4221e5152809b785bec79e2323799f1", size = 222577, upload-time = "2026-05-26T20:40:24.894Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/34/fc2f101b151af3799a101f0550b0454aa008afdc0add677394ec4aa8ea10/coverage-7.14.1-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:d5ed429d0b8edaac649e889b4ffcedb6c80b06629a3f93050e3dddfb99235bee", size = 220091, upload-time = "2026-05-26T20:40:27.249Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/a7/1ebae2ab5b961b5c79bb09fe7b3ac99edb190d8be4a8c510b2cf66f46468/coverage-7.14.1-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:8011224a62280e50dab346960c03cf47aca1a1e09e608c0fb33fd6e0cc8e9500", size = 220421, upload-time = "2026-05-26T20:40:30.084Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/90/92aca9cf0acc95123c96cd1eb1f08917897a7f5dee01e15738922971ec31/coverage-7.14.1-cp314-cp314-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:12c42ec1e14f553c4f817e989365982e646e27211f10a0f717855b94a79c8906", size = 251466, upload-time = "2026-05-26T20:40:32.542Z" },
+    { url = "https://files.pythonhosted.org/packages/26/2b/78048cbe3b999f6cbf9cc0d90abba6a88a3e0863a8c1c6cbc762f3f8802f/coverage-7.14.1-cp314-cp314-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:06144cd511cf2624873a035c5069cf297144f6e77a73ee3d7a55b605ec5efb42", size = 253973, upload-time = "2026-05-26T20:40:34.473Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/21/c2e33b29d1cfde484a19d437afc343c6cd30b08d78cbbf9f5aff14e57b2b/coverage-7.14.1-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:a311d8e1da24be5c1ccf85cbfb06315dbaa1703d5a1eab3f6432c72b837917c8", size = 255318, upload-time = "2026-05-26T20:40:38.154Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/ee/aad2f108d63b769121005302f16bf66db8625c88ceaba466942e09a2607e/coverage-7.14.1-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:c79cead5b5bc584d9c71451cb984d0e3a84e0c0937379c8efcbf27c8d661b851", size = 257633, upload-time = "2026-05-26T20:40:40.164Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/f8/11a2c29b4fd76d9849f81d0bb812ec0017a9396df3217214e38934a8c837/coverage-7.14.1-cp314-cp314-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:dcbf65f1f66a26cdd88c35cf68fb4729c5d1cd2e88added72420541dfb212034", size = 251488, upload-time = "2026-05-26T20:40:42.631Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/b8/9a5820de4b8ac2b71d85e3b5fb49108d7469c665f0e2ad0dd7569023e305/coverage-7.14.1-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:fd86572566fb40189a8260446158235159bc7a82dfbc87a3b39cf4fb57fcec1c", size = 253329, upload-time = "2026-05-26T20:40:45.208Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/ff/f33e4823667e27548e8fd8df44217515303f9808d0ff29817db56f87d990/coverage-7.14.1-cp314-cp314-musllinux_1_2_i686.whl", hash = "sha256:7771b601718fdde84832c3a434ca9bbf4ae9adbc49d84198b4110700c3c77c36", size = 251291, upload-time = "2026-05-26T20:40:47.502Z" },
+    { url = "https://files.pythonhosted.org/packages/68/9b/489db0ebb209054766b90a9014a45f6d26eb724c02ec21311c3733b5a644/coverage-7.14.1-cp314-cp314-musllinux_1_2_ppc64le.whl", hash = "sha256:39b21e212c55af06fa375e3dbf90a8a8e38792f3a910c580066d23563830ddd5", size = 255564, upload-time = "2026-05-26T20:40:49.372Z" },
+    { url = "https://files.pythonhosted.org/packages/27/b5/16bc2d4c2409b23c7737edb68c83bc89e345f378050549fe1d75ac7d34d5/coverage-7.14.1-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:f2302660e32562a532b442480121aef8aa61a5bdb20b30bf0adab29f10a5a4b4", size = 251107, upload-time = "2026-05-26T20:40:51.677Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/0c/2629997469a00cd069d588a41c9dc887610f2775ae89d250c4791e65272a/coverage-7.14.1-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:03a6f93c1ec3b7f2e77b5dbcc5573a2c21f12529a5c6bbe0f16f72303cc2fa4d", size = 252764, upload-time = "2026-05-26T20:40:54.267Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/ee/f78d63c8f079e0d7211c7e2401fa17e311514534ba61bae03e4b287ce4ab/coverage-7.14.1-cp314-cp314-win32.whl", hash = "sha256:8a3ce026d73290f42f08dafecbd82c193a74df280461fbf97300fec51fd133ee", size = 222837, upload-time = "2026-05-26T20:40:56.496Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/b9/be539854f93a70dfbeec69117f33ec70dc42ff0b65b5b07ab8d40d04228e/coverage-7.14.1-cp314-cp314-win_amd64.whl", hash = "sha256:114c95ef29302423b87d159075805f4ab973254a2638a5d7d046c94887cc87d7", size = 223650, upload-time = "2026-05-26T20:40:58.351Z" },
+    { url = "https://files.pythonhosted.org/packages/fe/9e/24e2842fef40f35ac82ba3a7719c8023d011bf3bf652d0675316a9d088a1/coverage-7.14.1-cp314-cp314-win_arm64.whl", hash = "sha256:a07891c3f4805442b31b71e84ba3cf29ed1aa9a428284e06deeb4b23e5b46343", size = 222218, upload-time = "2026-05-26T20:41:00.321Z" },
+    { url = "https://files.pythonhosted.org/packages/0a/1d/ac0a9df5fe31c1e8bdd658074905fc12844a05c1a7e3fdb8417e97c31e23/coverage-7.14.1-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:1101a5ebb083aecb625ebb6209d4105b58f647b093cb2dc8122d7b33f743cfe1", size = 220822, upload-time = "2026-05-26T20:41:02.281Z" },
+    { url = "https://files.pythonhosted.org/packages/32/cf/f964fd9aff20323f9f1a726c97135f8a76bcd87b92dad141a456a43f3c64/coverage-7.14.1-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:851b9e1e4e8a4608e77c79714b2e77c0970d2ed7202a05e92ae407817481887b", size = 221084, upload-time = "2026-05-26T20:41:04.593Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/5e/7e5ef2aba844de2b80d678619fcf0841b42e3f37f16411226f3fe4c1016f/coverage-7.14.1-cp314-cp314t-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:d5b89cdfb2ee051b71e8c3c70bd81a9eff81100f736a269136fe1a68efe00474", size = 262454, upload-time = "2026-05-26T20:41:06.641Z" },
+    { url = "https://files.pythonhosted.org/packages/64/62/75809bded87015cc4935524218a2a8ed8dd1a8498bfed30a2f4f7a4b4d34/coverage-7.14.1-cp314-cp314t-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:0177614a0370f227888b4e436a7c55686d6a9f90eb1ade2b624ba685a1686e86", size = 264578, upload-time = "2026-05-26T20:41:08.556Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/42/d33392dc14633525012d2d504fa1a33b05538bf535f5c1d64675e5754b78/coverage-7.14.1-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:2d69af5dea2de76fc485a83032a630523f985198b7e25be901ec60181587b01e", size = 266981, upload-time = "2026-05-26T20:41:10.824Z" },
+    { url = "https://files.pythonhosted.org/packages/2a/49/0157c4428c2aca7f1e09d5565930586fd5ae36f1655f08b0daa7cf1fcae1/coverage-7.14.1-cp314-cp314t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:35ab22d91de736e8966b980dc355cbcdd2c6dbbcfe275f9a2991bc8a91b3df65", size = 268112, upload-time = "2026-05-26T20:41:12.966Z" },
+    { url = "https://files.pythonhosted.org/packages/96/26/86b9ce71f4092b1ed325ce1421698081df1286b833400b6836912834d6e0/coverage-7.14.1-cp314-cp314t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:357d4e32935c36588aaba057d734fa32428c360c9fc2e4442afbf1b646beee6e", size = 261558, upload-time = "2026-05-26T20:41:15Z" },
+    { url = "https://files.pythonhosted.org/packages/20/4c/c311210c5472cf5401d8422b0d7812cdd520f24417673afabda6c323faca/coverage-7.14.1-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:51bd64741cc6fa065abd300ede1afe5a5291ece9c31da8b24884deda48bcc3f8", size = 264447, upload-time = "2026-05-26T20:41:17.369Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/71/59513f8710ed3e6b0ac0a050a5b7e977bb9c9e880354863b5d00d8809256/coverage-7.14.1-cp314-cp314t-musllinux_1_2_i686.whl", hash = "sha256:9132cd363a68a4c3daa7c8704a654b1e39d3360f6f5b8ddd470608a945236c07", size = 262048, upload-time = "2026-05-26T20:41:19.309Z" },
+    { url = "https://files.pythonhosted.org/packages/84/8d/bceed32dc494f5bbf50f775cd2e78ca814953942b5ea28d3c1c3ac316f14/coverage-7.14.1-cp314-cp314t-musllinux_1_2_ppc64le.whl", hash = "sha256:07c6290b1697b862c0478eab545eec949a0d0e4d6d03497f446d706da3b4f2de", size = 265781, upload-time = "2026-05-26T20:41:21.559Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/c5/9348fe40dbfd4991aaf78df2c6c3098bfb2cc834d1fd362a64b4efef855a/coverage-7.14.1-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:5ea0c297e27133853b4d8a3eb799bff5a2dbd9f2f41537a240d337ac9b4df890", size = 260896, upload-time = "2026-05-26T20:41:23.428Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/92/1ea0f03929da7cf87206b1fa24f4c8e9c158be0455481af29ec0a1f3503f/coverage-7.14.1-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:01b7733daad0237daa01ef80fe2dfceffc911e6a17fa7b55d14aa8214eaaaecd", size = 263214, upload-time = "2026-05-26T20:41:25.419Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/a9/b2493c054c0e01a643266742ab45e15744e60743f9260cd930c7142b1124/coverage-7.14.1-cp314-cp314t-win32.whl", hash = "sha256:6adc5a36984624a70bf11d7184e20fa0a49aa7c47ffab43804106a1a695ea22e", size = 223624, upload-time = "2026-05-26T20:41:27.795Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/bd/3e1e6a57fccd2d7c83fcdf338e93ba98eb85c6e877dd34731ac585375490/coverage-7.14.1-cp314-cp314t-win_amd64.whl", hash = "sha256:ddf799247318f34dbcd2efa8c95a8d0642674e926bb1774cf9b63dfd2a389d1c", size = 224728, upload-time = "2026-05-26T20:41:30.098Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/d7/31066cf1d2f0c6c797fce911bcfa01dd35642dc6da992a950256097c5860/coverage-7.14.1-cp314-cp314t-win_arm64.whl", hash = "sha256:145986fe66647eb489f18d9a997567a3fd358584c4b5a808769113abc07466af", size = 222752, upload-time = "2026-05-26T20:41:32.123Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/3c/1a983b9a745d7f83d53f057bcc5bf79ba6a2bbc08266b3f0c7d6fe630c9b/coverage-7.14.1-py3-none-any.whl", hash = "sha256:a252f21c27e38347e60111a3266b03827422a7d5525951aceee313aa68bab1d2", size = 211815, upload-time = "2026-05-26T20:41:34.078Z" },
+]
+
+[package.optional-dependencies]
+toml = [
+    { name = "tomli", marker = "python_full_version <= '3.11'" },
+]
+
+[[package]]
 name = "cryptography"
 version = "48.0.0"
 source = { registry = "https://pypi.org/simple" }
@@ -337,6 +473,31 @@ wheels = [
 ]
 
 [[package]]
+name = "fastapi"
+version = "0.136.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "annotated-doc" },
+    { name = "pydantic" },
+    { name = "starlette" },
+    { name = "typing-extensions" },
+    { name = "typing-inspection" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/81/2d/ff8d91d7b564d464629a0fd50a4489c97fcb836ac230bf3a7269232a9b1f/fastapi-0.136.3.tar.gz", hash = "sha256:e487fae93ad408e6f47641ee4dfe389864fd7bec92e547ea8498fc13f43e83ab", size = 396410, upload-time = "2026-05-23T18:53:15.192Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e0/82/45359b62a067409bd929ae8a56b8ed13e5a8c8a61194b3c236920999ab83/fastapi-0.136.3-py3-none-any.whl", hash = "sha256:3d2a69bdf04b7e9f3afa292c3bc7a98816bbfafa10bc9b45f3f3700d2f761620", size = 117481, upload-time = "2026-05-23T18:53:16.924Z" },
+]
+
+[[package]]
+name = "h11"
+version = "0.16.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/01/ee/02a2c011bdab74c6fb3c75474d40b3052059d95df7e73351460c8588d963/h11-0.16.0.tar.gz", hash = "sha256:4e35b956cf45792e4caa5885e69fba00bdbc6ffafbfa020300e549b208ee5ff1", size = 101250, upload-time = "2025-04-24T03:35:25.427Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/04/4b/29cac41a4d98d144bf5f6d33995617b185d14b22401f75ca86f384e87ff1/h11-0.16.0-py3-none-any.whl", hash = "sha256:63cf8bbe7522de3bf65932fda1d9c2772064ffb3dae62d55932da54b31cb6c86", size = 37515, upload-time = "2025-04-24T03:35:24.344Z" },
+]
+
+[[package]]
 name = "hcloud"
 version = "2.20.0"
 source = { registry = "https://pypi.org/simple" }
@@ -347,6 +508,77 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/43/0c/69b03f17185582631c991e7ad11c3b77c41b37d6e479729286452d9e0711/hcloud-2.20.0.tar.gz", hash = "sha256:27052effab1a25bb3cbfc8e2d2472e0e8503b20aecab5bbad5c4b0e8697696d5", size = 155249, upload-time = "2026-05-07T20:05:41.635Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/42/b1/ecb2bf25a2a1333bd85d29e13db91085a88e4ef32e77afbc57cbe2fc524f/hcloud-2.20.0-py3-none-any.whl", hash = "sha256:7373c807c3dbbe5e35e25945e7c1a54d66b6b126d700cc2b8accf0c160f035a6", size = 112086, upload-time = "2026-05-07T20:05:39.723Z" },
+]
+
+[[package]]
+name = "httpcore"
+version = "1.0.9"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "certifi" },
+    { name = "h11" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/06/94/82699a10bca87a5556c9c59b5963f2d039dbd239f25bc2a63907a05a14cb/httpcore-1.0.9.tar.gz", hash = "sha256:6e34463af53fd2ab5d807f399a9b45ea31c3dfa2276f15a2c3f00afff6e176e8", size = 85484, upload-time = "2025-04-24T22:06:22.219Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7e/f5/f66802a942d491edb555dd61e3a9961140fd64c90bce1eafd741609d334d/httpcore-1.0.9-py3-none-any.whl", hash = "sha256:2d400746a40668fc9dec9810239072b40b4484b640a8c38fd654a024c7a1bf55", size = 78784, upload-time = "2025-04-24T22:06:20.566Z" },
+]
+
+[[package]]
+name = "httptools"
+version = "0.8.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/43/e5/d471fcb0e14523fe1c3f4ba58ca52480e7bd70ad7109a3846bc75892f7fb/httptools-0.8.0.tar.gz", hash = "sha256:6b2a32f18d97e16e90827d7a819ffa8dbd8cc245fc4e1fa9d1095b54ef4bd999", size = 271342, upload-time = "2026-05-25T22:17:48.841Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f8/d2/c3eedaef57de65c3cc5f8dc244cf12d09c84ad258a479055aad6db23206c/httptools-0.8.0-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:ed377e64805bdba4943c82717333f8f8603a13b09aff9cead2717c6c817fb168", size = 208428, upload-time = "2026-05-25T22:16:59.717Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/94/dfe435d90d0ef61ec0f2cc3d480eef78c59727c6c2ce039f433882f6131a/httptools-0.8.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:9518c406d7b310f05adb1a37f80acabac40504a575d7c0da6d3e365c695ac20d", size = 113366, upload-time = "2026-05-25T22:17:00.795Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/d4/13025f1a56e615dcb331e0bbe2d9a1143212b58c263385fc5d2e558f5bac/httptools-0.8.0-cp311-cp311-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:57278e6fa0424c42a8a3e454828ab4f0aff27b40cddf9679579b98c6dce6a376", size = 464676, upload-time = "2026-05-25T22:17:02.014Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/95/4c1c26c0b985f8a3331682d802598f14e32dc41bf7509266eb2c04ad4801/httptools-0.8.0-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:bbb8caadb2b742d293169d2b458b5c001ef70e3158704aa3d3ef9597624c5d1d", size = 464235, upload-time = "2026-05-25T22:17:03.109Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/82/6735be2b0ca527718c431cdb8e5f70c3862c0844a687df0f572c51e11497/httptools-0.8.0-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:52dd695b865fe96d9d2b16b64a895f3f57bf3cb064e8383cd3b5713a069e8085", size = 449809, upload-time = "2026-05-25T22:17:04.443Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/f9/5811c74f37a758c8a4aa3dc430375119d335947e883efc4664d8f3559a41/httptools-0.8.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:20b4aac66ff65f7db06a375808b78f42a94970aa22e826b3cb2b43eb09174124", size = 452174, upload-time = "2026-05-25T22:17:05.476Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/94/97b75870dea07b71e3ec535cebe525b08d723152e4c7d13fa887e51f4de2/httptools-0.8.0-cp311-cp311-win_amd64.whl", hash = "sha256:a1b4c8e7a489a0d750d91894e9a8cdc295838f1924c0ca903ae993456fddec07", size = 90991, upload-time = "2026-05-25T22:17:06.75Z" },
+    { url = "https://files.pythonhosted.org/packages/14/88/1d21a36da8f5cb0fa49eafd4b169eba5608d57e75bbcf61845cbc6243216/httptools-0.8.0-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:880490234c10f70a9830743097e8958d6e4b9f5a0ffc24515023afeef984054d", size = 208247, upload-time = "2026-05-25T22:17:07.843Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/42/cc4feea2945cb3051038f090c9b36bd5b8a9d7f5a894a506a8983e33fd1c/httptools-0.8.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:5931891fb7b441b8a3853cf1b85c82c903defce084dd5f6771ca46e31bf862c5", size = 113064, upload-time = "2026-05-25T22:17:09.136Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/a6/febbb8b8db0f58b38e44ad6cb946e6a255ae49b55f2e8543408fb7501ccd/httptools-0.8.0-cp312-cp312-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:b15fc622b0f869d19207c4089a501d9bcc63ca5e071ffdd2f03f922df882dcb2", size = 523851, upload-time = "2026-05-25T22:17:10.106Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/e4/f90a0df0b83beff265b7e3b65f2a4cefd95792d4be0ac3e16049f2acd3c2/httptools-0.8.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:425f83884fd6343828d8c565f046cb72b6d19063f6924093e11bcd8e1548cd09", size = 518842, upload-time = "2026-05-25T22:17:11.218Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/2d/0c9ac76dd2c893841fbf6498d6acec4f2442e1b7067f6e3e316a80e494e8/httptools-0.8.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:ef7c3c97f4311c7be57e2986629df89d49cb434dbff78eafcd48c2bff986b15a", size = 501238, upload-time = "2026-05-25T22:17:12.728Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/42/906adc91ae3a5fa9c59c0a2f21c139725bd7e5b41ae6acd485cd14123ebf/httptools-0.8.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:a1afd7c9fbff0d9f5d489c4ce2768bd09c84a46ddefc7161e6aa82ae35c85745", size = 509567, upload-time = "2026-05-25T22:17:13.842Z" },
+    { url = "https://files.pythonhosted.org/packages/05/0b/4240efeb672751ee5b9b380cb0e3fdc050bc05f68adc7a8aefc4fcd9a69a/httptools-0.8.0-cp312-cp312-win_amd64.whl", hash = "sha256:cd96f29b4bab1d42fa6e3d008711c75e0f79e94e06827330160e3a304227f150", size = 90918, upload-time = "2026-05-25T22:17:15.155Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/e5/8cfcabc5546e8022f168be28bcdaa128a240a0befdd03b59d558b4f18bd6/httptools-0.8.0-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:614ceea8ea606848bece2338ac03b3ce5324bcb4be8dc7d377ed708012fa4db8", size = 205148, upload-time = "2026-05-25T22:17:16.333Z" },
+    { url = "https://files.pythonhosted.org/packages/2a/0e/0fb14848c19a686c8062ff9067c1a48793e3224b47bc5b201535b6036fce/httptools-0.8.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:2d689918c15a013c65ef52d9fd495d766893ab831a2c8d89f2ac5940a5df847c", size = 111368, upload-time = "2026-05-25T22:17:17.586Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/1b/46f1cecf06b9bbde8e4b8c88034ac7908989e5ff7a3a388ef38392949c1f/httptools-0.8.0-cp313-cp313-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:eb3028cca2fc0a6d720e52ef61d8ebb62fcbfeb1de56874546d858d3f25a26b7", size = 486447, upload-time = "2026-05-25T22:17:18.564Z" },
+    { url = "https://files.pythonhosted.org/packages/77/00/258bfc0837221f81d9725c45f9b948a6a6b2994a147a4fb66e85100c668f/httptools-0.8.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:88bdd940f2b5d487b4d032c6afa5489a7dc4694410d43de3c38c4fb3af0dc45d", size = 482448, upload-time = "2026-05-25T22:17:19.912Z" },
+    { url = "https://files.pythonhosted.org/packages/04/ab/d1cef3b5523f4d272a70f42a776c3169a2dddfe3a54de4b2ce4a36341528/httptools-0.8.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:6a43c9dd399758ccc0531acb0a3c4a6c299ee893ee9400e9c893b7bdcfae0681", size = 464460, upload-time = "2026-05-25T22:17:20.882Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/48/5d1d072442277bb2b3434e0e60690b8e8c23840ef7de8b6ea54040a536d3/httptools-0.8.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:0770728beb05094c809b98e814edff5fef69d26ad7d21185f2f6d5884a0ba683", size = 471312, upload-time = "2026-05-25T22:17:22.085Z" },
+    { url = "https://files.pythonhosted.org/packages/0d/66/b96623b27e51a68199ef4efdda0613cced9233fe3062ac74e50749c5ad37/httptools-0.8.0-cp313-cp313-win_amd64.whl", hash = "sha256:7685df791fad561384bfb139e77fde27a1ffd93134e016f95a0db424ffbf77b1", size = 90117, upload-time = "2026-05-25T22:17:23.074Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/12/fa3fbf5f9517b273edea2dc982aa82a8c634091e67c590792b729017bc6f/httptools-0.8.0-cp314-cp314-macosx_10_13_universal2.whl", hash = "sha256:de242a49b5d18e0a8776e654e9f6bf6d89f3875a5c35b425a0e7ce940feb3fd6", size = 206183, upload-time = "2026-05-25T22:17:24.004Z" },
+    { url = "https://files.pythonhosted.org/packages/30/fc/5e7c4cb443370f2090a3aba0453a07384d29ff66b7435bb90e77e1037599/httptools-0.8.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:159e9ab5f701ccd42e555a12f1ad8ff69702910fc1c996cf2bb66e5fcb7a231b", size = 112079, upload-time = "2026-05-25T22:17:25.216Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/53/771bd891eb0f236f32145d6a1775777ec85745f3cc983a1f23d1a3b8ddfe/httptools-0.8.0-cp314-cp314-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:c4a9f1707e4823d54dfec6c33fa3697d302aed536ed352a7ebb5a061ddb869d0", size = 481596, upload-time = "2026-05-25T22:17:26.186Z" },
+    { url = "https://files.pythonhosted.org/packages/62/42/94e15bc68ce3d423243c45d7f1b0c7561f13844f97dc52ae23182fb65628/httptools-0.8.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:d76ad7b951387e3632c8716a9bb03ac5b45c5f16119aa409db0459520887944e", size = 480865, upload-time = "2026-05-25T22:17:27.542Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/7c/fe2980fc03723272e30f135b62360b075f513dfe7cc73aef36c7f04012bd/httptools-0.8.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:a3b7387147361c3fd47a0bde763c5c91b5b4cd4dc9989b8ece84ff436c99843b", size = 463189, upload-time = "2026-05-25T22:17:28.546Z" },
+    { url = "https://files.pythonhosted.org/packages/15/1b/47fc5fff68acd1bfa20b4734059c9a06cadb88119dcd5258b5b0d21d91c8/httptools-0.8.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:f256d6ce930c52ca1cb2a960b7da03548c454e7d28b06059ad41bfe789036ce0", size = 466610, upload-time = "2026-05-25T22:17:29.816Z" },
+    { url = "https://files.pythonhosted.org/packages/60/bd/07b13c93ffd9bec9546e0d43f8e19378dd696dbd278511406bc07371ef1f/httptools-0.8.0-cp314-cp314-win_amd64.whl", hash = "sha256:19d1ee275bb59ba2643ba9a3a1e51cc0c788caf2b8df506368e03f56fdd08527", size = 92705, upload-time = "2026-05-25T22:17:31.133Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/c4/121648f68ce066d7bd762d6b6d97e620847642d38d54f3d90ff11d947629/httptools-0.8.0-cp314-cp314t-macosx_10_13_universal2.whl", hash = "sha256:de1ed58a974e75d56560acc7e7fed01a454994429456f65209789992e41f2568", size = 215023, upload-time = "2026-05-25T22:17:32.401Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/b0/312a062ae741ae3e8baa8c8bf20be81b2e67337b259ab4349bebc7b6142e/httptools-0.8.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:e93c227b595c6926c1acee96891dd9da4be338cfbe82e5cd3bb9d8dd7dc4ac0b", size = 117405, upload-time = "2026-05-25T22:17:33.742Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/37/fccd705f795386bb05bf413012fecff2a33e5aa8c2f069096de3e9fd8702/httptools-0.8.0-cp314-cp314t-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:2a021c3a8e65cc125390d72f59b968afca3bdcaff25bd67965e0a055a14946ca", size = 558497, upload-time = "2026-05-25T22:17:34.732Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/39/f172e8003576de35f5ba77ff417cf0e34429d35dc014deef15afa337a72c/httptools-0.8.0-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:48774d39cbb70e2b1f71f88852a3087ae1d3a1eb80482bb48c13067ab080c14f", size = 571585, upload-time = "2026-05-25T22:17:35.813Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/b9/f5564760af99f3dbbf3f9104dc00e5da27e96cf433c6bdcf77617f70bf3f/httptools-0.8.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:88eead8ec8680a9f146c655bc88445a325bd7921cfd8194c7337e9467282427d", size = 543297, upload-time = "2026-05-25T22:17:37.08Z" },
+    { url = "https://files.pythonhosted.org/packages/99/67/8d9f2c313618e161b82f3873188e7196126da1d6e29688df40eb3997c77a/httptools-0.8.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:2c032fa028f46871ec7e1fc59fc15e8023eab3e6bbe6ece786a1611719a5d081", size = 539535, upload-time = "2026-05-25T22:17:38.032Z" },
+    { url = "https://files.pythonhosted.org/packages/48/63/b906c01e53f50d432c0defe43ce52764a111dc1bdd028bafbeb54dcfd008/httptools-0.8.0-cp314-cp314t-win_amd64.whl", hash = "sha256:384c17174464c8e873398b7af24f0b1f44d992c820328413951a625323155d77", size = 108209, upload-time = "2026-05-25T22:17:39.473Z" },
+]
+
+[[package]]
+name = "httpx"
+version = "0.28.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "certifi" },
+    { name = "httpcore" },
+    { name = "idna" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b1/df/48c586a5fe32a0f01324ee087459e112ebb7224f646c0b5023f5e79e9956/httpx-0.28.1.tar.gz", hash = "sha256:75e98c5f16b0f35b567856f597f06ff2270a374470a5c2392242528e3e3e42fc", size = 141406, upload-time = "2024-12-06T15:37:23.222Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2a/39/e50c7c3a983047577ee07d2a9e53faf5a69493943ec3f6a384bdc792deb2/httpx-0.28.1-py3-none-any.whl", hash = "sha256:d909fcccc110f8c7faf814ca82a9a4d816bc5a6dbfea25d6591d6985b8ba59ad", size = 73517, upload-time = "2024-12-06T15:37:21.509Z" },
 ]
 
 [[package]]
@@ -666,6 +898,123 @@ wheels = [
 ]
 
 [[package]]
+name = "pydantic"
+version = "2.13.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "annotated-types" },
+    { name = "pydantic-core" },
+    { name = "typing-extensions" },
+    { name = "typing-inspection" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/18/a5/b60d21ac674192f8ab0ba4e9fd860690f9b4a6e51ca5df118733b487d8d6/pydantic-2.13.4.tar.gz", hash = "sha256:c40756b57adaa8b1efeeced5c196f3f3b7c435f90e84ea7f443901bec8099ef6", size = 844775, upload-time = "2026-05-06T13:43:05.343Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fd/7b/122376b1fd3c62c1ed9dc80c931ace4844b3c55407b6fb2d199377c9736f/pydantic-2.13.4-py3-none-any.whl", hash = "sha256:45a282cde31d808236fd7ea9d919b128653c8b38b393d1c4ab335c62924d9aba", size = 472262, upload-time = "2026-05-06T13:43:02.641Z" },
+]
+
+[[package]]
+name = "pydantic-core"
+version = "2.46.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/9d/56/921726b776ace8d8f5db44c4ef961006580d91dc52b803c489fafd1aa249/pydantic_core-2.46.4.tar.gz", hash = "sha256:62f875393d7f270851f20523dd2e29f082bcc82292d66db2b64ea71f64b6e1c1", size = 471464, upload-time = "2026-05-06T13:37:06.98Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5c/fa/6d7708d2cfc1a832acb6aeb0cd16e801902df8a0f583bb3b4b527fde022e/pydantic_core-2.46.4-cp311-cp311-macosx_10_12_x86_64.whl", hash = "sha256:0e96592440881c74a213e5ad528e2b24d3d4f940de2766bed9010ab1d9e51594", size = 2111872, upload-time = "2026-05-06T13:40:27.596Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/6f/aa064a3e74b5745afbdf250594f38e7ead05e2d651bcb35994b9417a0d4d/pydantic_core-2.46.4-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:e0d65b8c354be7fb5f720c3caa8bc940bc2d20ce749c8e06135f07f8ed95dd7c", size = 1948255, upload-time = "2026-05-06T13:39:12.574Z" },
+    { url = "https://files.pythonhosted.org/packages/43/3a/41114a9f7569b84b4d84e7a018c57c56347dac30c0d4a872946ec4e36c46/pydantic_core-2.46.4-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:7bfb192b3f4b9e8a89b6277b6ce787564f62cfd272055f6e685726b111dc7826", size = 1972827, upload-time = "2026-05-06T13:38:19.841Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/25/1ab42e8048fe551934d9884e8d64daa7e990ad386f310a15981aeb6a5b08/pydantic_core-2.46.4-cp311-cp311-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:9037063db01f09b09e237c282b6792bd4da634b5402c4e7f0c61effed7701a04", size = 2041051, upload-time = "2026-05-06T13:38:10.447Z" },
+    { url = "https://files.pythonhosted.org/packages/94/c2/1a934597ddf08da410385b3b7aae91956a5a76c635effef456074fad7e88/pydantic_core-2.46.4-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:fc010ab034c8c7452522748bf937df58020d256ccae0874463d1f4d01758af8e", size = 2221314, upload-time = "2026-05-06T13:40:13.089Z" },
+    { url = "https://files.pythonhosted.org/packages/02/6d/9e8ad178c9c4df27ad3c8f25d1fe2a7ab0d2ba0559fad4aee5d3d1f16771/pydantic_core-2.46.4-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:8c5dac79fa1614d1e06ca695109c6105923bd9c7d1d6c918d4e637b7e6b32fd3", size = 2285146, upload-time = "2026-05-06T13:38:59.224Z" },
+    { url = "https://files.pythonhosted.org/packages/80/50/540cd3aeefc041beb111125c4bff779831a2111fc6b15a9138cda277d32c/pydantic_core-2.46.4-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:f9fa868638bf362d3d138ea55829cefb3d5f4b0d7f142234382a15e2485dbec4", size = 2089685, upload-time = "2026-05-06T13:38:17.762Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/a4/b440ad35f05f6a38f89fa0f149accb3f0e02be94ca5e15f3c449a61b4bc9/pydantic_core-2.46.4-cp311-cp311-manylinux_2_31_riscv64.whl", hash = "sha256:17299feefe090f2caa5b8e37222bb5f663e4935a8bfa6931d4102e5df1a9f398", size = 2115420, upload-time = "2026-05-06T13:37:58.195Z" },
+    { url = "https://files.pythonhosted.org/packages/99/61/de4f55db8dfd57bfdfa9a12ec90fe1b57c4f41062f7ca86f08586b3e0ac0/pydantic_core-2.46.4-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:4c63ebc82684aa89d9a3bcbd13d515b3be44250dc68dd3bd81526c1cb31286c3", size = 2165122, upload-time = "2026-05-06T13:37:01.167Z" },
+    { url = "https://files.pythonhosted.org/packages/f7/52/7c529d7bdb2d1068bd52f51fe32572c8301f9a4febf1948f10639f1436f5/pydantic_core-2.46.4-cp311-cp311-musllinux_1_1_aarch64.whl", hash = "sha256:aaa2a54443eff1950ba5ddc6b6ccda0d9c84a364276a62f969bdf2a390650848", size = 2182573, upload-time = "2026-05-06T13:38:45.04Z" },
+    { url = "https://files.pythonhosted.org/packages/37/b3/7c40325848ba78247f2812dcf9c7274e38cd801820ca6dd9fe63bcfb0eb4/pydantic_core-2.46.4-cp311-cp311-musllinux_1_1_armv7l.whl", hash = "sha256:18e5ceec2ab67e6d5f1a9085e5a24c9c4e2ac4545730bfe668680bca05e555f3", size = 2317139, upload-time = "2026-05-06T13:37:15.539Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/37/f913f81a657c865b75da6c0dbed79876073c2a43b5bd9edbe8da785e4d49/pydantic_core-2.46.4-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:a0f62d0a58f4e7da165457e995725421e0064f2255d8eccebc49f41bbc23b109", size = 2360433, upload-time = "2026-05-06T13:37:30.099Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/67/6acaa1be2567f9256b056d8477158cac7240813956ce86e49deae8e173b4/pydantic_core-2.46.4-cp311-cp311-win32.whl", hash = "sha256:041bde0a48fd37cf71cab1c9d56d3e8625a3793fef1f7dd232b3ff37e978ecda", size = 1985513, upload-time = "2026-05-06T13:38:15.669Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/e6/c505f83dfeda9a2e5c995cfd872949e4d05e12f7feb3dca72f633daefa94/pydantic_core-2.46.4-cp311-cp311-win_amd64.whl", hash = "sha256:6f2eeda33a839975441c86a4119e1383c50b47faf0cbb5176985565c6bb02c33", size = 2071114, upload-time = "2026-05-06T13:40:35.416Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/da/7a263a96d965d9d0df5e8de8a475f33495451117035b09acb110288c381f/pydantic_core-2.46.4-cp311-cp311-win_arm64.whl", hash = "sha256:14f4c5d6db102bd796a627bbb3a17b4cf4574b9ae861d8b7c9a9661c6dd3362d", size = 2044298, upload-time = "2026-05-06T13:38:29.754Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/8c/af022f0af448d7747c5154288d46b5f2bc5f17366eaa0e23e9aa04d59f3b/pydantic_core-2.46.4-cp312-cp312-macosx_10_12_x86_64.whl", hash = "sha256:3245406455a5d98187ec35530fd772b1d799b26667980872c8d4614991e2c4a2", size = 2106158, upload-time = "2026-05-06T13:38:57.215Z" },
+    { url = "https://files.pythonhosted.org/packages/19/95/6195171e385007300f0f5574592e467c568becce2d937a0b6804f218bc49/pydantic_core-2.46.4-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:962ccbab7b642487b1d8b7df90ef677e03134cf1fd8880bf698649b22a69371f", size = 1951724, upload-time = "2026-05-06T13:37:02.697Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/bc/f47d1ff9cbb1620e1b5b697eef06010035735f07820180e74178226b27b3/pydantic_core-2.46.4-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:8233f2947cf85404441fd7e0085f53b10c93e0ee78611099b5c7237e36aacbf7", size = 1975742, upload-time = "2026-05-06T13:37:09.448Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/11/9b9a5b0306345664a2da6410877af6e8082481b5884b3ddd78d47c6013ce/pydantic_core-2.46.4-cp312-cp312-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:3a233125ac121aa3ffba9a2b59edfc4a985a76092dc8279586ab4b71390875e7", size = 2052418, upload-time = "2026-05-06T13:37:38.234Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/b7/a65fec226f5d78fc39f4a13c4cc0c768c22b113438f60c14adc9d2865038/pydantic_core-2.46.4-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:5b712b53160b79a5850310b912a5ef8e57e56947c8ad690c227f5c9d7e561712", size = 2232274, upload-time = "2026-05-06T13:38:27.753Z" },
+    { url = "https://files.pythonhosted.org/packages/68/f0/92039db98b907ef49269a8271f67db9cb78ae2fc68062ef7e4e77adb5f61/pydantic_core-2.46.4-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:9401557acd873c3a7f3eb9383edef8ac4968f9510e340f4808d427e75667e7b4", size = 2309940, upload-time = "2026-05-06T13:38:05.353Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/97/2aab507d3d00ca626e8e57c1eac6a79e4e5fbcc63eb99733ff55d1717f65/pydantic_core-2.46.4-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:926c9541b14b12b1681dca8a0b75feb510b06c6341b70a8e500c2fdcff837cce", size = 2094516, upload-time = "2026-05-06T13:39:10.577Z" },
+    { url = "https://files.pythonhosted.org/packages/22/37/a8aca44d40d737dde2bc05b3c6c07dff0de07ce6f82e9f3167aeaf4d5dea/pydantic_core-2.46.4-cp312-cp312-manylinux_2_31_riscv64.whl", hash = "sha256:56cb4851bcaf3d117eddcef4fe66afd750a50274b0da8e22be256d10e5611987", size = 2136854, upload-time = "2026-05-06T13:40:22.59Z" },
+    { url = "https://files.pythonhosted.org/packages/24/99/fcef1b79238c06a8cbec70819ac722ba76e02bc8ada9b0fd66eba40da01b/pydantic_core-2.46.4-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:c68fcd102d71ea85c5b2dfac3f4f8476eff42a9e078fd5faefff6d145063536b", size = 2180306, upload-time = "2026-05-06T13:40:10.666Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/6c/fc44000918855b42779d007ae63b0532794739027b2f417321cddbc44f6a/pydantic_core-2.46.4-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:b2f69dec1725e79a012d920df1707de5caf7ed5e08f3be4435e25803efc47458", size = 2190044, upload-time = "2026-05-06T13:40:43.231Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/65/d9cadc9f1920d7a127ad2edba16c1db7916e59719285cd6c94600b0080ba/pydantic_core-2.46.4-cp312-cp312-musllinux_1_1_armv7l.whl", hash = "sha256:8d0820e8192167f80d88d64038e609c31452eeca865b4e1d9950a27a4609b00b", size = 2329133, upload-time = "2026-05-06T13:39:57.365Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/cf/c873d91679f3a30bcf5e7ac280ce5573483e72295307685120d0d5ad3416/pydantic_core-2.46.4-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:fbdb89b3e1c94a30cc5edfce477c6e6a5dc4d8f84665b455c27582f211a1c72c", size = 2374464, upload-time = "2026-05-06T13:38:06.976Z" },
+    { url = "https://files.pythonhosted.org/packages/47/bd/6f2fc8188f31bf10590f1e98e7b306336161fac930a8c514cd7bd828c7dc/pydantic_core-2.46.4-cp312-cp312-win32.whl", hash = "sha256:9aa768456404a8bf48a4406685ac2bec8e72b62c69313734fa3b73cf33b3a894", size = 1974823, upload-time = "2026-05-06T13:40:47.985Z" },
+    { url = "https://files.pythonhosted.org/packages/40/8c/985c1d41ea1107c2534abd9870e4ed5c8e7669b5c308297835c001e7a1c4/pydantic_core-2.46.4-cp312-cp312-win_amd64.whl", hash = "sha256:e9c26f834c65f5752f3f06cb08cb86a913ceb7274d0db6e267808a708b46bc89", size = 2072919, upload-time = "2026-05-06T13:39:21.153Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/ba/f463d006e0c47373ca7ec5e1a261c59dc01ef4d62b2657af925fb0deee3a/pydantic_core-2.46.4-cp312-cp312-win_arm64.whl", hash = "sha256:4fc73cb559bdb54b1134a706a2802a4cddd27a0633f5abb7e53056268751ac6a", size = 2027604, upload-time = "2026-05-06T13:39:03.753Z" },
+    { url = "https://files.pythonhosted.org/packages/51/a2/5d30b469c5267a17b39dec53208222f76a8d351dfac4af661888c5aee77d/pydantic_core-2.46.4-cp313-cp313-macosx_10_12_x86_64.whl", hash = "sha256:5d5902252db0d3cedf8d4a1bc68f70eeb430f7e4c7104c8c476753519b423008", size = 2106306, upload-time = "2026-05-06T13:37:48.029Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/81/4fa520eaffa8bd7d1525e644cd6d39e7d60b1592bc5b516693c7340b50f1/pydantic_core-2.46.4-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:c94f0688e7b8d0a67abf40e57a7eaaecd17cc9586706a31b76c031f63df052b4", size = 1951906, upload-time = "2026-05-06T13:37:17.012Z" },
+    { url = "https://files.pythonhosted.org/packages/03/d5/fd02da45b659668b05923b17ba3a0100a0a3d5541e3bd8fcc4ecb711309e/pydantic_core-2.46.4-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:f027324c56cd5406ca49c124b0db10e56c69064fec039acc571c29020cc87c76", size = 1976802, upload-time = "2026-05-06T13:37:35.113Z" },
+    { url = "https://files.pythonhosted.org/packages/21/f2/95727e1368be3d3ed485eaab7adbd7dda408f33f7a36e8b48e0144002b91/pydantic_core-2.46.4-cp313-cp313-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:e739fee756ba1010f8bcccb534252e85a35fe45ae92c295a06059ce58b74ccd3", size = 2052446, upload-time = "2026-05-06T13:37:12.313Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/86/5d99feea3f77c7234b8718075b23db11532773c1a0dbd9b9490215dc2eeb/pydantic_core-2.46.4-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:9d56801be94b86a9da183e5f3766e6310752b99ff647e38b09a9500d88e46e76", size = 2232757, upload-time = "2026-05-06T13:39:01.149Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/3a/508ac615935ef7588cf6d9e9b91309fdc2da751af865e02a9098de88258c/pydantic_core-2.46.4-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:2412e734dcb48da14d4e4006b82b46b74f2518b8a26ee7e58c6844a6cd6d03c4", size = 2309275, upload-time = "2026-05-06T13:37:41.406Z" },
+    { url = "https://files.pythonhosted.org/packages/07/f8/41db9de19d7987d6b04715a02b3b40aea467000275d9d758ffaa31af7d50/pydantic_core-2.46.4-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:9551187363ffc0de2a00b2e47c25aeaeb1020b69b668762966df15fc5659dd5a", size = 2094467, upload-time = "2026-05-06T13:39:18.847Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/e2/f35033184cb11d0052daf4416e8e10a502ea2ac006fc4f459aee872727d1/pydantic_core-2.46.4-cp313-cp313-manylinux_2_31_riscv64.whl", hash = "sha256:0186750b482eefa11d7f435892b09c5c606193ef3375bcf94aa00ae6bfb66262", size = 2134417, upload-time = "2026-05-06T13:40:17.944Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/7b/6ceeb1cc90e193862f444ebe373d8fdf613f0a82572dde03fb10734c6c71/pydantic_core-2.46.4-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:5855698a4856556d86e8e6cd8434bc3ac0314ee8e12089ae0e143f64c6256e4e", size = 2179782, upload-time = "2026-05-06T13:40:32.618Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/f2/c8d7773ede6af08036423a00ae0ceffce266c3c52a096c435d68c896083f/pydantic_core-2.46.4-cp313-cp313-musllinux_1_1_aarch64.whl", hash = "sha256:cbaf13819775b7f769bf4a1f066cb6df7a28d4480081a589828ef190226881cd", size = 2188782, upload-time = "2026-05-06T13:36:51.018Z" },
+    { url = "https://files.pythonhosted.org/packages/59/31/0c864784e31f09f05cdd87606f08923b9c9e7f6e51dd27f20f62f975ce9f/pydantic_core-2.46.4-cp313-cp313-musllinux_1_1_armv7l.whl", hash = "sha256:633147d34cf4550417f12e2b1a0383973bdf5cdfde212cb09e9a581cf10820be", size = 2328334, upload-time = "2026-05-06T13:40:37.764Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/eb/4f6c8a41efa30baa755590f4141abf3a8c370fab610915733e74134a7270/pydantic_core-2.46.4-cp313-cp313-musllinux_1_1_x86_64.whl", hash = "sha256:82cf5301172168103724d49a1444d3378cb20cdee30b116a1bd6031236298a5d", size = 2372986, upload-time = "2026-05-06T13:39:34.152Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/24/b375a480d53113860c299764bfe9f349a3dc9108b3adc0d7f0d786492ebf/pydantic_core-2.46.4-cp313-cp313-win32.whl", hash = "sha256:9fa8ae11da9e2b3126c6426f147e0fba88d96d65921799bb30c6abd1cb2c97fb", size = 1973693, upload-time = "2026-05-06T13:37:55.072Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/e8/cff247591966f2d22ec8c003cd7587e27b7ba7b81ab2fb888e3ab75dc285/pydantic_core-2.46.4-cp313-cp313-win_amd64.whl", hash = "sha256:6b3ace8194b0e5204818c92802dcdca7fc6d88aabbb799d7c795540d9cd6d292", size = 2071819, upload-time = "2026-05-06T13:38:49.139Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/1a/f4aee670d5670e9e148e0c82c7db98d780be566c6e6a97ee8035528ca0b3/pydantic_core-2.46.4-cp313-cp313-win_arm64.whl", hash = "sha256:184c081504d17f1c1066e430e117142b2c77d9448a97f7b65c6ac9fd9aee238d", size = 2027411, upload-time = "2026-05-06T13:40:45.796Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/74/228a26ddad29c6672b805d9fd78e8d251cd04004fa7eed0e622096cd0250/pydantic_core-2.46.4-cp314-cp314-macosx_10_12_x86_64.whl", hash = "sha256:428e04521a40150c85216fc8b85e8d39fece235a9cf5e383761238c7fa9b96fb", size = 2102079, upload-time = "2026-05-06T13:38:41.019Z" },
+    { url = "https://files.pythonhosted.org/packages/ad/1f/8970b150a4b4365623ae00fc88603491f763c627311ae8031e3111356d6e/pydantic_core-2.46.4-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:23ace664830ee0bfe014a0c7bc248b1f7f25ed7ad103852c317624a1083af462", size = 1952179, upload-time = "2026-05-06T13:36:59.812Z" },
+    { url = "https://files.pythonhosted.org/packages/95/30/5211a831ae054928054b2f79731661087a2bc5c01e825c672b3a4a8f1b3e/pydantic_core-2.46.4-cp314-cp314-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ce5c1d2a8b27468f433ca974829c44060b8097eedc39933e3c206a90ee49c4a9", size = 1978926, upload-time = "2026-05-06T13:37:39.933Z" },
+    { url = "https://files.pythonhosted.org/packages/57/e9/689668733b1eb67adeef047db3c2e8788fcf65a7fd9c9e2b46b7744fe245/pydantic_core-2.46.4-cp314-cp314-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:7283d57845ecf5a163403eb0702dfc220cc4fbdd18919cb5ccea4f95ee1cdab4", size = 2046785, upload-time = "2026-05-06T13:38:01.995Z" },
+    { url = "https://files.pythonhosted.org/packages/60/d9/6715260422ff50a2109878fd24d948a6c3446bb2664f34ee78cd972b3acd/pydantic_core-2.46.4-cp314-cp314-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:8daafc69c93ee8a0204506a3b6b30f586ef54028f52aeeeb5c4cfc5184fd5914", size = 2228733, upload-time = "2026-05-06T13:40:50.371Z" },
+    { url = "https://files.pythonhosted.org/packages/18/ae/fdb2f64316afca925640f8e70bb1a564b0ec2721c1389e25b8eb4bf9a299/pydantic_core-2.46.4-cp314-cp314-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:cd2213145bcc2ba85884d0ac63d222fece9209678f77b9b4d76f054c561adb28", size = 2307534, upload-time = "2026-05-06T13:37:21.531Z" },
+    { url = "https://files.pythonhosted.org/packages/89/1d/8eff589b45bb8190a9d12c49cfad0f176a5cbd1534908a6b5125e2886239/pydantic_core-2.46.4-cp314-cp314-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:7a5f930472650a82629163023e630d160863fce524c616f4e5186e5de9d9a49b", size = 2099732, upload-time = "2026-05-06T13:39:31.942Z" },
+    { url = "https://files.pythonhosted.org/packages/06/d5/ee5a3366637fee41dee51a1fc91562dcf12ddbc68fda34e6b253da2324bb/pydantic_core-2.46.4-cp314-cp314-manylinux_2_31_riscv64.whl", hash = "sha256:c1b3f518abeca3aa13c712fd202306e145abf59a18b094a6bafb2d2bbf59192c", size = 2129627, upload-time = "2026-05-06T13:37:25.033Z" },
+    { url = "https://files.pythonhosted.org/packages/94/33/2414be571d2c6a6c4d08be21f9292b6d3fdb08949a97b6dfe985017821db/pydantic_core-2.46.4-cp314-cp314-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:1a7dd0b3ee80d90150e3495a3a13ac34dbcbfd4f012996a6a1d8900e91b5c0fb", size = 2179141, upload-time = "2026-05-06T13:37:14.046Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/79/7daa95be995be0eecc4cf75064cb33f9bbbfe3fe0158caf2f0d4a996a5c7/pydantic_core-2.46.4-cp314-cp314-musllinux_1_1_aarch64.whl", hash = "sha256:3fb702cd90b0446a3a1c5e470bfa0dd23c0233b676a9099ddcc964fa6ca13898", size = 2184325, upload-time = "2026-05-06T13:36:53.615Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/cb/d0a382f5c0de8a222dc61c65348e0ce831b1f68e0a018450d31c2cace3a5/pydantic_core-2.46.4-cp314-cp314-musllinux_1_1_armv7l.whl", hash = "sha256:b8458003118a712e66286df6a707db01c52c0f52f7db8e4a38f0da1d3b94fc4e", size = 2323990, upload-time = "2026-05-06T13:40:29.971Z" },
+    { url = "https://files.pythonhosted.org/packages/05/db/d9ba624cc4a5aced1598e88c04fdbd8310c8a69b9d38b9a3d39ce3a61ed7/pydantic_core-2.46.4-cp314-cp314-musllinux_1_1_x86_64.whl", hash = "sha256:372429a130e469c9cd698925ce5fc50940b7a1336b0d82038e63d5bbc4edc519", size = 2369978, upload-time = "2026-05-06T13:37:23.027Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/20/d15df15ba918c423461905802bfd2981c3af0bfa0e40d05e13edbfa48bc3/pydantic_core-2.46.4-cp314-cp314-win32.whl", hash = "sha256:85bb3611ff1802f3ee7fdd7dbff26b56f343fb432d57a4728fdd49b6ef35e2f4", size = 1966354, upload-time = "2026-05-06T13:38:03.499Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/b6/6b8de4c0a7d7ab3004c439c80c5c1e0a3e8d78bbae19379b01960383d9e5/pydantic_core-2.46.4-cp314-cp314-win_amd64.whl", hash = "sha256:811ff8e9c313ab425368bcbb36e5c4ebd7108c2bbf4e4089cfbb0b01eff63fac", size = 2072238, upload-time = "2026-05-06T13:39:40.807Z" },
+    { url = "https://files.pythonhosted.org/packages/32/36/51eb763beec1f4cf59b1db243a7dcc39cbb41230f050a09b9d69faaf0a48/pydantic_core-2.46.4-cp314-cp314-win_arm64.whl", hash = "sha256:bfec22eab3c8cc2ceec0248aec886624116dc079afa027ecc8ad4a7e62010f8a", size = 2018251, upload-time = "2026-05-06T13:37:26.72Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/91/855af51d625b23aa987116a19e231d2aaef9c4a415273ddc189b79a45fee/pydantic_core-2.46.4-cp314-cp314t-macosx_10_12_x86_64.whl", hash = "sha256:af8244b2bef6aaad6d92cda81372de7f8c8d36c9f0c3ea36e827c60e7d9467a0", size = 2099593, upload-time = "2026-05-06T13:39:47.682Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/1b/8784a54c65edb5f49f0a14d6977cf1b209bba85a4c77445b255c2de58ab3/pydantic_core-2.46.4-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:5a4330cdbc57162e4b3aa303f588ba752257694c9c9be3e7ebb11b4aca659b5d", size = 1935226, upload-time = "2026-05-06T13:40:40.428Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/e7/1955d28d1afc56dd4b3ad7cc0cf39df1b9852964cf16e5d13912756d6d6b/pydantic_core-2.46.4-cp314-cp314t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:29c61fc04a3d840155ff08e475a04809278972fe6aef51e2720554e96367e34b", size = 1974605, upload-time = "2026-05-06T13:37:32.029Z" },
+    { url = "https://files.pythonhosted.org/packages/93/e2/3fedbf0ba7a22850e6e9fd78117f1c0f10f950182344d8a6c535d468fdd8/pydantic_core-2.46.4-cp314-cp314t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:c50f2528cf200c5eed56faf3f4e22fcd5f38c157a8b78576e6ba3168ec35f000", size = 2030777, upload-time = "2026-05-06T13:38:55.239Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/61/46be275fcaaba0b4f5b9669dd852267ce1ff616592dccf7a7845588df091/pydantic_core-2.46.4-cp314-cp314t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:0cbe8b01f948de4286c74cdd6c667aceb38f5c1e26f0693b3983d9d74887c65e", size = 2236641, upload-time = "2026-05-06T13:37:08.096Z" },
+    { url = "https://files.pythonhosted.org/packages/60/db/12e93e46a8bac9988be3c016860f83293daea8c716c029c9ace279036f2f/pydantic_core-2.46.4-cp314-cp314t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:617d7e2ca7dcb8c5cf6bcb8c59b8832c94b36196bbf1cbd1bfb56ed341905edd", size = 2286404, upload-time = "2026-05-06T13:40:20.221Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/4a/4d8b19008f38d31c53b8219cfedc2e3d5de5fe99d90076b7e767de29274f/pydantic_core-2.46.4-cp314-cp314t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:7027560ee92211647d0d34e3f7cd6f50da56399d26a9c8ad0da286d3869a53f3", size = 2109219, upload-time = "2026-05-06T13:38:12.153Z" },
+    { url = "https://files.pythonhosted.org/packages/88/70/3cbc40978fefb7bb09c6708d40d4ad1a5d70fd7213c3d17f971de868ec1f/pydantic_core-2.46.4-cp314-cp314t-manylinux_2_31_riscv64.whl", hash = "sha256:f99626688942fb746e545232e7726926f3be91b5975f8b55327665fafda991c7", size = 2110594, upload-time = "2026-05-06T13:40:02.971Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/20/b8d36736216e29491125531685b2f9e61aa5b4b2599893f8268551da3338/pydantic_core-2.46.4-cp314-cp314t-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:fc3e9034a63de20e15e8ade85358bc6efc614008cab72898b4b4952bea0509ff", size = 2159542, upload-time = "2026-05-06T13:39:27.506Z" },
+    { url = "https://files.pythonhosted.org/packages/1d/a2/367df868eb584dacf6bf82a389272406d7178e301c4ac82545ab98bc2dd9/pydantic_core-2.46.4-cp314-cp314t-musllinux_1_1_aarch64.whl", hash = "sha256:97e7cf2be5c77b7d1a9713a05605d49460d02c6078d38d8bef3cbe323c548424", size = 2168146, upload-time = "2026-05-06T13:38:31.93Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/b8/4460f77f7e201893f649a29ab355dddd3beee8a97bcb1a320db414f9a06e/pydantic_core-2.46.4-cp314-cp314t-musllinux_1_1_armv7l.whl", hash = "sha256:3bf92c5d0e00fefaab325a4d27828fe6b6e2a21848686b5b60d2d9eeb09d76c6", size = 2306309, upload-time = "2026-05-06T13:37:44.717Z" },
+    { url = "https://files.pythonhosted.org/packages/64/c4/be2639293acd87dc8ddbcec41a73cee9b2ebf996fe6d892a1a74e88ad3f7/pydantic_core-2.46.4-cp314-cp314t-musllinux_1_1_x86_64.whl", hash = "sha256:3ecbc122d18468d06ca279dc26a8c2e2d5acb10943bb35e36ae92096dc3b5565", size = 2369736, upload-time = "2026-05-06T13:37:05.645Z" },
+    { url = "https://files.pythonhosted.org/packages/30/a6/9f9f380dbb301f67023bf8f707aaa75daadf84f7152d95c410fd7e81d994/pydantic_core-2.46.4-cp314-cp314t-win32.whl", hash = "sha256:e846ae7835bf0703ae43f534ab79a867146dadd59dc9ca5c8b53d5c8f7c9ef02", size = 1955575, upload-time = "2026-05-06T13:38:51.116Z" },
+    { url = "https://files.pythonhosted.org/packages/40/1f/f1eb9eb350e795d1af8586289746f5c5677d16043040d63710e22abc43c9/pydantic_core-2.46.4-cp314-cp314t-win_amd64.whl", hash = "sha256:2108ba5c1c1eca18030634489dc544844144ee36357f2f9f780b93e7ddbb44b5", size = 2051624, upload-time = "2026-05-06T13:38:21.672Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/d2/42dd53d0a85c27606f316d3aa5d2869c4e8470a5ed6dec30e4a1abe19192/pydantic_core-2.46.4-cp314-cp314t-win_arm64.whl", hash = "sha256:4fcbe087dbc2068af7eda3aa87634eba216dbda64d1ae73c8684b621d33f6596", size = 2017325, upload-time = "2026-05-06T13:40:52.723Z" },
+    { url = "https://files.pythonhosted.org/packages/ee/a4/73995fd4ebbb46ba0ee51e6fa049b8f02c40daebb762208feda8a6b7894d/pydantic_core-2.46.4-graalpy311-graalpy242_311_native-macosx_10_12_x86_64.whl", hash = "sha256:14d4edf427bdcf950a8a02d7cb44a08614388dd6e1bdcbf4f67504fa7887da9c", size = 2111589, upload-time = "2026-05-06T13:37:10.817Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/7f/f37d3a5e8bfcc2e403f5c57a730f2d815693fb42119e8ea48b3789335af1/pydantic_core-2.46.4-graalpy311-graalpy242_311_native-macosx_11_0_arm64.whl", hash = "sha256:0ce40cd7b21210e99342afafbd4d0f76d784eb5b1d60f3bdc566be4983c6c73b", size = 1944552, upload-time = "2026-05-06T13:36:56.717Z" },
+    { url = "https://files.pythonhosted.org/packages/15/3c/d7eb777b3ff43e8433a4efb39a17aa8fd98a4ee8561a24a67ef5db07b2d6/pydantic_core-2.46.4-graalpy311-graalpy242_311_native-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:90884113d8b48f760e9587002789ddd741e76ab9f89518cd1e43b1f1a52ec44b", size = 1982984, upload-time = "2026-05-06T13:39:06.207Z" },
+    { url = "https://files.pythonhosted.org/packages/63/87/70b9f40170a81afd55ca26c9b2acb25c20d64bcfbf888fafecb3ba077d4c/pydantic_core-2.46.4-graalpy311-graalpy242_311_native-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:66ce7632c22d837c95301830e111ad0128a32b8207533b60896a96c4915192ea", size = 2138417, upload-time = "2026-05-06T13:39:45.476Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/1d/8987ad40f65ae1432753072f214fb5c74fe47ffbd0698bb9cbbb585664f8/pydantic_core-2.46.4-graalpy312-graalpy250_312_native-macosx_10_12_x86_64.whl", hash = "sha256:1d8ba486450b14f3b1d63bc521d410ec7565e52f887b9fb671791886436a42f7", size = 2095527, upload-time = "2026-05-06T13:39:52.283Z" },
+    { url = "https://files.pythonhosted.org/packages/64/d3/84c282a7eee1d3ac4c0377546ef5a1ea436ce26840d9ac3b7ed54a377507/pydantic_core-2.46.4-graalpy312-graalpy250_312_native-macosx_11_0_arm64.whl", hash = "sha256:3009f12e4e90b7f88b4f9adb1b0c4a3d58fe7820f3238c190047209d148026df", size = 1936024, upload-time = "2026-05-06T13:40:15.671Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/ca/eac61596cdeb4d7e174d3dc0bd8a6238f14f75f97a24e7b7db4c7e7340a0/pydantic_core-2.46.4-graalpy312-graalpy250_312_native-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ad785e92e6dc634c21555edc8bd6b64957ab844541bcb96a1366c202951ae526", size = 1990696, upload-time = "2026-05-06T13:38:34.717Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/c3/7c8b240552251faf6b3a957db200fcfbbcec36763c050428b601e0c9b83b/pydantic_core-2.46.4-graalpy312-graalpy250_312_native-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:00c603d540afdd6b80eb39f078f33ebd46211f02f33e34a32d9f053bba711de0", size = 2147590, upload-time = "2026-05-06T13:39:29.883Z" },
+    { url = "https://files.pythonhosted.org/packages/11/cb/428de0385b6c8d44b716feba566abfacfbd23ee3c4439faa789a1456242f/pydantic_core-2.46.4-pp311-pypy311_pp73-macosx_10_12_x86_64.whl", hash = "sha256:0c563b08bca408dc7f65f700633d8442fffb2421fc47b8101377e9fd65051ff0", size = 2112782, upload-time = "2026-05-06T13:37:04.016Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/b5/6a17bdadd0fc1f170adfd05a20d37c832f52b117b4d9131da1f41bb097ce/pydantic_core-2.46.4-pp311-pypy311_pp73-macosx_11_0_arm64.whl", hash = "sha256:db06ffe51636ffe9ca531fe9023dd64bdd794be8754cb5df57c5498ae5b518a7", size = 1952146, upload-time = "2026-05-06T13:39:43.092Z" },
+    { url = "https://files.pythonhosted.org/packages/2a/dc/03734d80e362cd43ef65428e9de77c730ce7f2f11c60d2b1e1b39f0fbf99/pydantic_core-2.46.4-pp311-pypy311_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:133878133d271ade3d41d1bfb2a45ec38dbdbda40bc065921c6b04e4630127e2", size = 2134492, upload-time = "2026-05-06T13:36:58.124Z" },
+    { url = "https://files.pythonhosted.org/packages/de/df/5e5ffc085ed07cc22d298134d3d911c63e91f6a0eb91fe646750a3209910/pydantic_core-2.46.4-pp311-pypy311_pp73-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:9bc519fbf2b7578398853d815009ae5e4d4603d12f4e3f91da8c06852d3da3e9", size = 2156604, upload-time = "2026-05-06T13:37:49.88Z" },
+    { url = "https://files.pythonhosted.org/packages/81/44/6e112a4253e56f5705467cbab7ab5e91ee7398ba3d56d358635958893d3e/pydantic_core-2.46.4-pp311-pypy311_pp73-musllinux_1_1_aarch64.whl", hash = "sha256:c7a7bd4e39e8e4c12c39cd480356842b6a8a06e41b23a55a5e3e191718838ddf", size = 2183828, upload-time = "2026-05-06T13:37:43.053Z" },
+    { url = "https://files.pythonhosted.org/packages/ac/ad/5565071e937d8e752842ac241463944c9eb14c87e2d269f2658a5bd05e98/pydantic_core-2.46.4-pp311-pypy311_pp73-musllinux_1_1_armv7l.whl", hash = "sha256:d396ec2b979760aaf3218e76c24e65bd0aca24983298653b3a9d7a45f9e47b30", size = 2310000, upload-time = "2026-05-06T13:37:56.694Z" },
+    { url = "https://files.pythonhosted.org/packages/4f/c3/66883a5cec183e7fba4d024b4cbbe61851a63750ef606b0afecc46d1f2bf/pydantic_core-2.46.4-pp311-pypy311_pp73-musllinux_1_1_x86_64.whl", hash = "sha256:86e1a4418c6cd97d60c95c71164158eaf7324fae7b0923264016baa993eba6fc", size = 2361286, upload-time = "2026-05-06T13:40:05.667Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/2d/69abac8f838090bbecd5df894befb2c2619e7996a98ddb949db9f3b93225/pydantic_core-2.46.4-pp311-pypy311_pp73-win_amd64.whl", hash = "sha256:d51026d73fcfd93610abc7b27789c26b313920fcfb20e27462d74a7f8b06e983", size = 2193071, upload-time = "2026-05-06T13:38:08.682Z" },
+]
+
+[[package]]
 name = "pygments"
 version = "2.20.0"
 source = { registry = "https://pypi.org/simple" }
@@ -691,6 +1040,33 @@ wheels = [
 ]
 
 [[package]]
+name = "pytest-asyncio"
+version = "1.4.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pytest" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/43/7c/d36d04db312ecf4298932ef77e6e4a9e8ad017906e24e34f0b0c361a2473/pytest_asyncio-1.4.0.tar.gz", hash = "sha256:c6c0d2259945122819f171a32ecea2c349ead889ee28176caaf492143424be42", size = 58514, upload-time = "2026-05-26T09:56:04.083Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/03/e2/08a497ef684b88559c9cc5f4ad53a37e7b99e727094a86d6ea32536d5d3c/pytest_asyncio-1.4.0-py3-none-any.whl", hash = "sha256:933ca923a23075a87fb7070c0ec272a6848489824d887c85c812670932835aa1", size = 16930, upload-time = "2026-05-26T09:56:02.576Z" },
+]
+
+[[package]]
+name = "pytest-cov"
+version = "7.1.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "coverage", extra = ["toml"] },
+    { name = "pluggy" },
+    { name = "pytest" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b1/51/a849f96e117386044471c8ec2bd6cfebacda285da9525c9106aeb28da671/pytest_cov-7.1.0.tar.gz", hash = "sha256:30674f2b5f6351aa09702a9c8c364f6a01c27aae0c1366ae8016160d1efc56b2", size = 55592, upload-time = "2026-03-21T20:11:16.284Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9d/7a/d968e294073affff457b041c2be9868a40c1c71f4a35fcc1e45e5493067b/pytest_cov-7.1.0-py3-none-any.whl", hash = "sha256:a0461110b7865f9a271aa1b51e516c9a95de9d696734a2f71e3e78f46e1d4678", size = 22876, upload-time = "2026-03-21T20:11:14.438Z" },
+]
+
+[[package]]
 name = "pytest-mock"
 version = "3.15.1"
 source = { registry = "https://pypi.org/simple" }
@@ -712,6 +1088,28 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/66/c0/0c8b6ad9f17a802ee498c46e004a0eb49bc148f2fd230864601a86dcf6db/python-dateutil-2.9.0.post0.tar.gz", hash = "sha256:37dd54208da7e1cd875388217d5e00ebd4179249f90fb72437e91a35459a0ad3", size = 342432, upload-time = "2024-03-01T18:36:20.211Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/ec/57/56b9bcc3c9c6a792fcbaf139543cee77261f3651ca9da0c93f5c1221264b/python_dateutil-2.9.0.post0-py2.py3-none-any.whl", hash = "sha256:a8b2bc7bffae282281c8140a97d3aa9c14da0b136dfe83f850eea9a5f7470427", size = 229892, upload-time = "2024-03-01T18:36:18.57Z" },
+]
+
+[[package]]
+name = "python-dotenv"
+version = "1.2.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/82/ed/0301aeeac3e5353ef3d94b6ec08bbcabd04a72018415dcb29e588514bba8/python_dotenv-1.2.2.tar.gz", hash = "sha256:2c371a91fbd7ba082c2c1dc1f8bf89ca22564a087c2c287cd9b662adde799cf3", size = 50135, upload-time = "2026-03-01T16:00:26.196Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0b/d7/1959b9648791274998a9c3526f6d0ec8fd2233e4d4acce81bbae76b44b2a/python_dotenv-1.2.2-py3-none-any.whl", hash = "sha256:1d8214789a24de455a8b8bd8ae6fe3c6b69a5e3d64aa8a8e5d68e694bbcb285a", size = 22101, upload-time = "2026-03-01T16:00:25.09Z" },
+]
+
+[[package]]
+name = "python-telegram-bot"
+version = "22.7"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "httpcore", marker = "python_full_version >= '3.14'" },
+    { name = "httpx" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e4/25/2258161b1069e66d6c39c0a602dbe57461d4767dc0012539970ea40bc9d6/python_telegram_bot-22.7.tar.gz", hash = "sha256:784b59ea3852fe4616ad63b4a0264c755637f5d725e87755ecdee28300febf61", size = 1516454, upload-time = "2026-03-16T09:36:03.174Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/94/f7/0e2f89dd62f45d46d4ea0d8aec5893ce5b37389638db010c117f46f11450/python_telegram_bot-22.7-py3-none-any.whl", hash = "sha256:d72eed532cf763758cd9331b57a6d790aff0bb4d37d8f4e92149436fe21c6475", size = 745365, upload-time = "2026-03-16T09:36:01.498Z" },
 ]
 
 [[package]]
@@ -783,10 +1181,20 @@ dependencies = [
 
 [package.optional-dependencies]
 dev = [
+    { name = "httpx" },
     { name = "mypy" },
     { name = "pytest" },
+    { name = "pytest-asyncio" },
+    { name = "pytest-cov" },
     { name = "pytest-mock" },
     { name = "ruff" },
+]
+notifier = [
+    { name = "fastapi" },
+    { name = "pydantic" },
+    { name = "python-telegram-bot" },
+    { name = "structlog" },
+    { name = "uvicorn", extra = ["standard"] },
 ]
 
 [package.metadata]
@@ -794,14 +1202,23 @@ requires-dist = [
     { name = "ansible-core", specifier = ">=2.18.0,<2.20.0" },
     { name = "boto3" },
     { name = "click", specifier = ">=8.1" },
+    { name = "fastapi", marker = "extra == 'notifier'", specifier = ">=0.115" },
     { name = "hcloud" },
+    { name = "httpx", marker = "extra == 'dev'" },
     { name = "inquirerpy", specifier = ">=0.3.4" },
     { name = "mypy", marker = "extra == 'dev'" },
+    { name = "pydantic", marker = "extra == 'notifier'", specifier = ">=2.9" },
     { name = "pytest", marker = "extra == 'dev'" },
+    { name = "pytest-asyncio", marker = "extra == 'dev'" },
+    { name = "pytest-cov", marker = "extra == 'dev'" },
     { name = "pytest-mock", marker = "extra == 'dev'" },
+    { name = "python-telegram-bot", marker = "extra == 'notifier'", specifier = ">=21.6" },
     { name = "ruff", marker = "extra == 'dev'" },
+    { name = "structlog", marker = "extra == 'notifier'", specifier = ">=24.4" },
+    { name = "tomli", marker = "python_full_version < '3.11' and extra == 'notifier'", specifier = ">=2.0" },
+    { name = "uvicorn", extras = ["standard"], marker = "extra == 'notifier'", specifier = ">=0.32" },
 ]
-provides-extras = ["dev"]
+provides-extras = ["dev", "notifier"]
 
 [[package]]
 name = "requests"
@@ -874,12 +1291,100 @@ wheels = [
 ]
 
 [[package]]
+name = "starlette"
+version = "1.2.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/25/44/ec35f1b6e83094b997da438a02c8c9b0ade2b1e84cfc48bd4656780760a6/starlette-1.2.1.tar.gz", hash = "sha256:9b9b5ebb992e67d6093741e63c2f59e4f6fff986f81163c087867bd7b924b3f6", size = 2701854, upload-time = "2026-05-31T01:07:51.847Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1c/54/196d0c1db10af76baa4f64894448505d60d3cdf70ef92cbb35f46a4e4c71/starlette-1.2.1-py3-none-any.whl", hash = "sha256:4de0082d08c8f6764a85a54cf1120d6939507a19905c7768acad2a9f875d2b89", size = 73350, upload-time = "2026-05-31T01:07:50.09Z" },
+]
+
+[[package]]
+name = "structlog"
+version = "25.5.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ef/52/9ba0f43b686e7f3ddfeaa78ac3af750292662284b3661e91ad5494f21dbc/structlog-25.5.0.tar.gz", hash = "sha256:098522a3bebed9153d4570c6d0288abf80a031dfdb2048d59a49e9dc2190fc98", size = 1460830, upload-time = "2025-10-27T08:28:23.028Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a8/45/a132b9074aa18e799b891b91ad72133c98d8042c70f6240e4c5f9dabee2f/structlog-25.5.0-py3-none-any.whl", hash = "sha256:a8453e9b9e636ec59bd9e79bbd4a72f025981b3ba0f5837aebf48f02f37a7f9f", size = 72510, upload-time = "2025-10-27T08:28:21.535Z" },
+]
+
+[[package]]
+name = "tomli"
+version = "2.4.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/22/de/48c59722572767841493b26183a0d1cc411d54fd759c5607c4590b6563a6/tomli-2.4.1.tar.gz", hash = "sha256:7c7e1a961a0b2f2472c1ac5b69affa0ae1132c39adcb67aba98568702b9cc23f", size = 17543, upload-time = "2026-03-25T20:22:03.828Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f4/11/db3d5885d8528263d8adc260bb2d28ebf1270b96e98f0e0268d32b8d9900/tomli-2.4.1-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:f8f0fc26ec2cc2b965b7a3b87cd19c5c6b8c5e5f436b984e85f486d652285c30", size = 154704, upload-time = "2026-03-25T20:21:10.473Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/f7/675db52c7e46064a9aa928885a9b20f4124ecb9bc2e1ce74c9106648d202/tomli-2.4.1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:4ab97e64ccda8756376892c53a72bd1f964e519c77236368527f758fbc36a53a", size = 149454, upload-time = "2026-03-25T20:21:12.036Z" },
+    { url = "https://files.pythonhosted.org/packages/61/71/81c50943cf953efa35bce7646caab3cf457a7d8c030b27cfb40d7235f9ee/tomli-2.4.1-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:96481a5786729fd470164b47cdb3e0e58062a496f455ee41b4403be77cb5a076", size = 237561, upload-time = "2026-03-25T20:21:13.098Z" },
+    { url = "https://files.pythonhosted.org/packages/48/c1/f41d9cb618acccca7df82aaf682f9b49013c9397212cb9f53219e3abac37/tomli-2.4.1-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:5a881ab208c0baf688221f8cecc5401bd291d67e38a1ac884d6736cbcd8247e9", size = 243824, upload-time = "2026-03-25T20:21:14.569Z" },
+    { url = "https://files.pythonhosted.org/packages/22/e4/5a816ecdd1f8ca51fb756ef684b90f2780afc52fc67f987e3c61d800a46d/tomli-2.4.1-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:47149d5bd38761ac8be13a84864bf0b7b70bc051806bc3669ab1cbc56216b23c", size = 242227, upload-time = "2026-03-25T20:21:15.712Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/49/2b2a0ef529aa6eec245d25f0c703e020a73955ad7edf73e7f54ddc608aa5/tomli-2.4.1-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:ec9bfaf3ad2df51ace80688143a6a4ebc09a248f6ff781a9945e51937008fcbc", size = 247859, upload-time = "2026-03-25T20:21:17.001Z" },
+    { url = "https://files.pythonhosted.org/packages/83/bd/6c1a630eaca337e1e78c5903104f831bda934c426f9231429396ce3c3467/tomli-2.4.1-cp311-cp311-win32.whl", hash = "sha256:ff2983983d34813c1aeb0fa89091e76c3a22889ee83ab27c5eeb45100560c049", size = 97204, upload-time = "2026-03-25T20:21:18.079Z" },
+    { url = "https://files.pythonhosted.org/packages/42/59/71461df1a885647e10b6bb7802d0b8e66480c61f3f43079e0dcd315b3954/tomli-2.4.1-cp311-cp311-win_amd64.whl", hash = "sha256:5ee18d9ebdb417e384b58fe414e8d6af9f4e7a0ae761519fb50f721de398dd4e", size = 108084, upload-time = "2026-03-25T20:21:18.978Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/83/dceca96142499c069475b790e7913b1044c1a4337e700751f48ed723f883/tomli-2.4.1-cp311-cp311-win_arm64.whl", hash = "sha256:c2541745709bad0264b7d4705ad453b76ccd191e64aa6f0fc66b69a293a45ece", size = 95285, upload-time = "2026-03-25T20:21:20.309Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/ba/42f134a3fe2b370f555f44b1d72feebb94debcab01676bf918d0cb70e9aa/tomli-2.4.1-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:c742f741d58a28940ce01d58f0ab2ea3ced8b12402f162f4d534dfe18ba1cd6a", size = 155924, upload-time = "2026-03-25T20:21:21.626Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/c7/62d7a17c26487ade21c5422b646110f2162f1fcc95980ef7f63e73c68f14/tomli-2.4.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:7f86fd587c4ed9dd76f318225e7d9b29cfc5a9d43de44e5754db8d1128487085", size = 150018, upload-time = "2026-03-25T20:21:23.002Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/05/79d13d7c15f13bdef410bdd49a6485b1c37d28968314eabee452c22a7fda/tomli-2.4.1-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ff18e6a727ee0ab0388507b89d1bc6a22b138d1e2fa56d1ad494586d61d2eae9", size = 244948, upload-time = "2026-03-25T20:21:24.04Z" },
+    { url = "https://files.pythonhosted.org/packages/10/90/d62ce007a1c80d0b2c93e02cab211224756240884751b94ca72df8a875ca/tomli-2.4.1-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:136443dbd7e1dee43c68ac2694fde36b2849865fa258d39bf822c10e8068eac5", size = 253341, upload-time = "2026-03-25T20:21:25.177Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/7e/caf6496d60152ad4ed09282c1885cca4eea150bfd007da84aea07bcc0a3e/tomli-2.4.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:5e262d41726bc187e69af7825504c933b6794dc3fbd5945e41a79bb14c31f585", size = 248159, upload-time = "2026-03-25T20:21:26.364Z" },
+    { url = "https://files.pythonhosted.org/packages/99/e7/c6f69c3120de34bbd882c6fba7975f3d7a746e9218e56ab46a1bc4b42552/tomli-2.4.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:5cb41aa38891e073ee49d55fbc7839cfdb2bc0e600add13874d048c94aadddd1", size = 253290, upload-time = "2026-03-25T20:21:27.46Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/2f/4a3c322f22c5c66c4b836ec58211641a4067364f5dcdd7b974b4c5da300c/tomli-2.4.1-cp312-cp312-win32.whl", hash = "sha256:da25dc3563bff5965356133435b757a795a17b17d01dbc0f42fb32447ddfd917", size = 98141, upload-time = "2026-03-25T20:21:28.492Z" },
+    { url = "https://files.pythonhosted.org/packages/24/22/4daacd05391b92c55759d55eaee21e1dfaea86ce5c571f10083360adf534/tomli-2.4.1-cp312-cp312-win_amd64.whl", hash = "sha256:52c8ef851d9a240f11a88c003eacb03c31fc1c9c4ec64a99a0f922b93874fda9", size = 108847, upload-time = "2026-03-25T20:21:29.386Z" },
+    { url = "https://files.pythonhosted.org/packages/68/fd/70e768887666ddd9e9f5d85129e84910f2db2796f9096aa02b721a53098d/tomli-2.4.1-cp312-cp312-win_arm64.whl", hash = "sha256:f758f1b9299d059cc3f6546ae2af89670cb1c4d48ea29c3cacc4fe7de3058257", size = 95088, upload-time = "2026-03-25T20:21:30.677Z" },
+    { url = "https://files.pythonhosted.org/packages/07/06/b823a7e818c756d9a7123ba2cda7d07bc2dd32835648d1a7b7b7a05d848d/tomli-2.4.1-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:36d2bd2ad5fb9eaddba5226aa02c8ec3fa4f192631e347b3ed28186d43be6b54", size = 155866, upload-time = "2026-03-25T20:21:31.65Z" },
+    { url = "https://files.pythonhosted.org/packages/14/6f/12645cf7f08e1a20c7eb8c297c6f11d31c1b50f316a7e7e1e1de6e2e7b7e/tomli-2.4.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:eb0dc4e38e6a1fd579e5d50369aa2e10acfc9cace504579b2faabb478e76941a", size = 149887, upload-time = "2026-03-25T20:21:33.028Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/e0/90637574e5e7212c09099c67ad349b04ec4d6020324539297b634a0192b0/tomli-2.4.1-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:c7f2c7f2b9ca6bdeef8f0fa897f8e05085923eb091721675170254cbc5b02897", size = 243704, upload-time = "2026-03-25T20:21:34.51Z" },
+    { url = "https://files.pythonhosted.org/packages/10/8f/d3ddb16c5a4befdf31a23307f72828686ab2096f068eaf56631e136c1fdd/tomli-2.4.1-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:f3c6818a1a86dd6dca7ddcaaf76947d5ba31aecc28cb1b67009a5877c9a64f3f", size = 251628, upload-time = "2026-03-25T20:21:36.012Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/f1/dbeeb9116715abee2485bf0a12d07a8f31af94d71608c171c45f64c0469d/tomli-2.4.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:d312ef37c91508b0ab2cee7da26ec0b3ed2f03ce12bd87a588d771ae15dcf82d", size = 247180, upload-time = "2026-03-25T20:21:37.136Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/74/16336ffd19ed4da28a70959f92f506233bd7cfc2332b20bdb01591e8b1d1/tomli-2.4.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:51529d40e3ca50046d7606fa99ce3956a617f9b36380da3b7f0dd3dd28e68cb5", size = 251674, upload-time = "2026-03-25T20:21:38.298Z" },
+    { url = "https://files.pythonhosted.org/packages/16/f9/229fa3434c590ddf6c0aa9af64d3af4b752540686cace29e6281e3458469/tomli-2.4.1-cp313-cp313-win32.whl", hash = "sha256:2190f2e9dd7508d2a90ded5ed369255980a1bcdd58e52f7fe24b8162bf9fedbd", size = 97976, upload-time = "2026-03-25T20:21:39.316Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/1e/71dfd96bcc1c775420cb8befe7a9d35f2e5b1309798f009dca17b7708c1e/tomli-2.4.1-cp313-cp313-win_amd64.whl", hash = "sha256:8d65a2fbf9d2f8352685bc1364177ee3923d6baf5e7f43ea4959d7d8bc326a36", size = 108755, upload-time = "2026-03-25T20:21:40.248Z" },
+    { url = "https://files.pythonhosted.org/packages/83/7a/d34f422a021d62420b78f5c538e5b102f62bea616d1d75a13f0a88acb04a/tomli-2.4.1-cp313-cp313-win_arm64.whl", hash = "sha256:4b605484e43cdc43f0954ddae319fb75f04cc10dd80d830540060ee7cd0243cd", size = 95265, upload-time = "2026-03-25T20:21:41.219Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/fb/9a5c8d27dbab540869f7c1f8eb0abb3244189ce780ba9cd73f3770662072/tomli-2.4.1-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:fd0409a3653af6c147209d267a0e4243f0ae46b011aa978b1080359fddc9b6cf", size = 155726, upload-time = "2026-03-25T20:21:42.23Z" },
+    { url = "https://files.pythonhosted.org/packages/62/05/d2f816630cc771ad836af54f5001f47a6f611d2d39535364f148b6a92d6b/tomli-2.4.1-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:a120733b01c45e9a0c34aeef92bf0cf1d56cfe81ed9d47d562f9ed591a9828ac", size = 149859, upload-time = "2026-03-25T20:21:43.386Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/48/66341bdb858ad9bd0ceab5a86f90eddab127cf8b046418009f2125630ecb/tomli-2.4.1-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:559db847dc486944896521f68d8190be1c9e719fced785720d2216fe7022b662", size = 244713, upload-time = "2026-03-25T20:21:44.474Z" },
+    { url = "https://files.pythonhosted.org/packages/df/6d/c5fad00d82b3c7a3ab6189bd4b10e60466f22cfe8a08a9394185c8a8111c/tomli-2.4.1-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:01f520d4f53ef97964a240a035ec2a869fe1a37dde002b57ebc4417a27ccd853", size = 252084, upload-time = "2026-03-25T20:21:45.62Z" },
+    { url = "https://files.pythonhosted.org/packages/00/71/3a69e86f3eafe8c7a59d008d245888051005bd657760e96d5fbfb0b740c2/tomli-2.4.1-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:7f94b27a62cfad8496c8d2513e1a222dd446f095fca8987fceef261225538a15", size = 247973, upload-time = "2026-03-25T20:21:46.937Z" },
+    { url = "https://files.pythonhosted.org/packages/67/50/361e986652847fec4bd5e4a0208752fbe64689c603c7ae5ea7cb16b1c0ca/tomli-2.4.1-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:ede3e6487c5ef5d28634ba3f31f989030ad6af71edfb0055cbbd14189ff240ba", size = 256223, upload-time = "2026-03-25T20:21:48.467Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/9a/b4173689a9203472e5467217e0154b00e260621caa227b6fa01feab16998/tomli-2.4.1-cp314-cp314-win32.whl", hash = "sha256:3d48a93ee1c9b79c04bb38772ee1b64dcf18ff43085896ea460ca8dec96f35f6", size = 98973, upload-time = "2026-03-25T20:21:49.526Z" },
+    { url = "https://files.pythonhosted.org/packages/14/58/640ac93bf230cd27d002462c9af0d837779f8773bc03dee06b5835208214/tomli-2.4.1-cp314-cp314-win_amd64.whl", hash = "sha256:88dceee75c2c63af144e456745e10101eb67361050196b0b6af5d717254dddf7", size = 109082, upload-time = "2026-03-25T20:21:50.506Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/2f/702d5e05b227401c1068f0d386d79a589bb12bf64c3d2c72ce0631e3bc49/tomli-2.4.1-cp314-cp314-win_arm64.whl", hash = "sha256:b8c198f8c1805dc42708689ed6864951fd2494f924149d3e4bce7710f8eb5232", size = 96490, upload-time = "2026-03-25T20:21:51.474Z" },
+    { url = "https://files.pythonhosted.org/packages/45/4b/b877b05c8ba62927d9865dd980e34a755de541eb65fffba52b4cc495d4d2/tomli-2.4.1-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:d4d8fe59808a54658fcc0160ecfb1b30f9089906c50b23bcb4c69eddc19ec2b4", size = 164263, upload-time = "2026-03-25T20:21:52.543Z" },
+    { url = "https://files.pythonhosted.org/packages/24/79/6ab420d37a270b89f7195dec5448f79400d9e9c1826df982f3f8e97b24fd/tomli-2.4.1-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:7008df2e7655c495dd12d2a4ad038ff878d4ca4b81fccaf82b714e07eae4402c", size = 160736, upload-time = "2026-03-25T20:21:53.674Z" },
+    { url = "https://files.pythonhosted.org/packages/02/e0/3630057d8eb170310785723ed5adcdfb7d50cb7e6455f85ba8a3deed642b/tomli-2.4.1-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:1d8591993e228b0c930c4bb0db464bdad97b3289fb981255d6c9a41aedc84b2d", size = 270717, upload-time = "2026-03-25T20:21:55.129Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/b4/1613716072e544d1a7891f548d8f9ec6ce2faf42ca65acae01d76ea06bb0/tomli-2.4.1-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:734e20b57ba95624ecf1841e72b53f6e186355e216e5412de414e3c51e5e3c41", size = 278461, upload-time = "2026-03-25T20:21:56.228Z" },
+    { url = "https://files.pythonhosted.org/packages/05/38/30f541baf6a3f6df77b3df16b01ba319221389e2da59427e221ef417ac0c/tomli-2.4.1-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:8a650c2dbafa08d42e51ba0b62740dae4ecb9338eefa093aa5c78ceb546fcd5c", size = 274855, upload-time = "2026-03-25T20:21:57.653Z" },
+    { url = "https://files.pythonhosted.org/packages/77/a3/ec9dd4fd2c38e98de34223b995a3b34813e6bdadf86c75314c928350ed14/tomli-2.4.1-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:504aa796fe0569bb43171066009ead363de03675276d2d121ac1a4572397870f", size = 283144, upload-time = "2026-03-25T20:21:59.089Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/be/605a6261cac79fba2ec0c9827e986e00323a1945700969b8ee0b30d85453/tomli-2.4.1-cp314-cp314t-win32.whl", hash = "sha256:b1d22e6e9387bf4739fbe23bfa80e93f6b0373a7f1b96c6227c32bef95a4d7a8", size = 108683, upload-time = "2026-03-25T20:22:00.214Z" },
+    { url = "https://files.pythonhosted.org/packages/12/64/da524626d3b9cc40c168a13da8335fe1c51be12c0a63685cc6db7308daae/tomli-2.4.1-cp314-cp314t-win_amd64.whl", hash = "sha256:2c1c351919aca02858f740c6d33adea0c5deea37f9ecca1cc1ef9e884a619d26", size = 121196, upload-time = "2026-03-25T20:22:01.169Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/cd/e80b62269fc78fc36c9af5a6b89c835baa8af28ff5ad28c7028d60860320/tomli-2.4.1-cp314-cp314t-win_arm64.whl", hash = "sha256:eab21f45c7f66c13f2a9e0e1535309cee140182a9cdae1e041d02e47291e8396", size = 100393, upload-time = "2026-03-25T20:22:02.137Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/61/cceae43728b7de99d9b847560c262873a1f6c98202171fd5ed62640b494b/tomli-2.4.1-py3-none-any.whl", hash = "sha256:0d85819802132122da43cb86656f8d1f8c6587d54ae7dcaf30e90533028b49fe", size = 14583, upload-time = "2026-03-25T20:22:03.012Z" },
+]
+
+[[package]]
 name = "typing-extensions"
 version = "4.15.0"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/72/94/1a15dd82efb362ac84269196e94cf00f187f7ed21c242792a923cdb1c61f/typing_extensions-4.15.0.tar.gz", hash = "sha256:0cea48d173cc12fa28ecabc3b837ea3cf6f38c6d1136f85cbaaf598984861466", size = 109391, upload-time = "2025-08-25T13:49:26.313Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/18/67/36e9267722cc04a6b9f15c7f3441c2363321a3ea07da7ae0c0707beb2a9c/typing_extensions-4.15.0-py3-none-any.whl", hash = "sha256:f0fa19c6845758ab08074a0cfa8b7aecb71c999ca73d62883bc25cc018c4e548", size = 44614, upload-time = "2025-08-25T13:49:24.86Z" },
+]
+
+[[package]]
+name = "typing-inspection"
+version = "0.4.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/55/e3/70399cb7dd41c10ac53367ae42139cf4b1ca5f36bb3dc6c9d33acdb43655/typing_inspection-0.4.2.tar.gz", hash = "sha256:ba561c48a67c5958007083d386c3295464928b01faa735ab8547c5692e87f464", size = 75949, upload-time = "2025-10-01T02:14:41.687Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/dc/9b/47798a6c91d8bdb567fe2698fe81e0c6b7cb7ef4d13da4114b41d239f65d/typing_inspection-0.4.2-py3-none-any.whl", hash = "sha256:4ed1cacbdc298c220f1bd249ed5287caa16f34d44ef4e9c3d0cbad5b521545e7", size = 14611, upload-time = "2025-10-01T02:14:40.154Z" },
 ]
 
 [[package]]
@@ -892,10 +1397,235 @@ wheels = [
 ]
 
 [[package]]
+name = "uvicorn"
+version = "0.48.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "click" },
+    { name = "h11" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e6/bf/f6544ba992ddb9a6077343a576f9844f7f8f06ab819aefd00206e9255f18/uvicorn-0.48.0.tar.gz", hash = "sha256:a5504207195d08c2511bf9125ede5ac4a4b71725d519e758d01dcf0bc2d31c37", size = 91074, upload-time = "2026-05-24T12:08:41.925Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/01/be/72532be3da7acc5fdfbccdb95215cd04f995a0886532a5b423f929cda4cc/uvicorn-0.48.0-py3-none-any.whl", hash = "sha256:48097851328b87ec36117d3d575234519eb58c2b22d79666e9bbc6c49a761dad", size = 71410, upload-time = "2026-05-24T12:08:40.258Z" },
+]
+
+[package.optional-dependencies]
+standard = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "httptools" },
+    { name = "python-dotenv" },
+    { name = "pyyaml" },
+    { name = "uvloop", marker = "platform_python_implementation != 'PyPy' and sys_platform != 'cygwin' and sys_platform != 'win32'" },
+    { name = "watchfiles" },
+    { name = "websockets" },
+]
+
+[[package]]
+name = "uvloop"
+version = "0.22.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/06/f0/18d39dbd1971d6d62c4629cc7fa67f74821b0dc1f5a77af43719de7936a7/uvloop-0.22.1.tar.gz", hash = "sha256:6c84bae345b9147082b17371e3dd5d42775bddce91f885499017f4607fdaf39f", size = 2443250, upload-time = "2025-10-16T22:17:19.342Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c7/d5/69900f7883235562f1f50d8184bb7dd84a2fb61e9ec63f3782546fdbd057/uvloop-0.22.1-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:c60ebcd36f7b240b30788554b6f0782454826a0ed765d8430652621b5de674b9", size = 1352420, upload-time = "2025-10-16T22:16:21.187Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/73/c4e271b3bce59724e291465cc936c37758886a4868787da0278b3b56b905/uvloop-0.22.1-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:3b7f102bf3cb1995cfeaee9321105e8f5da76fdb104cdad8986f85461a1b7b77", size = 748677, upload-time = "2025-10-16T22:16:22.558Z" },
+    { url = "https://files.pythonhosted.org/packages/86/94/9fb7fad2f824d25f8ecac0d70b94d0d48107ad5ece03769a9c543444f78a/uvloop-0.22.1-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:53c85520781d84a4b8b230e24a5af5b0778efdb39142b424990ff1ef7c48ba21", size = 3753819, upload-time = "2025-10-16T22:16:23.903Z" },
+    { url = "https://files.pythonhosted.org/packages/74/4f/256aca690709e9b008b7108bc85fba619a2bc37c6d80743d18abad16ee09/uvloop-0.22.1-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:56a2d1fae65fd82197cb8c53c367310b3eabe1bbb9fb5a04d28e3e3520e4f702", size = 3804529, upload-time = "2025-10-16T22:16:25.246Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/74/03c05ae4737e871923d21a76fe28b6aad57f5c03b6e6bfcfa5ad616013e4/uvloop-0.22.1-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:40631b049d5972c6755b06d0bfe8233b1bd9a8a6392d9d1c45c10b6f9e9b2733", size = 3621267, upload-time = "2025-10-16T22:16:26.819Z" },
+    { url = "https://files.pythonhosted.org/packages/75/be/f8e590fe61d18b4a92070905497aec4c0e64ae1761498cad09023f3f4b3e/uvloop-0.22.1-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:535cc37b3a04f6cd2c1ef65fa1d370c9a35b6695df735fcff5427323f2cd5473", size = 3723105, upload-time = "2025-10-16T22:16:28.252Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/ff/7f72e8170be527b4977b033239a83a68d5c881cc4775fca255c677f7ac5d/uvloop-0.22.1-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:fe94b4564e865d968414598eea1a6de60adba0c040ba4ed05ac1300de402cd42", size = 1359936, upload-time = "2025-10-16T22:16:29.436Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/c6/e5d433f88fd54d81ef4be58b2b7b0cea13c442454a1db703a1eea0db1a59/uvloop-0.22.1-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:51eb9bd88391483410daad430813d982010f9c9c89512321f5b60e2cddbdddd6", size = 752769, upload-time = "2025-10-16T22:16:30.493Z" },
+    { url = "https://files.pythonhosted.org/packages/24/68/a6ac446820273e71aa762fa21cdcc09861edd3536ff47c5cd3b7afb10eeb/uvloop-0.22.1-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:700e674a166ca5778255e0e1dc4e9d79ab2acc57b9171b79e65feba7184b3370", size = 4317413, upload-time = "2025-10-16T22:16:31.644Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/6f/e62b4dfc7ad6518e7eff2516f680d02a0f6eb62c0c212e152ca708a0085e/uvloop-0.22.1-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:7b5b1ac819a3f946d3b2ee07f09149578ae76066d70b44df3fa990add49a82e4", size = 4426307, upload-time = "2025-10-16T22:16:32.917Z" },
+    { url = "https://files.pythonhosted.org/packages/90/60/97362554ac21e20e81bcef1150cb2a7e4ffdaf8ea1e5b2e8bf7a053caa18/uvloop-0.22.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:e047cc068570bac9866237739607d1313b9253c3051ad84738cbb095be0537b2", size = 4131970, upload-time = "2025-10-16T22:16:34.015Z" },
+    { url = "https://files.pythonhosted.org/packages/99/39/6b3f7d234ba3964c428a6e40006340f53ba37993f46ed6e111c6e9141d18/uvloop-0.22.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:512fec6815e2dd45161054592441ef76c830eddaad55c8aa30952e6fe1ed07c0", size = 4296343, upload-time = "2025-10-16T22:16:35.149Z" },
+    { url = "https://files.pythonhosted.org/packages/89/8c/182a2a593195bfd39842ea68ebc084e20c850806117213f5a299dfc513d9/uvloop-0.22.1-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:561577354eb94200d75aca23fbde86ee11be36b00e52a4eaf8f50fb0c86b7705", size = 1358611, upload-time = "2025-10-16T22:16:36.833Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/14/e301ee96a6dc95224b6f1162cd3312f6d1217be3907b79173b06785f2fe7/uvloop-0.22.1-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:1cdf5192ab3e674ca26da2eada35b288d2fa49fdd0f357a19f0e7c4e7d5077c8", size = 751811, upload-time = "2025-10-16T22:16:38.275Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/02/654426ce265ac19e2980bfd9ea6590ca96a56f10c76e63801a2df01c0486/uvloop-0.22.1-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:6e2ea3d6190a2968f4a14a23019d3b16870dd2190cd69c8180f7c632d21de68d", size = 4288562, upload-time = "2025-10-16T22:16:39.375Z" },
+    { url = "https://files.pythonhosted.org/packages/15/c0/0be24758891ef825f2065cd5db8741aaddabe3e248ee6acc5e8a80f04005/uvloop-0.22.1-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:0530a5fbad9c9e4ee3f2b33b148c6a64d47bbad8000ea63704fa8260f4cf728e", size = 4366890, upload-time = "2025-10-16T22:16:40.547Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/53/8369e5219a5855869bcee5f4d317f6da0e2c669aecf0ef7d371e3d084449/uvloop-0.22.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:bc5ef13bbc10b5335792360623cc378d52d7e62c2de64660616478c32cd0598e", size = 4119472, upload-time = "2025-10-16T22:16:41.694Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/ba/d69adbe699b768f6b29a5eec7b47dd610bd17a69de51b251126a801369ea/uvloop-0.22.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:1f38ec5e3f18c8a10ded09742f7fb8de0108796eb673f30ce7762ce1b8550cad", size = 4239051, upload-time = "2025-10-16T22:16:43.224Z" },
+    { url = "https://files.pythonhosted.org/packages/90/cd/b62bdeaa429758aee8de8b00ac0dd26593a9de93d302bff3d21439e9791d/uvloop-0.22.1-cp314-cp314-macosx_10_13_universal2.whl", hash = "sha256:3879b88423ec7e97cd4eba2a443aa26ed4e59b45e6b76aabf13fe2f27023a142", size = 1362067, upload-time = "2025-10-16T22:16:44.503Z" },
+    { url = "https://files.pythonhosted.org/packages/0d/f8/a132124dfda0777e489ca86732e85e69afcd1ff7686647000050ba670689/uvloop-0.22.1-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:4baa86acedf1d62115c1dc6ad1e17134476688f08c6efd8a2ab076e815665c74", size = 752423, upload-time = "2025-10-16T22:16:45.968Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/94/94af78c156f88da4b3a733773ad5ba0b164393e357cc4bd0ab2e2677a7d6/uvloop-0.22.1-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:297c27d8003520596236bdb2335e6b3f649480bd09e00d1e3a99144b691d2a35", size = 4272437, upload-time = "2025-10-16T22:16:47.451Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/35/60249e9fd07b32c665192cec7af29e06c7cd96fa1d08b84f012a56a0b38e/uvloop-0.22.1-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:c1955d5a1dd43198244d47664a5858082a3239766a839b2102a269aaff7a4e25", size = 4292101, upload-time = "2025-10-16T22:16:49.318Z" },
+    { url = "https://files.pythonhosted.org/packages/02/62/67d382dfcb25d0a98ce73c11ed1a6fba5037a1a1d533dcbb7cab033a2636/uvloop-0.22.1-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:b31dc2fccbd42adc73bc4e7cdbae4fc5086cf378979e53ca5d0301838c5682c6", size = 4114158, upload-time = "2025-10-16T22:16:50.517Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/7a/f1171b4a882a5d13c8b7576f348acfe6074d72eaf52cccef752f748d4a9f/uvloop-0.22.1-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:93f617675b2d03af4e72a5333ef89450dfaa5321303ede6e67ba9c9d26878079", size = 4177360, upload-time = "2025-10-16T22:16:52.646Z" },
+    { url = "https://files.pythonhosted.org/packages/79/7b/b01414f31546caf0919da80ad57cbfe24c56b151d12af68cee1b04922ca8/uvloop-0.22.1-cp314-cp314t-macosx_10_13_universal2.whl", hash = "sha256:37554f70528f60cad66945b885eb01f1bb514f132d92b6eeed1c90fd54ed6289", size = 1454790, upload-time = "2025-10-16T22:16:54.355Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/31/0bb232318dd838cad3fa8fb0c68c8b40e1145b32025581975e18b11fab40/uvloop-0.22.1-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:b76324e2dc033a0b2f435f33eb88ff9913c156ef78e153fb210e03c13da746b3", size = 796783, upload-time = "2025-10-16T22:16:55.906Z" },
+    { url = "https://files.pythonhosted.org/packages/42/38/c9b09f3271a7a723a5de69f8e237ab8e7803183131bc57c890db0b6bb872/uvloop-0.22.1-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:badb4d8e58ee08dad957002027830d5c3b06aea446a6a3744483c2b3b745345c", size = 4647548, upload-time = "2025-10-16T22:16:57.008Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/37/945b4ca0ac27e3dc4952642d4c900edd030b3da6c9634875af6e13ae80e5/uvloop-0.22.1-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:b91328c72635f6f9e0282e4a57da7470c7350ab1c9f48546c0f2866205349d21", size = 4467065, upload-time = "2025-10-16T22:16:58.206Z" },
+    { url = "https://files.pythonhosted.org/packages/97/cc/48d232f33d60e2e2e0b42f4e73455b146b76ebe216487e862700457fbf3c/uvloop-0.22.1-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:daf620c2995d193449393d6c62131b3fbd40a63bf7b307a1527856ace637fe88", size = 4328384, upload-time = "2025-10-16T22:16:59.36Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/16/c1fd27e9549f3c4baf1dc9c20c456cd2f822dbf8de9f463824b0c0357e06/uvloop-0.22.1-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:6cde23eeda1a25c75b2e07d39970f3374105d5eafbaab2a4482be82f272d5a5e", size = 4296730, upload-time = "2025-10-16T22:17:00.744Z" },
+]
+
+[[package]]
+name = "watchfiles"
+version = "1.2.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/cd/41/5e1a4bb12aac5f1493fa1bdc11154eca3b258ca4eba65d39c473fe19d8e9/watchfiles-1.2.0.tar.gz", hash = "sha256:c995fba777f1ea992f090f9236e9284cf7a5d1a0130dd5a3d82c598cacd76838", size = 108252, upload-time = "2026-05-18T04:32:04.251Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fc/3d/8024c801df84d1587740d0359e7fdd80afeae3d159011f3d5376dd82f18e/watchfiles-1.2.0-cp311-cp311-macosx_10_12_x86_64.whl", hash = "sha256:704fd259e332e01f9b9c178f4bce9e49027e5587cc2600eeeaf8e76e1c846201", size = 400242, upload-time = "2026-05-18T04:31:19.014Z" },
+    { url = "https://files.pythonhosted.org/packages/87/5b/f4dfd45323e949984a3a7f9dc31d1cbb049921e7d98253488dda72ccdaa9/watchfiles-1.2.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:6543cf55d170003296d185c0af981f3e1311564907e1f4e08671fc7693a890a5", size = 394562, upload-time = "2026-05-18T04:30:08.46Z" },
+    { url = "https://files.pythonhosted.org/packages/98/d8/19483ef075d601c409bce8bcbb5c0f81a10876fff870400568f08ce484a1/watchfiles-1.2.0-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:89d8c2394a065ca86f5d2910ff263ae67c127e1376ccc4f9fc35c71db879f80a", size = 456611, upload-time = "2026-05-18T04:30:45.723Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/6a/cc81fbe7ee42f2f22e661a6e12def7807e01b14b2f39e0ff83fd373fd307/watchfiles-1.2.0-cp311-cp311-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:772b80df316480d894a0e3165fdd19cf77f5d17f9a787f94029465ad0e3529d1", size = 461379, upload-time = "2026-05-18T04:31:29.292Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/57/7e669002082c0a0f4fb5113bb70125f7110124b846b0a11bc5ae8e90eac1/watchfiles-1.2.0-cp311-cp311-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:d158cd89df6053823533e06fb1d73c549133bff5f0396170c0e53d9559340717", size = 493556, upload-time = "2026-05-18T04:30:05.44Z" },
+    { url = "https://files.pythonhosted.org/packages/45/7d/f60a2b19807b21fe8281f3a8da4f59eef0d5f96825ac4680ba2d4f2ebf91/watchfiles-1.2.0-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:d516b3283a758e087841aedb8031549fb41ced08f3db10aa6d2bf32dc042525b", size = 575255, upload-time = "2026-05-18T04:30:40.568Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/49/77f5b5e6efbcd57482f74948ebb1b97e5c0046d6b61475042d830c84b3ff/watchfiles-1.2.0-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:53b2290c92e0506d102cd448fbc610d87079553f86caa39d67440856a8b8bba5", size = 467052, upload-time = "2026-05-18T04:31:17.942Z" },
+    { url = "https://files.pythonhosted.org/packages/ee/5a/73e2959af1b97fd5d556f9a8bdba017be23ceeef731869d5eaa0a753d5a3/watchfiles-1.2.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:a711b51aec4370d0dcda5b6c09463206f133a5759341d7744b953a7b62e1100e", size = 456858, upload-time = "2026-05-18T04:30:30.182Z" },
+    { url = "https://files.pythonhosted.org/packages/50/57/1bc8c27fad7e6c19bddee15d276dbb6ab72480ec01c127afff1673aee417/watchfiles-1.2.0-cp311-cp311-manylinux_2_31_riscv64.whl", hash = "sha256:e2ca07fa7d89195ec0865d3d285666286740bfa83d83e5cee204043a31ecc165", size = 467579, upload-time = "2026-05-18T04:32:15.897Z" },
+    { url = "https://files.pythonhosted.org/packages/09/6c/3c2e44edba3553c5e3c3b8c8a2a6dee6b9e12ae2cf4bd2378bebf9dc3038/watchfiles-1.2.0-cp311-cp311-musllinux_1_1_aarch64.whl", hash = "sha256:e0618518f282c4ebff60f5e5b1247b6d91bb8b9f4476947563a1e74acc66f3c6", size = 633253, upload-time = "2026-05-18T04:31:37.123Z" },
+    { url = "https://files.pythonhosted.org/packages/30/c2/d8c84a882ab39bbefcc4915ab3e91830b7a7e990c5570b0b69075aba3faf/watchfiles-1.2.0-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:0d191c054d0715c3c95c99df9b8dbf6fd096d8c1e021e8f212e1bd8bc444ccb5", size = 660713, upload-time = "2026-05-18T04:31:24.62Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/07/f97736a5fc605364fe67b25e9fa4a6965dfd4840d50c406ada507e9d735f/watchfiles-1.2.0-cp311-cp311-win32.whl", hash = "sha256:9342472aff9b093c5acd4f6d8f70ae0937964ab56542502bcf5579782da69ae8", size = 277222, upload-time = "2026-05-18T04:31:21.131Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/99/2b04981977fc2608afd60360d928c6aecf6b950292ca221d98f4005f6694/watchfiles-1.2.0-cp311-cp311-win_amd64.whl", hash = "sha256:dbd6c97045dad81227c8d040173da044c1de08de64a5ea8b555da4aee1d5fa22", size = 290274, upload-time = "2026-05-18T04:31:45.966Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/74/f7f58a7075ee9cf612b0cfcddb78b8cd8234f0742d6f0075cf0da2dde1c6/watchfiles-1.2.0-cp311-cp311-win_arm64.whl", hash = "sha256:57a2d9fa4fb4c2ecae57b13dfff2c7ab53e21a2ba674fe9f05506680fcdcc0d7", size = 283460, upload-time = "2026-05-18T04:31:39.126Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/2f/e42c992d2afda3108ea1c02acecc991b9f31d05c14adc2a7cee9ee211fc4/watchfiles-1.2.0-cp312-cp312-macosx_10_12_x86_64.whl", hash = "sha256:bc13eb17538be00c874699dc0abe4ee2bc8d50bb1166a6b9e175ef3fd7eb8f26", size = 400115, upload-time = "2026-05-18T04:32:02.06Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/8f/6af2ea19065c91d8b0ea3516fdfc8c0d349f407e8e9fbf4e5a17360de8ad/watchfiles-1.2.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:2d95ddc1eb6914154253d239089900813f6a767e174b8e6a50e7fdacb7e4236c", size = 393659, upload-time = "2026-05-18T04:30:50.951Z" },
+    { url = "https://files.pythonhosted.org/packages/13/01/b32a967c56fb3e3e5be3db52c3d3b87fa4513aa367d8ed1ad96d42952e5f/watchfiles-1.2.0-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:8f70d8b291ef6e88d19b1f297a6905ddb978888d9272b0d05e6f53309856bcfc", size = 453207, upload-time = "2026-05-18T04:31:04.231Z" },
+    { url = "https://files.pythonhosted.org/packages/04/98/97557a812180338cb1abd32e1cffcc4588f59b5f23e0cb006b2ba95ba64a/watchfiles-1.2.0-cp312-cp312-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:56d8641cf834c2836922899105bd3ce3d0dfc69291d52edf0b4d0436829b34c0", size = 459273, upload-time = "2026-05-18T04:31:50.377Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/a8/b4b08dcb7653b8087c6586f7ce649505900e866bbcfe40dc9587af02e686/watchfiles-1.2.0-cp312-cp312-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:2581a94056e55d7d0a31a823ea92bf73749c489ca2285bfdc0fbe6b2bb49d50c", size = 489927, upload-time = "2026-05-18T04:31:42.485Z" },
+    { url = "https://files.pythonhosted.org/packages/50/94/3dceea03545d2e5ddfd839f0ddd5e1cecbf1697b5a428d5ba11cef6af95d/watchfiles-1.2.0-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:41bc1199f7523b3f82843c88cbb979180c949caef0342cf90968f178e5d49b01", size = 570476, upload-time = "2026-05-18T04:31:03.071Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/f2/d39a5450c3532092b91f81d274360e613c2371bc874a89c7a1a3c5e8d138/watchfiles-1.2.0-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:7571e4464cb6e434958f867f7f730b8ab0b75e3f8e5eac0499168486ab3c33a8", size = 465650, upload-time = "2026-05-18T04:30:12.701Z" },
+    { url = "https://files.pythonhosted.org/packages/22/24/ed72f68cbc1333ca9b9f2200aa048bb6658ae41709bc1caad4310f4bdffd/watchfiles-1.2.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:e53a384f76b631c3ae5334ce6a52f0baa3a911eb94a4eac7f160079868b716d5", size = 456398, upload-time = "2026-05-18T04:30:13.784Z" },
+    { url = "https://files.pythonhosted.org/packages/0d/64/982ef4a4e5bab5b6e5b6becc8cd5e732f6130a78b855f0abec6439a9a135/watchfiles-1.2.0-cp312-cp312-manylinux_2_31_riscv64.whl", hash = "sha256:d20029a60a71a052a24c4db7673bc4de39ab89adbaccbfb5d67987c5d73f424d", size = 465140, upload-time = "2026-05-18T04:31:52.111Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/0c/95282abf4ed680b6096010bcfc30c5fa7a041fc5aa5a2ad17a2cc6c75bba/watchfiles-1.2.0-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:2cb93af48550faf1cea04c303107c8b75833de7013e57ce27d3b8d21d8d0f58c", size = 630259, upload-time = "2026-05-18T04:31:25.676Z" },
+    { url = "https://files.pythonhosted.org/packages/30/45/607c1de1530c4bdcf2cf1d1ecc2505ddba5d96bd43ba9f2b0e79876f850f/watchfiles-1.2.0-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:2995c176de7692b86a2e4c58d9ec718f753150a979cb4a754e2b4ffa38e70906", size = 659859, upload-time = "2026-05-18T04:30:24.333Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/08/d9e2e0f9e8e6791d33aefc694ad7eefa7f901f63caff84a81ded38692f9c/watchfiles-1.2.0-cp312-cp312-win32.whl", hash = "sha256:7a2cffd17d27d2ecbb310c2b1d8174f222a5495b1a721894afa88ec11e25b898", size = 275480, upload-time = "2026-05-18T04:30:31.307Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/e6/9d42569c0102645cc8cea5d8c7d8a1e9d4ada2cb7f05f75e554b8aa2202a/watchfiles-1.2.0-cp312-cp312-win_amd64.whl", hash = "sha256:f155b3a1b2a5fc89cdc70d47ee5d54e3b75e88efa34982028a35daef9ba00379", size = 288718, upload-time = "2026-05-18T04:32:10.745Z" },
+    { url = "https://files.pythonhosted.org/packages/0a/26/88e0dc6ee3898169d7fa22bb6a69cabf2502d2ee25cb8c876d1262d204f8/watchfiles-1.2.0-cp312-cp312-win_arm64.whl", hash = "sha256:8fa585ede612ee9f9e91b18bebf9ba11b9ae29a4e3a0d0cf6fca3e382133f0d5", size = 281026, upload-time = "2026-05-18T04:30:22.23Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/4d/70a7feced9f87e2ff26dba42667290f41694fc64646c67261fbb8cab5d5c/watchfiles-1.2.0-cp313-cp313-macosx_10_12_x86_64.whl", hash = "sha256:01ea8d66f0693b9b60a6541c8d10263091ca9a9060d242f3c1f3143f9aad2c98", size = 399730, upload-time = "2026-05-18T04:31:38.162Z" },
+    { url = "https://files.pythonhosted.org/packages/31/3a/0da302f2307aee316922806ebd5726c542cbd787c938271cf14a074c7daf/watchfiles-1.2.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:7ba0480b9a74af058f43b337e937a451e109295c420916d68ad24e3dc02f5e44", size = 392842, upload-time = "2026-05-18T04:30:27.051Z" },
+    { url = "https://files.pythonhosted.org/packages/db/ef/d5bdb705c224dbc256aa0c1ec47bf4e61ec52558f2afb44a71a1fe4d7015/watchfiles-1.2.0-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:4f34e26a19f91f710c08e0183429f0d1d15df734e6bc78c31e77b9ea9c433658", size = 452989, upload-time = "2026-05-18T04:31:11.945Z" },
+    { url = "https://files.pythonhosted.org/packages/71/29/5495f2c1661949ef7a35e4d71111d129cfe7606414a26887a919d0a55406/watchfiles-1.2.0-cp313-cp313-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:b4e77f6a55f858504069abd35d336a637555c09bca453dde1ee1e5ada8a6a1fb", size = 458978, upload-time = "2026-05-18T04:30:52.606Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/8c/7f9c07c433811c2fffd93e13fdfb7135de9aab5f2ae41be08960fa0047dc/watchfiles-1.2.0-cp313-cp313-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:0cb4d80e212f116474a545c21c912b445f16bb0cef9e6a73a498164223e14e2f", size = 490248, upload-time = "2026-05-18T04:31:36.003Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/11/d93632febc52fbc21be90231bb7c17fd5387f46c9076fd40a5f9c2ae6910/watchfiles-1.2.0-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:b974946a10af379d425e2eef5b62f5c6ebeaccf91d45eaad6f5b27ecd4f91aa0", size = 571847, upload-time = "2026-05-18T04:31:10.862Z" },
+    { url = "https://files.pythonhosted.org/packages/55/b4/383173e73aabb07ad1d9c7aa859d95437ac46a6d6a1e11005facda0c9d19/watchfiles-1.2.0-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:86bc13c25a8d1fcd70b51d0ce7c9b65e90de5666fcbfd3e34957cc73ee19aeb5", size = 465974, upload-time = "2026-05-18T04:30:17.006Z" },
+    { url = "https://files.pythonhosted.org/packages/a7/6c/89b1a230a78f57c52dd8893adb1f92f94411721b6ec12596c56d98c74356/watchfiles-1.2.0-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ca148d73dea36c9763aaa351e4d7a51780ec1584217c45276f4fe8239c768b71", size = 454782, upload-time = "2026-05-18T04:30:35.656Z" },
+    { url = "https://files.pythonhosted.org/packages/24/62/1732118367cfff0a9fce3bf62ff4bfded09ef5df21d9d446b858b3f70a96/watchfiles-1.2.0-cp313-cp313-manylinux_2_31_riscv64.whl", hash = "sha256:c525543d91961c6955b2636b308569e84a1d1c5f5f2932041ab9ef46422f43e3", size = 465182, upload-time = "2026-05-18T04:30:20.846Z" },
+    { url = "https://files.pythonhosted.org/packages/28/96/716f7e5f51339bf22963f3345f9f27d7f3b30e2eadc597e257c881dd3c53/watchfiles-1.2.0-cp313-cp313-musllinux_1_1_aarch64.whl", hash = "sha256:a204794696ffb8f9b10fba6f7cb5216d42f3b2b71860ccac6b6e42f5f10973b0", size = 629841, upload-time = "2026-05-18T04:31:05.397Z" },
+    { url = "https://files.pythonhosted.org/packages/4c/fe/c40783950fd771ccf66ab3ec2722d188a9af1c7f96c6e811f36e40c6e03f/watchfiles-1.2.0-cp313-cp313-musllinux_1_1_x86_64.whl", hash = "sha256:10d86db20695afe7997ac9e1717637d6714a8d0220458c33f3d2061f54cec427", size = 658028, upload-time = "2026-05-18T04:31:48.22Z" },
+    { url = "https://files.pythonhosted.org/packages/71/72/4508db1856d1d87fcbb3b63f4839bab1b5682cb0e8d224d122263c09654a/watchfiles-1.2.0-cp313-cp313-win32.whl", hash = "sha256:eb283ee99e21ad6443c8cdb06ac5b34b1308c329cbdf03fa02b445363714c799", size = 275183, upload-time = "2026-05-18T04:30:59.57Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/36/14b76ca57652e5cc5fd1c11f32a261292c08a0d19a00351013c2549cbfb2/watchfiles-1.2.0-cp313-cp313-win_amd64.whl", hash = "sha256:a0f27f01bee51861392bb6b7c4fdb290b27d1eb194e9e28788d68102a0e898d9", size = 288059, upload-time = "2026-05-18T04:32:07.937Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/8d/0a85e395398d8d20fadfe5c5d32c726eee17a519e78fb356f2cf7531bffe/watchfiles-1.2.0-cp313-cp313-win_arm64.whl", hash = "sha256:3651aa7058595e9cfb75d35dd5ada2bf9f48a5b8a0f3562821d3e210c507e077", size = 280186, upload-time = "2026-05-18T04:31:54.484Z" },
+    { url = "https://files.pythonhosted.org/packages/37/68/36db056f1fdcc5f07302f56e631774d6835bcd6fa3ace402304621d5f9e5/watchfiles-1.2.0-cp313-cp313t-macosx_10_12_x86_64.whl", hash = "sha256:faea288b6f0ab1902ef08f4ca6de005dccf856c4e0c4f21b8c5fce02d90a1b08", size = 399031, upload-time = "2026-05-18T04:30:44.576Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/64/01a9d6f66a82a5c101ce939274106cc72759d62427e153f01edd2b9f87c2/watchfiles-1.2.0-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:01859b11fd9fbca670f4d5da00fbac282cfea9bd67a2125d8b2833a3b5617ea9", size = 391205, upload-time = "2026-05-18T04:30:25.413Z" },
+    { url = "https://files.pythonhosted.org/packages/84/2c/0a44fe058cb4bb7b8ede6b6670698bbb7c0400740e378d00022189b7b31d/watchfiles-1.2.0-cp313-cp313t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:fff610d7bb2256a317bb1e96f0d7862c7aa8076733ee5df0fd41bbe76a24a4f4", size = 451892, upload-time = "2026-05-18T04:32:14.005Z" },
+    { url = "https://files.pythonhosted.org/packages/67/a1/351e0d56cd35e6488b5c8b4fb11a809a5bc923e8fe8fed9faf8920be0c89/watchfiles-1.2.0-cp313-cp313t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:b141a4891c995a039cd89e9a49e62df1dc8a559a5d1a6e4c7106d16c12777a55", size = 458867, upload-time = "2026-05-18T04:31:22.279Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/7d/9d09605187f1b838998624049fcf8bf47b73c1a3b76901fcac1782f62277/watchfiles-1.2.0-cp313-cp313t-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:f22943b7770483f6ea0721c6b11d022947a98eb0acae14694de034f4d0d38925", size = 490217, upload-time = "2026-05-18T04:31:43.657Z" },
+    { url = "https://files.pythonhosted.org/packages/60/5d/a17a16eccb182f04188cd308ec24b1a71a9b5c4e7098269cf35d9fa56d02/watchfiles-1.2.0-cp313-cp313t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:1bc6195825b7dcd217968bb1f801a60fd4c16e8eeab5bedc7fe917d7d5995ab4", size = 571458, upload-time = "2026-05-18T04:32:11.875Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/3d/4dd457062083ab1938e5dfd45032eb425cee2ac817287ca8ff4356183e5d/watchfiles-1.2.0-cp313-cp313t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:d4a4b147f5dca2a5d325a06a832fb43f345751adfbc63204aec30e0d9ca965a2", size = 464707, upload-time = "2026-05-18T04:30:43.492Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/71/ea8c57b128f5383de74d0c7d2d9c57ad7c9a65a930c451bd25d524b295b7/watchfiles-1.2.0-cp313-cp313t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:4543579a9bdb0c9560039b4ffddbdb39545707659fbc430ce4c10f3f68d557f9", size = 454663, upload-time = "2026-05-18T04:30:16.061Z" },
+    { url = "https://files.pythonhosted.org/packages/53/fd/2e812bf938406d7db351f0703ddd3fc6c061cf30d96153a77bc79a943a44/watchfiles-1.2.0-cp313-cp313t-manylinux_2_31_riscv64.whl", hash = "sha256:20aa0e708b920bde876a4aa82dc7dd6ebea228a63a67cda6632c2fc87b787efa", size = 463537, upload-time = "2026-05-18T04:31:44.9Z" },
+    { url = "https://files.pythonhosted.org/packages/86/56/d17a7f1dd1bc3035f1072694a551301272f1739c2d8e319c927cb9e29b38/watchfiles-1.2.0-cp313-cp313t-musllinux_1_1_aarch64.whl", hash = "sha256:d413349d565dab74297f2a63e84a097936be69bf8f3b3801f27f380e32040f44", size = 629194, upload-time = "2026-05-18T04:31:14.141Z" },
+    { url = "https://files.pythonhosted.org/packages/be/06/f1ff66bf5cae50aa4062779a0ecd0bbaf15e466195719074078947d9a17d/watchfiles-1.2.0-cp313-cp313t-musllinux_1_1_x86_64.whl", hash = "sha256:f28b2725eb8cce327b9b3ab02415c853011dc55c95832fe90de6bc56f5315f72", size = 656194, upload-time = "2026-05-18T04:31:47.14Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/54/a9c7ea9a82a4ac65e7004c0a03920b5cdd2f9c3b678757d9cd425aa51d53/watchfiles-1.2.0-cp314-cp314-macosx_10_12_x86_64.whl", hash = "sha256:b8c8358484d5fa12ef34f05b7f4168eaf1932f408725ff6d023c33ec17bd79d4", size = 400205, upload-time = "2026-05-18T04:32:05.153Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/5d/c9ab3534374a4a67450696905d6ef16a04405448b8dc52bd752ae50423d4/watchfiles-1.2.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:9f04b092229ad2c50126dd3c922c8822e51e605993764a33058d4a791ab42281", size = 392508, upload-time = "2026-05-18T04:30:54.849Z" },
+    { url = "https://files.pythonhosted.org/packages/26/ca/1ad30103535cf0cecd7b993e8d50edc5351b1820e38f2d22e3df58962feb/watchfiles-1.2.0-cp314-cp314-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:7a7ce236284f002a156f70add88efe5c70879cccbb658be0822c54b1306fc09d", size = 452448, upload-time = "2026-05-18T04:30:53.727Z" },
+    { url = "https://files.pythonhosted.org/packages/37/a1/ceee2cdf2afbd715fa07758d39c9859513eae411b23196f7fd039e5feedd/watchfiles-1.2.0-cp314-cp314-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:b9909cc2b48468b575eefa944919e1fe8a36c5849d5c7c168f80a8c1db69398e", size = 459605, upload-time = "2026-05-18T04:30:23.312Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/f6/421e30fd1cb3907a84ed92ab3f1983e37ba2dca015e9a894a048418417a2/watchfiles-1.2.0-cp314-cp314-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:0a37faaed405c67e28e6be45a1fa4f206ef5a2860f27c237db9fa30704c38242", size = 490757, upload-time = "2026-05-18T04:30:47.358Z" },
+    { url = "https://files.pythonhosted.org/packages/41/b0/55ed1b97ed08be7bba6f9a541cac15f2a858e1d74d2b07b6da70a82aab00/watchfiles-1.2.0-cp314-cp314-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:9649193aa27bd9ff2e80ff29bfaa93085496c7a3a377592823cc58b77ee88add", size = 568672, upload-time = "2026-05-18T04:30:38.915Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/cf/d8ae8a80dd7bafab395ea7681c10237311bbf34d37704a8c744e7cf31fc7/watchfiles-1.2.0-cp314-cp314-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:4e4ff8e37f99cf1da89e255e07c9c4b37c214038c4283707bdec308cb1b0ea1f", size = 464197, upload-time = "2026-05-18T04:30:09.914Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/8a/3076c496ca8dafe0e8cd03fcebdfc47be4b1174b4e5b24ff6e396e6b3af2/watchfiles-1.2.0-cp314-cp314-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:054dc20fd2e3132b4c3883b4a00d72fd6e1f56fdaf89fccd12e8057d74cd74d7", size = 453181, upload-time = "2026-05-18T04:30:14.829Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/10/9745e17c98e7b8a86454df0a3c7b5686bd650383f1e9f26e4ebcbd6cc0c0/watchfiles-1.2.0-cp314-cp314-manylinux_2_31_riscv64.whl", hash = "sha256:e140ed30ebde76796b686e67c182cff10ea2fbab186fafd1560f74bb5a473a6e", size = 465109, upload-time = "2026-05-18T04:30:28.123Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/95/8ef4a95481d3e0cb52d62a06fa6e972e81424be2d9698b91a2fecca9904c/watchfiles-1.2.0-cp314-cp314-musllinux_1_1_aarch64.whl", hash = "sha256:bb7e52ecf68ba46d22df23467b87cffeb2146908aa523ebfe803019618cfda06", size = 630653, upload-time = "2026-05-18T04:31:49.304Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/e4/3b3bf36b0f829b50c6ebcb8d031583863c59f923d6a6af3d485e470d0fac/watchfiles-1.2.0-cp314-cp314-musllinux_1_1_x86_64.whl", hash = "sha256:23282a321c8baf9b3a3c4afff673f9fe65eb7fdc2338d765ccad9d3d1916a5ba", size = 657838, upload-time = "2026-05-18T04:31:06.497Z" },
+    { url = "https://files.pythonhosted.org/packages/21/b1/6cbbb50c1f3002ab568777d44aa21206dfb8807a840990c4037523b51812/watchfiles-1.2.0-cp314-cp314-win32.whl", hash = "sha256:c0db965c5f79aa49fe672d297cf1febc5ad149b658594944f49a54a2b96270a7", size = 275108, upload-time = "2026-05-18T04:30:06.891Z" },
+    { url = "https://files.pythonhosted.org/packages/92/45/190ce6db8dcb4536682cf75d3889ff1a27182a58cb519d343cb6d9ea63d8/watchfiles-1.2.0-cp314-cp314-win_amd64.whl", hash = "sha256:71283b39fd17e5408eb123bd37aeecfd9d54c81fc184421943208aadb879d103", size = 288441, upload-time = "2026-05-18T04:32:12.901Z" },
+    { url = "https://files.pythonhosted.org/packages/74/0d/3eae1c2313ab08378431d907c3f8095ecca00f3eda33111cf4f0f2591799/watchfiles-1.2.0-cp314-cp314-win_arm64.whl", hash = "sha256:c5c19526f4e54a00f2666a6c0e9e40d582c09e865055ea7378bf0009aab857b3", size = 280684, upload-time = "2026-05-18T04:31:26.902Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/75/fb64e6c25d6b5ca636d03df34ffb1c6e9873303e76d27967e045f8df088f/watchfiles-1.2.0-cp314-cp314t-macosx_10_12_x86_64.whl", hash = "sha256:d73a585accffa5ae39c17264c36ec3166d2fad7000c780f5ef83b2722afb9dd2", size = 398857, upload-time = "2026-05-18T04:32:17.108Z" },
+    { url = "https://files.pythonhosted.org/packages/73/4e/9f7adf01754cbf81843722ccfec169d8f26c69778281a302855cecd2ee08/watchfiles-1.2.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:ae99b14c5f21e026e0e9d96f40e07d8570ebee6cafd9d8fc318354606daa7a28", size = 392413, upload-time = "2026-05-18T04:31:07.911Z" },
+    { url = "https://files.pythonhosted.org/packages/47/c8/bec626bcc2d69f44b9acb24ce7d60ed7b16b73628eea747fcbd169d8edda/watchfiles-1.2.0-cp314-cp314t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:4429f3b105524a10b72c3a819b091c495d2811d419c1e1e8df773a5a5974f831", size = 452409, upload-time = "2026-05-18T04:31:20.142Z" },
+    { url = "https://files.pythonhosted.org/packages/00/b7/b6362068e81e7c556d155a34c35d40ac3ef42d747b06d7f6e5bf58e359c2/watchfiles-1.2.0-cp314-cp314t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:43d818978d06062d9b22c4fab2ebe44cf5213d42dc8e62bda8c2760cfa2eeb33", size = 458827, upload-time = "2026-05-18T04:32:06.219Z" },
+    { url = "https://files.pythonhosted.org/packages/67/f8/9a813fa42afb1e0b4625e75f0479826644d3ee8dc287e093799bc01f390c/watchfiles-1.2.0-cp314-cp314t-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:b9f732dc58b2dbe69e464ccf8fff7a03b0dd0be439da4c0720d3558527d3d6b4", size = 490104, upload-time = "2026-05-18T04:31:56.034Z" },
+    { url = "https://files.pythonhosted.org/packages/2f/bf/27dfb6094ca4c9aad21298b5525b6c53cb36121ee454331d05161e58d130/watchfiles-1.2.0-cp314-cp314t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:8f200104103feb097de4cab8fe4f5dd18a2026934c7dea98c55a2f5fd6d5a33b", size = 571360, upload-time = "2026-05-18T04:31:57.133Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/39/44a096d67270ea93df91d33877dbe91fbda3aa4f8ec2edf799d93eda8736/watchfiles-1.2.0-cp314-cp314t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:63ac26eefbf4af1741247d6fb68b11c49a25b2f7413fbd318a83a12aaa9cf666", size = 464644, upload-time = "2026-05-18T04:30:57.33Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/80/c7472203bad6268e3ef1ad260739704847898938ad7ea8b63a5131f46b50/watchfiles-1.2.0-cp314-cp314t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:0c4997d4e4a55f0d02b6cde327322daf3a0400e5df6c6b15948994bf72497925", size = 454771, upload-time = "2026-05-18T04:30:48.736Z" },
+    { url = "https://files.pythonhosted.org/packages/51/cf/3b10b268b4b7f0fc26e9debb5eef1998b515887840f444cd3ec80c688755/watchfiles-1.2.0-cp314-cp314t-manylinux_2_31_riscv64.whl", hash = "sha256:4c887eba18b7945ac73067a8b4a66f21cd46c2539b2bc68588f7be6c7eb6d26b", size = 463494, upload-time = "2026-05-18T04:31:33.826Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/3e/a4302545cd589262a0dc7d140e86f7688eba3f9c72776c27f7e23b8864c4/watchfiles-1.2.0-cp314-cp314t-musllinux_1_1_aarch64.whl", hash = "sha256:3416ff151bb6b5a8d8d11664974fbef4d9305b9b2957839ab5a270468fd8df30", size = 629383, upload-time = "2026-05-18T04:31:15.596Z" },
+    { url = "https://files.pythonhosted.org/packages/db/99/d5649df0a9a410d45b7c882304d0b790903ac9b6e8f2cfd12114e0c6b9f2/watchfiles-1.2.0-cp314-cp314t-musllinux_1_1_x86_64.whl", hash = "sha256:0e831a271c035d89789cffc386b6aa1375f39f1cd25eb7ca0997e4970d152fc5", size = 656093, upload-time = "2026-05-18T04:31:58.707Z" },
+    { url = "https://files.pythonhosted.org/packages/92/b9/362702539275019a54dd2e94511b31a9b89c5f9e6a21966de7eb692549fc/watchfiles-1.2.0-cp315-cp315-macosx_10_12_x86_64.whl", hash = "sha256:37a6721cdf3f65dbb13aa9503510ccb4451603ac837e44d265d7992a597e1374", size = 400109, upload-time = "2026-05-18T04:31:16.879Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/75/71d5ba62db781e5587bded1d944c675374bc4aa37ff33d5018d98e8b6538/watchfiles-1.2.0-cp315-cp315-macosx_11_0_arm64.whl", hash = "sha256:2b37d10b5a63bd4d87e18472d80fa525bd670586fae62e5dd580452764879b65", size = 392167, upload-time = "2026-05-18T04:31:28.058Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/01/c66dd95d0423fe30d31820e2d1d5bda773764131bbb6ac0cb1cf303ac328/watchfiles-1.2.0-cp315-cp315-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:0a105bc2283f67e8fbec74253ec2d94925de92ed72c0393f1206bf326b7b7b69", size = 452372, upload-time = "2026-05-18T04:31:00.836Z" },
+    { url = "https://files.pythonhosted.org/packages/91/15/2fe99557e72f85627c6a8eed50d889e8d101623e060a22ad75b875cb932d/watchfiles-1.2.0-cp315-cp315-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:5327989a465505f05cfe06f04fa9d0c2fd5432bb243e10e6f012b1bdca3c8579", size = 459596, upload-time = "2026-05-18T04:31:34.96Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/23/d4acfa0023367428ed48351b3b9b267893037b6cadae55620c61c24bcfd4/watchfiles-1.2.0-cp315-cp315-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:ecb47f183a8025b2aa18b546725c3657e542112ae9c0613a2af79b4fa8d04ad7", size = 490869, upload-time = "2026-05-18T04:31:59.923Z" },
+    { url = "https://files.pythonhosted.org/packages/a4/5f/3164cbdce06c9fb95c4f7b9e2f9760b5e2797af43a9ecc317ef42a23a278/watchfiles-1.2.0-cp315-cp315-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:8520a4ab0e37f770afc34459c4f8f7019e153f9124dc101c15538365875d1ab2", size = 571641, upload-time = "2026-05-18T04:32:00.948Z" },
+    { url = "https://files.pythonhosted.org/packages/41/e6/85d3731c55e65cd7690f3f803d24c139588aaf863e4bf2148fe7a7fa1a19/watchfiles-1.2.0-cp315-cp315-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:71cd71740ed2c15211ebb237ced4e39a1cdf6f80566e5fe95428da1626f4fde6", size = 464444, upload-time = "2026-05-18T04:30:34.298Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/7d/562641012b8b09872742c3b8adf9629ec479fd78f8d68ae4a0c13da8add6/watchfiles-1.2.0-cp315-cp315-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:f88af53d6ddaf72179ef613ddc905e6f4785f712b49b80b3bef9f3525e6194b4", size = 453593, upload-time = "2026-05-18T04:31:23.464Z" },
+    { url = "https://files.pythonhosted.org/packages/56/fe/cb8ef3d6f929d14158fdaaad9925985b7310abc9384dcd4d82dd0016fb59/watchfiles-1.2.0-cp315-cp315-manylinux_2_31_riscv64.whl", hash = "sha256:cee9d5efd929efdac5f7e58f72b3376f676b64050a91c5b99a7094c5b2317488", size = 465096, upload-time = "2026-05-18T04:31:30.384Z" },
+    { url = "https://files.pythonhosted.org/packages/25/91/80908e835e100527a9267147b08c0eee1fa6ab0ffec15edc04d1d44885f7/watchfiles-1.2.0-cp315-cp315-musllinux_1_1_aarch64.whl", hash = "sha256:b718bf356bbc15e559bd8ef41782b573b8ae0e3f177ab244b440568d7ea02cfb", size = 630638, upload-time = "2026-05-18T04:30:49.89Z" },
+    { url = "https://files.pythonhosted.org/packages/46/4b/95ab2f256bb4af3cb2eb23b9317bda984ee6e0f11733a5c004a6c95b06e3/watchfiles-1.2.0-cp315-cp315-musllinux_1_1_x86_64.whl", hash = "sha256:922c0e019fe68b3ae392965a766b02a71ba1168c932cebc3733cd52c5fe5b377", size = 657684, upload-time = "2026-05-18T04:31:32.027Z" },
+    { url = "https://files.pythonhosted.org/packages/23/f4/7513ef1e85fc4c6331b59479d6d72661fc391fbe543678052ac72c8b6c19/watchfiles-1.2.0-pp311-pypy311_pp73-macosx_10_12_x86_64.whl", hash = "sha256:4674d49eb94706dfe666c069fc0a1b646ffcf920473492e209f6d5f60d3f0cc2", size = 403050, upload-time = "2026-05-18T04:30:36.753Z" },
+    { url = "https://files.pythonhosted.org/packages/27/0b/a54103cfd732bb703c7a749222011a0483ef3705948dae3b203158601119/watchfiles-1.2.0-pp311-pypy311_pp73-macosx_11_0_arm64.whl", hash = "sha256:094b9b70103d4e963499bdea001ee3c2697b144cd9ae6218a62c0f89ec9e31db", size = 396629, upload-time = "2026-05-18T04:32:03.268Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/2c/73f31a3b893886206c3f54d73e8ad8dee58cdb2f69ad2622e0a8a9e07f4e/watchfiles-1.2.0-pp311-pypy311_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:b0ef001f8c25ad0fa9529f914c1600647ecd0f542d11c19b7894768c67b6acb7", size = 457318, upload-time = "2026-05-18T04:31:01.932Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/f9/45d021e4a5cc7b9dd567f7cbb06d3b75f751a690063fb6cc7ec60f4e46b7/watchfiles-1.2.0-pp311-pypy311_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:a88fc94e647bc4eec523f1caa540258eb71d14278b9daf72fa1e2658a98df0f0", size = 457771, upload-time = "2026-05-18T04:30:56.331Z" },
+]
+
+[[package]]
 name = "wcwidth"
 version = "0.7.0"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/2c/ee/afaf0f85a9a18fe47a67f1e4422ed6cf1fe642f0ae0a2f81166231303c52/wcwidth-0.7.0.tar.gz", hash = "sha256:90e3a7ea092341c44b99562e75d09e4d5160fe7a3974c6fb842a101a95e7eed0", size = 182132, upload-time = "2026-05-02T16:04:12.653Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/41/52/e465037f5375f43533d1a80b6923955201596a99142ed524d77b571a1418/wcwidth-0.7.0-py3-none-any.whl", hash = "sha256:5d69154c429a82910e241c738cd0e2976fac8a2dd47a1a805f4afed1c0f136f2", size = 110825, upload-time = "2026-05-02T16:04:11.033Z" },
+]
+
+[[package]]
+name = "websockets"
+version = "16.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/04/24/4b2031d72e840ce4c1ccb255f693b15c334757fc50023e4db9537080b8c4/websockets-16.0.tar.gz", hash = "sha256:5f6261a5e56e8d5c42a4497b364ea24d94d9563e8fbd44e78ac40879c60179b5", size = 179346, upload-time = "2026-01-10T09:23:47.181Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f2/db/de907251b4ff46ae804ad0409809504153b3f30984daf82a1d84a9875830/websockets-16.0-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:31a52addea25187bde0797a97d6fc3d2f92b6f72a9370792d65a6e84615ac8a8", size = 177340, upload-time = "2026-01-10T09:22:34.539Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/fa/abe89019d8d8815c8781e90d697dec52523fb8ebe308bf11664e8de1877e/websockets-16.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:417b28978cdccab24f46400586d128366313e8a96312e4b9362a4af504f3bbad", size = 175022, upload-time = "2026-01-10T09:22:36.332Z" },
+    { url = "https://files.pythonhosted.org/packages/58/5d/88ea17ed1ded2079358b40d31d48abe90a73c9e5819dbcde1606e991e2ad/websockets-16.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:af80d74d4edfa3cb9ed973a0a5ba2b2a549371f8a741e0800cb07becdd20f23d", size = 175319, upload-time = "2026-01-10T09:22:37.602Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/ae/0ee92b33087a33632f37a635e11e1d99d429d3d323329675a6022312aac2/websockets-16.0-cp311-cp311-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:08d7af67b64d29823fed316505a89b86705f2b7981c07848fb5e3ea3020c1abe", size = 184631, upload-time = "2026-01-10T09:22:38.789Z" },
+    { url = "https://files.pythonhosted.org/packages/c8/c5/27178df583b6c5b31b29f526ba2da5e2f864ecc79c99dae630a85d68c304/websockets-16.0-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:7be95cfb0a4dae143eaed2bcba8ac23f4892d8971311f1b06f3c6b78952ee70b", size = 185870, upload-time = "2026-01-10T09:22:39.893Z" },
+    { url = "https://files.pythonhosted.org/packages/87/05/536652aa84ddc1c018dbb7e2c4cbcd0db884580bf8e95aece7593fde526f/websockets-16.0-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:d6297ce39ce5c2e6feb13c1a996a2ded3b6832155fcfc920265c76f24c7cceb5", size = 185361, upload-time = "2026-01-10T09:22:41.016Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/e2/d5332c90da12b1e01f06fb1b85c50cfc489783076547415bf9f0a659ec19/websockets-16.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:1c1b30e4f497b0b354057f3467f56244c603a79c0d1dafce1d16c283c25f6e64", size = 184615, upload-time = "2026-01-10T09:22:42.442Z" },
+    { url = "https://files.pythonhosted.org/packages/77/fb/d3f9576691cae9253b51555f841bc6600bf0a983a461c79500ace5a5b364/websockets-16.0-cp311-cp311-win32.whl", hash = "sha256:5f451484aeb5cafee1ccf789b1b66f535409d038c56966d6101740c1614b86c6", size = 178246, upload-time = "2026-01-10T09:22:43.654Z" },
+    { url = "https://files.pythonhosted.org/packages/54/67/eaff76b3dbaf18dcddabc3b8c1dba50b483761cccff67793897945b37408/websockets-16.0-cp311-cp311-win_amd64.whl", hash = "sha256:8d7f0659570eefb578dacde98e24fb60af35350193e4f56e11190787bee77dac", size = 178684, upload-time = "2026-01-10T09:22:44.941Z" },
+    { url = "https://files.pythonhosted.org/packages/84/7b/bac442e6b96c9d25092695578dda82403c77936104b5682307bd4deb1ad4/websockets-16.0-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:71c989cbf3254fbd5e84d3bff31e4da39c43f884e64f2551d14bb3c186230f00", size = 177365, upload-time = "2026-01-10T09:22:46.787Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/fe/136ccece61bd690d9c1f715baaeefd953bb2360134de73519d5df19d29ca/websockets-16.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:8b6e209ffee39ff1b6d0fa7bfef6de950c60dfb91b8fcead17da4ee539121a79", size = 175038, upload-time = "2026-01-10T09:22:47.999Z" },
+    { url = "https://files.pythonhosted.org/packages/40/1e/9771421ac2286eaab95b8575b0cb701ae3663abf8b5e1f64f1fd90d0a673/websockets-16.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:86890e837d61574c92a97496d590968b23c2ef0aeb8a9bc9421d174cd378ae39", size = 175328, upload-time = "2026-01-10T09:22:49.809Z" },
+    { url = "https://files.pythonhosted.org/packages/18/29/71729b4671f21e1eaa5d6573031ab810ad2936c8175f03f97f3ff164c802/websockets-16.0-cp312-cp312-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:9b5aca38b67492ef518a8ab76851862488a478602229112c4b0d58d63a7a4d5c", size = 184915, upload-time = "2026-01-10T09:22:51.071Z" },
+    { url = "https://files.pythonhosted.org/packages/97/bb/21c36b7dbbafc85d2d480cd65df02a1dc93bf76d97147605a8e27ff9409d/websockets-16.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:e0334872c0a37b606418ac52f6ab9cfd17317ac26365f7f65e203e2d0d0d359f", size = 186152, upload-time = "2026-01-10T09:22:52.224Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/34/9bf8df0c0cf88fa7bfe36678dc7b02970c9a7d5e065a3099292db87b1be2/websockets-16.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:a0b31e0b424cc6b5a04b8838bbaec1688834b2383256688cf47eb97412531da1", size = 185583, upload-time = "2026-01-10T09:22:53.443Z" },
+    { url = "https://files.pythonhosted.org/packages/47/88/4dd516068e1a3d6ab3c7c183288404cd424a9a02d585efbac226cb61ff2d/websockets-16.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:485c49116d0af10ac698623c513c1cc01c9446c058a4e61e3bf6c19dff7335a2", size = 184880, upload-time = "2026-01-10T09:22:55.033Z" },
+    { url = "https://files.pythonhosted.org/packages/91/d6/7d4553ad4bf1c0421e1ebd4b18de5d9098383b5caa1d937b63df8d04b565/websockets-16.0-cp312-cp312-win32.whl", hash = "sha256:eaded469f5e5b7294e2bdca0ab06becb6756ea86894a47806456089298813c89", size = 178261, upload-time = "2026-01-10T09:22:56.251Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/f0/f3a17365441ed1c27f850a80b2bc680a0fa9505d733fe152fdf5e98c1c0b/websockets-16.0-cp312-cp312-win_amd64.whl", hash = "sha256:5569417dc80977fc8c2d43a86f78e0a5a22fee17565d78621b6bb264a115d4ea", size = 178693, upload-time = "2026-01-10T09:22:57.478Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/9c/baa8456050d1c1b08dd0ec7346026668cbc6f145ab4e314d707bb845bf0d/websockets-16.0-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:878b336ac47938b474c8f982ac2f7266a540adc3fa4ad74ae96fea9823a02cc9", size = 177364, upload-time = "2026-01-10T09:22:59.333Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/0c/8811fc53e9bcff68fe7de2bcbe75116a8d959ac699a3200f4847a8925210/websockets-16.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:52a0fec0e6c8d9a784c2c78276a48a2bdf099e4ccc2a4cad53b27718dbfd0230", size = 175039, upload-time = "2026-01-10T09:23:01.171Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/82/39a5f910cb99ec0b59e482971238c845af9220d3ab9fa76dd9162cda9d62/websockets-16.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:e6578ed5b6981005df1860a56e3617f14a6c307e6a71b4fff8c48fdc50f3ed2c", size = 175323, upload-time = "2026-01-10T09:23:02.341Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/28/0a25ee5342eb5d5f297d992a77e56892ecb65e7854c7898fb7d35e9b33bd/websockets-16.0-cp313-cp313-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:95724e638f0f9c350bb1c2b0a7ad0e83d9cc0c9259f3ea94e40d7b02a2179ae5", size = 184975, upload-time = "2026-01-10T09:23:03.756Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/66/27ea52741752f5107c2e41fda05e8395a682a1e11c4e592a809a90c6a506/websockets-16.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:c0204dc62a89dc9d50d682412c10b3542d748260d743500a85c13cd1ee4bde82", size = 186203, upload-time = "2026-01-10T09:23:05.01Z" },
+    { url = "https://files.pythonhosted.org/packages/37/e5/8e32857371406a757816a2b471939d51c463509be73fa538216ea52b792a/websockets-16.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:52ac480f44d32970d66763115edea932f1c5b1312de36df06d6b219f6741eed8", size = 185653, upload-time = "2026-01-10T09:23:06.301Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/67/f926bac29882894669368dc73f4da900fcdf47955d0a0185d60103df5737/websockets-16.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:6e5a82b677f8f6f59e8dfc34ec06ca6b5b48bc4fcda346acd093694cc2c24d8f", size = 184920, upload-time = "2026-01-10T09:23:07.492Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/a1/3d6ccdcd125b0a42a311bcd15a7f705d688f73b2a22d8cf1c0875d35d34a/websockets-16.0-cp313-cp313-win32.whl", hash = "sha256:abf050a199613f64c886ea10f38b47770a65154dc37181bfaff70c160f45315a", size = 178255, upload-time = "2026-01-10T09:23:09.245Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/ae/90366304d7c2ce80f9b826096a9e9048b4bb760e44d3b873bb272cba696b/websockets-16.0-cp313-cp313-win_amd64.whl", hash = "sha256:3425ac5cf448801335d6fdc7ae1eb22072055417a96cc6b31b3861f455fbc156", size = 178689, upload-time = "2026-01-10T09:23:10.483Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/1d/e88022630271f5bd349ed82417136281931e558d628dd52c4d8621b4a0b2/websockets-16.0-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:8cc451a50f2aee53042ac52d2d053d08bf89bcb31ae799cb4487587661c038a0", size = 177406, upload-time = "2026-01-10T09:23:12.178Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/78/e63be1bf0724eeb4616efb1ae1c9044f7c3953b7957799abb5915bffd38e/websockets-16.0-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:daa3b6ff70a9241cf6c7fc9e949d41232d9d7d26fd3522b1ad2b4d62487e9904", size = 175085, upload-time = "2026-01-10T09:23:13.511Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/f4/d3c9220d818ee955ae390cf319a7c7a467beceb24f05ee7aaaa2414345ba/websockets-16.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:fd3cb4adb94a2a6e2b7c0d8d05cb94e6f1c81a0cf9dc2694fb65c7e8d94c42e4", size = 175328, upload-time = "2026-01-10T09:23:14.727Z" },
+    { url = "https://files.pythonhosted.org/packages/63/bc/d3e208028de777087e6fb2b122051a6ff7bbcca0d6df9d9c2bf1dd869ae9/websockets-16.0-cp314-cp314-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:781caf5e8eee67f663126490c2f96f40906594cb86b408a703630f95550a8c3e", size = 185044, upload-time = "2026-01-10T09:23:15.939Z" },
+    { url = "https://files.pythonhosted.org/packages/ad/6e/9a0927ac24bd33a0a9af834d89e0abc7cfd8e13bed17a86407a66773cc0e/websockets-16.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:caab51a72c51973ca21fa8a18bd8165e1a0183f1ac7066a182ff27107b71e1a4", size = 186279, upload-time = "2026-01-10T09:23:17.148Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/ca/bf1c68440d7a868180e11be653c85959502efd3a709323230314fda6e0b3/websockets-16.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:19c4dc84098e523fd63711e563077d39e90ec6702aff4b5d9e344a60cb3c0cb1", size = 185711, upload-time = "2026-01-10T09:23:18.372Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/f8/fdc34643a989561f217bb477cbc47a3a07212cbda91c0e4389c43c296ebf/websockets-16.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:a5e18a238a2b2249c9a9235466b90e96ae4795672598a58772dd806edc7ac6d3", size = 184982, upload-time = "2026-01-10T09:23:19.652Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/d1/574fa27e233764dbac9c52730d63fcf2823b16f0856b3329fc6268d6ae4f/websockets-16.0-cp314-cp314-win32.whl", hash = "sha256:a069d734c4a043182729edd3e9f247c3b2a4035415a9172fd0f1b71658a320a8", size = 177915, upload-time = "2026-01-10T09:23:21.458Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/f1/ae6b937bf3126b5134ce1f482365fde31a357c784ac51852978768b5eff4/websockets-16.0-cp314-cp314-win_amd64.whl", hash = "sha256:c0ee0e63f23914732c6d7e0cce24915c48f3f1512ec1d079ed01fc629dab269d", size = 178381, upload-time = "2026-01-10T09:23:22.715Z" },
+    { url = "https://files.pythonhosted.org/packages/06/9b/f791d1db48403e1f0a27577a6beb37afae94254a8c6f08be4a23e4930bc0/websockets-16.0-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:a35539cacc3febb22b8f4d4a99cc79b104226a756aa7400adc722e83b0d03244", size = 177737, upload-time = "2026-01-10T09:23:24.523Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/40/53ad02341fa33b3ce489023f635367a4ac98b73570102ad2cdd770dacc9a/websockets-16.0-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:b784ca5de850f4ce93ec85d3269d24d4c82f22b7212023c974c401d4980ebc5e", size = 175268, upload-time = "2026-01-10T09:23:25.781Z" },
+    { url = "https://files.pythonhosted.org/packages/74/9b/6158d4e459b984f949dcbbb0c5d270154c7618e11c01029b9bbd1bb4c4f9/websockets-16.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:569d01a4e7fba956c5ae4fc988f0d4e187900f5497ce46339c996dbf24f17641", size = 175486, upload-time = "2026-01-10T09:23:27.033Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/2d/7583b30208b639c8090206f95073646c2c9ffd66f44df967981a64f849ad/websockets-16.0-cp314-cp314t-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:50f23cdd8343b984957e4077839841146f67a3d31ab0d00e6b824e74c5b2f6e8", size = 185331, upload-time = "2026-01-10T09:23:28.259Z" },
+    { url = "https://files.pythonhosted.org/packages/45/b0/cce3784eb519b7b5ad680d14b9673a31ab8dcb7aad8b64d81709d2430aa8/websockets-16.0-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:152284a83a00c59b759697b7f9e9cddf4e3c7861dd0d964b472b70f78f89e80e", size = 186501, upload-time = "2026-01-10T09:23:29.449Z" },
+    { url = "https://files.pythonhosted.org/packages/19/60/b8ebe4c7e89fb5f6cdf080623c9d92789a53636950f7abacfc33fe2b3135/websockets-16.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:bc59589ab64b0022385f429b94697348a6a234e8ce22544e3681b2e9331b5944", size = 186062, upload-time = "2026-01-10T09:23:31.368Z" },
+    { url = "https://files.pythonhosted.org/packages/88/a8/a080593f89b0138b6cba1b28f8df5673b5506f72879322288b031337c0b8/websockets-16.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:32da954ffa2814258030e5a57bc73a3635463238e797c7375dc8091327434206", size = 185356, upload-time = "2026-01-10T09:23:32.627Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/b6/b9afed2afadddaf5ebb2afa801abf4b0868f42f8539bfe4b071b5266c9fe/websockets-16.0-cp314-cp314t-win32.whl", hash = "sha256:5a4b4cc550cb665dd8a47f868c8d04c8230f857363ad3c9caf7a0c3bf8c61ca6", size = 178085, upload-time = "2026-01-10T09:23:33.816Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/3e/28135a24e384493fa804216b79a6a6759a38cc4ff59118787b9fb693df93/websockets-16.0-cp314-cp314t-win_amd64.whl", hash = "sha256:b14dc141ed6d2dde437cddb216004bcac6a1df0935d79656387bd41632ba0bbd", size = 178531, upload-time = "2026-01-10T09:23:35.016Z" },
+    { url = "https://files.pythonhosted.org/packages/72/07/c98a68571dcf256e74f1f816b8cc5eae6eb2d3d5cfa44d37f801619d9166/websockets-16.0-pp311-pypy311_pp73-macosx_10_15_x86_64.whl", hash = "sha256:349f83cd6c9a415428ee1005cadb5c2c56f4389bc06a9af16103c3bc3dcc8b7d", size = 174947, upload-time = "2026-01-10T09:23:36.166Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/52/93e166a81e0305b33fe416338be92ae863563fe7bce446b0f687b9df5aea/websockets-16.0-pp311-pypy311_pp73-macosx_11_0_arm64.whl", hash = "sha256:4a1aba3340a8dca8db6eb5a7986157f52eb9e436b74813764241981ca4888f03", size = 175260, upload-time = "2026-01-10T09:23:37.409Z" },
+    { url = "https://files.pythonhosted.org/packages/56/0c/2dbf513bafd24889d33de2ff0368190a0e69f37bcfa19009ef819fe4d507/websockets-16.0-pp311-pypy311_pp73-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:f4a32d1bd841d4bcbffdcb3d2ce50c09c3909fbead375ab28d0181af89fd04da", size = 176071, upload-time = "2026-01-10T09:23:39.158Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/8f/aea9c71cc92bf9b6cc0f7f70df8f0b420636b6c96ef4feee1e16f80f75dd/websockets-16.0-pp311-pypy311_pp73-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:0298d07ee155e2e9fda5be8a9042200dd2e3bb0b8a38482156576f863a9d457c", size = 176968, upload-time = "2026-01-10T09:23:41.031Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/3f/f70e03f40ffc9a30d817eef7da1be72ee4956ba8d7255c399a01b135902a/websockets-16.0-pp311-pypy311_pp73-win_amd64.whl", hash = "sha256:a653aea902e0324b52f1613332ddf50b00c06fdaf7e92624fbf8c77c78fa5767", size = 178735, upload-time = "2026-01-10T09:23:42.259Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/28/258ebab549c2bf3e64d2b0217b973467394a9cea8c42f70418ca2c5d0d2e/websockets-16.0-py3-none-any.whl", hash = "sha256:1637db62fad1dc833276dded54215f2c7fa46912301a24bd94d45d46a011ceec", size = 171598, upload-time = "2026-01-10T09:23:45.395Z" },
 ]


### PR DESCRIPTION
## Supply-chain cooldown (7-day minimum release age)

Part of an org-wide rollout hardening get2knowio repos against supply-chain attacks. A newly published dependency version must age **7 days** before it can be installed/resolved or proposed by Dependabot — giving time for a malicious release to be detected and yanked. Security updates are never delayed (Dependabot cooldown applies to *version* updates only).

Config schema verified against current official docs (not training data).

### Changes
- **uv (`pyproject.toml`)** — `exclude-newer = "7 days"` (repo is uv-managed via `uv.lock`).
- **Dependabot** — `cooldown: { default-days: 7 }` on the existing `pip` and `github-actions` entries, **plus a new `docker` entry** (`/` and `/notifier` Dockerfiles).

Notes: the existing Dependabot `pip` ecosystem value is left as-is (minimal diff). Docker base images have no install-time cooldown — covered by the Dependabot layer only.
