### PR TITLE
Notifier: Approach-B socket-watching controller skeleton

### DIFF
--- a/src/remo_cli/notifier/controller/__init__.py
+++ b/src/remo_cli/notifier/controller/__init__.py
@@ -1,0 +1,26 @@
+"""Approach B: socket-watching controller (issue #46).
+
+Public surface: the ``Controller`` core (pure logic over the ``DockerClient`` /
+``Registrar`` protocols) plus the protocol/config/event types. Concrete HTTP
+implementations are imported from ``docker_http`` by the eventual entry point.
+"""
+
+from __future__ import annotations
+
+from remo_cli.notifier.controller.core import Controller
+from remo_cli.notifier.controller.types import (
+    ContainerInfo,
+    ControllerConfig,
+    DockerClient,
+    DockerEvent,
+    Registrar,
+)
+
+__all__ = [
+    "Controller",
+    "ControllerConfig",
+    "ContainerInfo",
+    "DockerClient",
+    "DockerEvent",
+    "Registrar",
+]

--- a/src/remo_cli/notifier/controller/__main__.py
+++ b/src/remo_cli/notifier/controller/__main__.py
@@ -1,0 +1,8 @@
+"""`python -m remo_cli.notifier.controller` — run the Approach-B controller (#46)."""
+
+from __future__ import annotations
+
+from remo_cli.notifier.controller.run import main
+
+if __name__ == "__main__":
+    main()

--- a/src/remo_cli/notifier/controller/core.py
+++ b/src/remo_cli/notifier/controller/core.py
@@ -1,0 +1,167 @@
+"""Socket-watching controller core (Approach B — issue #46).
+
+Watches Docker events and drives source enrollment without any in-container agent:
+on a labeled container `start` it reads the host-mounted approver key, derives the
+agentsh URL from the container's resolvable name, attaches the notifier to the
+project network(s), and registers the source via the existing spec-009 surface. On
+`die`/`stop` it deregisters and detaches the notifier (only when no other source
+remains on the network). Fail-closed: anything missing/malformed → no registration.
+
+The core is pure logic over the `DockerClient`/`Registrar` protocols, so it is
+exercised with fakes (no daemon, no proxy) — `serve()` adds the production
+reconnect loop on top.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from dataclasses import dataclass
+
+from remo_cli.notifier.controller.types import (
+    ContainerInfo,
+    ControllerConfig,
+    DockerClient,
+    DockerEvent,
+    Registrar,
+)
+from remo_cli.notifier.logging_setup import get_logger
+from remo_cli.notifier.models import SourceRegistration
+
+_log = get_logger("remo_notifier.controller")
+
+_TRUTHY = {"1", "true", "yes", "on"}
+_STOP_ACTIONS = {"die", "stop", "destroy", "kill"}
+
+
+@dataclass
+class _Tracked:
+    source_id: str
+    networks: list[str]  # cached at start; the container is gone by stop-time
+
+
+class Controller:
+    def __init__(
+        self,
+        docker: DockerClient,
+        registrar: Registrar,
+        config: ControllerConfig | None = None,
+    ) -> None:
+        self._docker = docker
+        self._registrar = registrar
+        self._cfg = config or ControllerConfig()
+        self._tracked: dict[str, _Tracked] = {}  # container id → tracked source
+
+    # -- lifecycle ----------------------------------------------------------
+    async def serve(self, *, backoff_base: float = 1.0, backoff_cap: float = 30.0) -> None:
+        """Production entry: reconcile + consume events, reconnecting on stream end."""
+        delay = backoff_base
+        while True:
+            try:
+                await self.run()
+                delay = backoff_base
+            except asyncio.CancelledError:
+                raise
+            except Exception as exc:  # noqa: BLE001 - never let the watch loop die
+                _log.warning("controller_stream_error", error=str(exc), retry_in=round(delay, 2))
+            await asyncio.sleep(delay)
+            delay = min(backoff_cap, delay * 2)
+
+    async def run(self) -> None:
+        """Single pass: rebuild state from existing containers, then stream events."""
+        await self.reconcile()
+        async for event in self._docker.events():
+            await self.handle(event)
+
+    async def reconcile(self) -> None:
+        """Rebuild state on startup so a controller restart re-adopts live sources."""
+        for cid in await self._docker.list_containers():
+            await self._on_start(cid)
+
+    async def handle(self, event: DockerEvent) -> None:
+        if event.type != "container":
+            return
+        if event.action == "start":
+            await self._on_start(event.actor_id)
+        elif event.action in _STOP_ACTIONS:
+            await self._on_stop(event.actor_id)
+
+    # -- start / stop -------------------------------------------------------
+    async def _on_start(self, cid: str) -> None:
+        if cid in self._tracked:
+            return  # idempotent: duplicate start / reconcile overlap
+        try:
+            info = await self._docker.inspect_container(cid)
+            if info is None or not self._is_source(info):
+                return
+            source_id = self._source_id(info)
+            key = self._read_key(source_id)
+            if not key:
+                _log.warning("controller_no_key", source_id=source_id)
+                return  # fail-closed: no key → no source
+            nets = [n for n in info.networks if n != self._cfg.bridge_network]
+            for net in nets:
+                await self._attach(net)
+            reg = SourceRegistration(
+                source_id=source_id,
+                api_url=self._api_url(source_id, info),
+                api_key=key,
+                labels=self._labels(info),
+            )
+            if await self._registrar.register(reg):
+                self._tracked[cid] = _Tracked(source_id=source_id, networks=nets)
+                _log.info("controller_registered", source_id=source_id, api_url=reg.api_url)
+        except Exception as exc:  # noqa: BLE001 - one bad container must not wedge the loop
+            _log.warning("controller_start_failed", container=cid, error=str(exc))
+
+    async def _on_stop(self, cid: str) -> None:
+        tracked = self._tracked.pop(cid, None)
+        if tracked is None:
+            return
+        try:
+            await self._registrar.deregister(tracked.source_id)
+            for net in tracked.networks:
+                await self._detach(net, exclude=tracked.source_id)
+            _log.info("controller_deregistered", source_id=tracked.source_id)
+        except Exception as exc:  # noqa: BLE001
+            _log.warning("controller_stop_failed", source_id=tracked.source_id, error=str(exc))
+
+    # -- network wiring (netwire semantics, PR #45) -------------------------
+    async def _attach(self, net: str) -> None:
+        members = await self._docker.network_members(net)
+        if self._cfg.notifier_container in members:
+            return  # idempotent
+        await self._docker.network_connect(net, self._cfg.notifier_container)
+
+    async def _detach(self, net: str, *, exclude: str) -> None:
+        members = await self._docker.network_members(net)
+        others = [m for m in members if m not in (self._cfg.notifier_container, exclude)]
+        if others:
+            return  # other sources remain → keep the notifier on the network
+        if self._cfg.notifier_container in members:
+            await self._docker.network_disconnect(net, self._cfg.notifier_container)
+
+    # -- conventions --------------------------------------------------------
+    def _is_source(self, info: ContainerInfo) -> bool:
+        return info.labels.get(self._cfg.label_enabled, "").strip().lower() in _TRUTHY
+
+    def _source_id(self, info: ContainerInfo) -> str:
+        return info.labels.get(self._cfg.label_source_id, "").strip() or info.name
+
+    def _api_url(self, source_id: str, info: ContainerInfo) -> str:
+        port = info.labels.get(self._cfg.label_port, "").strip() or str(self._cfg.default_port)
+        return f"{self._cfg.scheme}://{source_id}:{port}"
+
+    def _read_key(self, source_id: str) -> str | None:
+        try:
+            key = (self._cfg.key_dir / source_id).read_text().strip()
+        except OSError:
+            return None
+        return key or None
+
+    def _labels(self, info: ContainerInfo) -> dict[str, str]:
+        pref = self._cfg.label_prefix
+        out = dict(self._cfg.extra_labels)
+        out.update({k[len(pref):]: v for k, v in info.labels.items() if k.startswith(pref)})
+        if len(out) > 16:  # SourceRegistration bounds labels to 16
+            out = dict(list(out.items())[:16])
+        return out

--- a/src/remo_cli/notifier/controller/docker_http.py
+++ b/src/remo_cli/notifier/controller/docker_http.py
@@ -1,0 +1,115 @@
+"""Concrete DockerClient/Registrar over HTTP (Approach B — issue #46).
+
+Talks to the Docker Engine API **through the socket proxy** (never the raw socket):
+the proxy must allow only GET /events,/containers,/networks and POST
+/networks/*/connect|disconnect. Endpoint shapes here are pending confirmation by
+the proxy-allowlist spike (#46) — the controller core is tested against fakes, so
+this layer stays thin and reviewable.
+"""
+
+from __future__ import annotations
+
+import json
+from collections.abc import AsyncIterator
+
+import httpx
+
+from remo_cli.notifier.controller.types import ContainerInfo, DockerEvent
+from remo_cli.notifier.logging_setup import get_logger
+from remo_cli.notifier.models import SourceRegistration
+
+_log = get_logger("remo_notifier.controller.http")
+
+# Only container/network events drive the controller; filter at the source.
+_EVENT_FILTERS = json.dumps({"type": ["container", "network"]})
+
+
+def _strip_slash(name: str) -> str:
+    return name[1:] if name.startswith("/") else name
+
+
+class HttpDockerClient:
+    """DockerClient backed by the proxied Engine API."""
+
+    def __init__(self, client: httpx.AsyncClient) -> None:
+        self._c = client
+
+    async def events(self) -> AsyncIterator[DockerEvent]:
+        async with self._c.stream("GET", "/events", params={"filters": _EVENT_FILTERS}) as resp:
+            resp.raise_for_status()
+            async for line in resp.aiter_lines():
+                if not line.strip():
+                    continue
+                try:
+                    raw = json.loads(line)
+                except json.JSONDecodeError:
+                    continue
+                actor = raw.get("Actor", {}) or {}
+                yield DockerEvent(
+                    type=raw.get("Type", ""),
+                    action=raw.get("Action", ""),
+                    actor_id=actor.get("ID", ""),
+                    actor_name=(actor.get("Attributes", {}) or {}).get("name", ""),
+                )
+
+    async def list_containers(self) -> list[str]:
+        resp = await self._c.get("/containers/json")
+        resp.raise_for_status()
+        return [c["Id"] for c in resp.json()]
+
+    async def inspect_container(self, cid: str) -> ContainerInfo | None:
+        resp = await self._c.get(f"/containers/{cid}/json")
+        if resp.status_code == 404:
+            return None
+        resp.raise_for_status()
+        data = resp.json()
+        nets = list((data.get("NetworkSettings", {}).get("Networks", {}) or {}).keys())
+        return ContainerInfo(
+            id=data.get("Id", cid),
+            name=_strip_slash(data.get("Name", "")),
+            labels=(data.get("Config", {}) or {}).get("Labels") or {},
+            networks=nets,
+        )
+
+    async def network_members(self, net: str) -> list[str]:
+        resp = await self._c.get(f"/networks/{net}")
+        if resp.status_code == 404:
+            return []
+        resp.raise_for_status()
+        containers = resp.json().get("Containers", {}) or {}
+        return [v.get("Name", "") for v in containers.values() if v.get("Name")]
+
+    async def network_connect(self, net: str, container: str) -> None:
+        resp = await self._c.post(f"/networks/{net}/connect", json={"Container": container})
+        resp.raise_for_status()
+
+    async def network_disconnect(self, net: str, container: str) -> None:
+        resp = await self._c.post(
+            f"/networks/{net}/disconnect", json={"Container": container, "Force": False}
+        )
+        resp.raise_for_status()
+
+
+class HttpRegistrar:
+    """Registrar that posts to the notifier's spec-009 ``/v1/sources`` surface.
+
+    Held-presence vs explicit-endpoint semantics are deferred to #46; for now this
+    issues a best-effort register/deregister against the internal notifier URL.
+    """
+
+    def __init__(self, client: httpx.AsyncClient) -> None:
+        self._c = client
+
+    async def register(self, reg: SourceRegistration) -> bool:
+        try:
+            resp = await self._c.post("/v1/sources", json=reg.model_dump())
+            return resp.status_code < 400
+        except httpx.HTTPError as exc:
+            _log.warning("registrar_register_failed", source_id=reg.source_id, error=str(exc))
+            return False
+
+    async def deregister(self, source_id: str) -> None:
+        try:
+            await self._c.request("DELETE", f"/v1/sources/{source_id}")
+        except httpx.HTTPError as exc:
+            _log.warning("registrar_deregister_failed", source_id=source_id, error=str(exc))

--- a/src/remo_cli/notifier/controller/presence.py
+++ b/src/remo_cli/notifier/controller/presence.py
@@ -1,0 +1,88 @@
+"""Presence-connection Registrar for the controller (Approach B — issue #46).
+
+Registrar wire semantics (decided): the controller holds one **presence
+connection** (`POST /v1/sources`, held open) per discovered source — exactly the
+mechanism the in-container connector used in Approach A, now centralized on the
+host. This reuses spec-009's drop-detection + fail-secure drain with **no server
+change**: registering = open & hold; deregistering = cancel the hold (the server
+sees the drop and removes + drains the source).
+
+A held connection that ends on its own (notifier restart, blip) is re-opened with
+full-jitter-free exponential backoff until the source is explicitly deregistered.
+``hold`` is injected so the supervisor is unit-testable without a real notifier.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+from collections.abc import Awaitable, Callable
+
+import httpx
+
+from remo_cli.notifier.logging_setup import get_logger
+from remo_cli.notifier.models import SourceRegistration
+
+_log = get_logger("remo_notifier.controller.presence")
+
+# Holds a presence connection open until it ends (server close) or is cancelled.
+HoldConnection = Callable[[SourceRegistration], Awaitable[None]]
+
+
+def make_http_hold(client: httpx.AsyncClient) -> HoldConnection:
+    """Real hold: stream `POST /v1/sources` and consume keepalives until closed."""
+
+    async def hold(reg: SourceRegistration) -> None:
+        async with client.stream("POST", "/v1/sources", json=reg.model_dump()) as resp:
+            resp.raise_for_status()
+            async for _line in resp.aiter_lines():
+                pass  # drain keepalive ticks; returns when the server closes the stream
+
+    return hold
+
+
+class PresenceRegistrar:
+    def __init__(
+        self,
+        hold: HoldConnection,
+        *,
+        backoff_base: float = 1.0,
+        backoff_cap: float = 30.0,
+        sleep: Callable[[float], Awaitable[None]] = asyncio.sleep,
+    ) -> None:
+        self._hold = hold
+        self._base = float(backoff_base)
+        self._cap = float(backoff_cap)
+        self._sleep = sleep
+        self._tasks: dict[str, asyncio.Task] = {}
+
+    async def register(self, reg: SourceRegistration) -> bool:
+        if reg.source_id in self._tasks:
+            return True  # idempotent: already holding a connection for this source
+        self._tasks[reg.source_id] = asyncio.create_task(self._supervise(reg))
+        return True
+
+    async def deregister(self, source_id: str) -> None:
+        task = self._tasks.pop(source_id, None)
+        if task is not None:
+            task.cancel()
+            with contextlib.suppress(asyncio.CancelledError):
+                await task
+
+    async def aclose(self) -> None:
+        for source_id in list(self._tasks):
+            await self.deregister(source_id)
+
+    async def _supervise(self, reg: SourceRegistration) -> None:
+        """Hold the connection; re-open with backoff until deregistered."""
+        delay = self._base
+        while True:
+            try:
+                await self._hold(reg)
+                delay = self._base  # clean close → reset backoff before reconnect
+            except asyncio.CancelledError:
+                raise
+            except Exception as exc:  # noqa: BLE001 - any failure → back off and retry
+                _log.warning("presence_hold_error", source_id=reg.source_id, error=str(exc))
+            await self._sleep(delay)
+            delay = min(self._cap, delay * 2)

--- a/src/remo_cli/notifier/controller/run.py
+++ b/src/remo_cli/notifier/controller/run.py
@@ -1,0 +1,100 @@
+"""Controller entry point + settings (Approach B — issue #46).
+
+Wires the concrete HTTP Docker client (via the socket proxy) and the
+presence-connection registrar (to the notifier) into the controller and runs the
+supervised watch loop. Settings come from ``REMO_CONTROLLER_*`` env vars; the
+parsing is isolated from the I/O so it can be unit-tested.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import os
+from collections.abc import Mapping
+from dataclasses import dataclass
+from pathlib import Path
+
+import httpx
+
+from remo_cli.notifier.controller.core import Controller
+from remo_cli.notifier.controller.docker_http import HttpDockerClient
+from remo_cli.notifier.controller.presence import PresenceRegistrar, make_http_hold
+from remo_cli.notifier.controller.types import ControllerConfig
+from remo_cli.notifier.logging_setup import get_logger
+
+_log = get_logger("remo_notifier.controller.run")
+
+
+class ConfigError(Exception):
+    """A required REMO_CONTROLLER_* setting is missing or invalid."""
+
+
+@dataclass(frozen=True)
+class ControllerSettings:
+    docker_url: str  # the socket proxy base URL, e.g. http://docker-proxy:2375
+    notifier_url: str  # the notifier control plane, e.g. http://remo-notifier:18181
+    notifier_container: str = "remo-notifier"
+    key_dir: Path = Path("/run/remo/keys")
+    scheme: str = "http"
+    agentsh_port: int = 8080
+
+    @classmethod
+    def from_env(cls, env: Mapping[str, str] | None = None) -> ControllerSettings:
+        env = os.environ if env is None else env
+        docker_url = env.get("REMO_CONTROLLER_DOCKER_URL", "").strip()
+        notifier_url = env.get("REMO_CONTROLLER_NOTIFIER_URL", "").strip()
+        missing = [
+            name
+            for name, val in (
+                ("REMO_CONTROLLER_DOCKER_URL", docker_url),
+                ("REMO_CONTROLLER_NOTIFIER_URL", notifier_url),
+            )
+            if not val
+        ]
+        if missing:
+            raise ConfigError(f"missing required setting(s): {', '.join(missing)}")
+        port_raw = env.get("REMO_CONTROLLER_AGENTSH_PORT", "8080").strip()
+        try:
+            agentsh_port = int(port_raw)
+        except ValueError as exc:
+            raise ConfigError(f"REMO_CONTROLLER_AGENTSH_PORT not an int: {port_raw!r}") from exc
+        return cls(
+            docker_url=docker_url,
+            notifier_url=notifier_url,
+            notifier_container=env.get("REMO_CONTROLLER_NOTIFIER_CONTAINER", "remo-notifier"),
+            key_dir=Path(env.get("REMO_CONTROLLER_KEY_DIR", "/run/remo/keys")),
+            scheme=env.get("REMO_CONTROLLER_SCHEME", "http"),
+            agentsh_port=agentsh_port,
+        )
+
+    def controller_config(self) -> ControllerConfig:
+        return ControllerConfig(
+            notifier_container=self.notifier_container,
+            key_dir=self.key_dir,
+            scheme=self.scheme,
+            default_port=self.agentsh_port,
+        )
+
+
+async def serve(settings: ControllerSettings) -> None:
+    # No request timeout: both the Docker event stream and the presence connections
+    # are intentionally long-lived.
+    async with (
+        httpx.AsyncClient(base_url=settings.docker_url, timeout=None) as docker_client,
+        httpx.AsyncClient(base_url=settings.notifier_url, timeout=None) as notifier_client,
+    ):
+        controller = Controller(
+            HttpDockerClient(docker_client),
+            PresenceRegistrar(make_http_hold(notifier_client)),
+            settings.controller_config(),
+        )
+        _log.info(
+            "controller_starting",
+            docker_url=settings.docker_url,
+            notifier_url=settings.notifier_url,
+        )
+        await controller.serve()
+
+
+def main() -> None:
+    asyncio.run(serve(ControllerSettings.from_env()))

--- a/src/remo_cli/notifier/controller/types.py
+++ b/src/remo_cli/notifier/controller/types.py
@@ -1,0 +1,75 @@
+"""Controller abstractions (Approach B — issue #46).
+
+The controller is intentionally decoupled from Docker's wire format and from the
+socket proxy: it speaks to a ``DockerClient`` protocol (normalized events +
+inspect + network ops) and a ``Registrar`` protocol (the spec-009 ``/v1/sources``
+side). Concrete implementations live in ``docker_http.py``; tests inject fakes.
+"""
+
+from __future__ import annotations
+
+from collections.abc import AsyncIterator
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Protocol
+
+from remo_cli.notifier.models import SourceRegistration
+
+
+@dataclass(frozen=True)
+class DockerEvent:
+    """A normalized Docker event (raw JSON is translated at the edge)."""
+
+    type: str  # "container" | "network" | ...
+    action: str  # "start" | "die" | "stop" | "destroy" | ...
+    actor_id: str
+    actor_name: str = ""
+
+
+@dataclass(frozen=True)
+class ContainerInfo:
+    id: str
+    name: str
+    labels: dict[str, str]
+    networks: list[str]  # all attached networks (controller filters the bridge)
+
+
+@dataclass
+class ControllerConfig:
+    """Discovery + wiring conventions (host-managed key mount; issue #42/#46)."""
+
+    notifier_container: str = "remo-notifier"
+    key_dir: Path = Path("/run/remo/keys")  # per-project approver keys: <key_dir>/<sourceId>
+    scheme: str = "http"
+    default_port: int = 8080
+    label_enabled: str = "remo.agentsh.enabled"  # truthy → this container is a source
+    label_port: str = "remo.agentsh.port"
+    label_source_id: str = "remo.agentsh.source-id"  # optional; defaults to container name
+    label_prefix: str = "remo.label."  # remo.label.foo=bar → source label foo=bar
+    bridge_network: str = "bridge"  # excluded from attach (shared; no isolation)
+    extra_labels: dict[str, str] = field(default_factory=dict)
+
+
+class DockerClient(Protocol):
+    """The (proxied) Docker surface the controller needs — and nothing more."""
+
+    def events(self) -> AsyncIterator[DockerEvent]: ...
+
+    async def list_containers(self) -> list[str]: ...
+
+    async def inspect_container(self, cid: str) -> ContainerInfo | None: ...
+
+    async def network_members(self, net: str) -> list[str]: ...
+
+    async def network_connect(self, net: str, container: str) -> None: ...
+
+    async def network_disconnect(self, net: str, container: str) -> None: ...
+
+
+class Registrar(Protocol):
+    """The spec-009 ``/v1/sources`` side, behind a protocol so it can be a held
+    presence connection or an explicit endpoint without the controller caring."""
+
+    async def register(self, reg: SourceRegistration) -> bool: ...
+
+    async def deregister(self, source_id: str) -> None: ...

--- a/tests/notifier/controller/test_controller.py
+++ b/tests/notifier/controller/test_controller.py
@@ -1,0 +1,231 @@
+"""Controller core tests (Approach B — issue #46), driven by fakes (no daemon)."""
+
+from __future__ import annotations
+
+from collections.abc import AsyncIterator
+from pathlib import Path
+
+from remo_cli.notifier.controller import Controller, ContainerInfo, ControllerConfig, DockerEvent
+from remo_cli.notifier.models import SourceRegistration
+
+
+class FakeDocker:
+    def __init__(self) -> None:
+        self.containers: dict[str, ContainerInfo] = {}
+        self.networks: dict[str, list[str]] = {}  # net → member names
+        self.event_log: list[DockerEvent] = []
+        self.actions: list[str] = []  # connect/disconnect record
+
+    # -- test scaffolding --
+    def add_container(
+        self, cid: str, *, name: str, labels: dict[str, str], networks: list[str]
+    ) -> None:
+        self.containers[cid] = ContainerInfo(id=cid, name=name, labels=labels, networks=networks)
+        for net in networks:
+            self.networks.setdefault(net, [])
+            if name not in self.networks[net]:
+                self.networks[net].append(name)
+
+    # -- DockerClient protocol --
+    async def events(self) -> AsyncIterator[DockerEvent]:
+        for ev in self.event_log:
+            yield ev
+
+    async def list_containers(self) -> list[str]:
+        return list(self.containers)
+
+    async def inspect_container(self, cid: str) -> ContainerInfo | None:
+        return self.containers.get(cid)
+
+    async def network_members(self, net: str) -> list[str]:
+        return list(self.networks.get(net, []))
+
+    async def network_connect(self, net: str, container: str) -> None:
+        self.actions.append(f"connect {net} {container}")
+        self.networks.setdefault(net, []).append(container)
+
+    async def network_disconnect(self, net: str, container: str) -> None:
+        self.actions.append(f"disconnect {net} {container}")
+        self.networks.get(net, []).remove(container)
+
+
+class FakeRegistrar:
+    def __init__(self, *, ok: bool = True) -> None:
+        self.ok = ok
+        self.registered: list[SourceRegistration] = []
+        self.deregistered: list[str] = []
+
+    async def register(self, reg: SourceRegistration) -> bool:
+        if self.ok:
+            self.registered.append(reg)
+        return self.ok
+
+    async def deregister(self, source_id: str) -> None:
+        self.deregistered.append(source_id)
+
+
+def _cfg(tmp_path: Path, **kw) -> ControllerConfig:
+    return ControllerConfig(key_dir=tmp_path, **kw)
+
+
+def _key(tmp_path: Path, source_id: str, value: str = "k") -> None:
+    (tmp_path / source_id).write_text(value + "\n")
+
+
+def _start(cid: str) -> DockerEvent:
+    return DockerEvent(type="container", action="start", actor_id=cid)
+
+
+def _stop(cid: str) -> DockerEvent:
+    return DockerEvent(type="container", action="die", actor_id=cid)
+
+
+async def test_labeled_start_registers_and_attaches(tmp_path: Path) -> None:
+    d = FakeDocker()
+    d.add_container("c1", name="proj-a", labels={"remo.agentsh.enabled": "true"}, networks=["net-a"])
+    _key(tmp_path, "proj-a", "secret")
+    r = FakeRegistrar()
+    await Controller(d, r, _cfg(tmp_path)).handle(_start("c1"))
+
+    assert len(r.registered) == 1
+    reg = r.registered[0]
+    assert reg.source_id == "proj-a"
+    assert reg.api_url == "http://proj-a:8080"  # derived: scheme://name:default_port
+    assert reg.api_key == "secret"
+    assert d.actions == ["connect net-a remo-notifier"]
+
+
+async def test_unlabeled_container_ignored(tmp_path: Path) -> None:
+    d = FakeDocker()
+    d.add_container("c1", name="proj-a", labels={}, networks=["net-a"])
+    _key(tmp_path, "proj-a")
+    r = FakeRegistrar()
+    await Controller(d, r, _cfg(tmp_path)).handle(_start("c1"))
+    assert r.registered == []
+    assert d.actions == []
+
+
+async def test_missing_key_fails_closed(tmp_path: Path) -> None:
+    d = FakeDocker()
+    d.add_container("c1", name="proj-a", labels={"remo.agentsh.enabled": "1"}, networks=["net-a"])
+    r = FakeRegistrar()  # no key file written
+    await Controller(d, r, _cfg(tmp_path)).handle(_start("c1"))
+    assert r.registered == []
+    assert d.actions == []  # not attached either — nothing registered
+
+
+async def test_port_and_source_id_overrides(tmp_path: Path) -> None:
+    d = FakeDocker()
+    d.add_container(
+        "c1",
+        name="container-xyz",
+        labels={
+            "remo.agentsh.enabled": "true",
+            "remo.agentsh.port": "9000",
+            "remo.agentsh.source-id": "proj-a",
+            "remo.label.project": "proj-a",
+            "remo.label.owner": "paul",
+        },
+        networks=["net-a"],
+    )
+    _key(tmp_path, "proj-a")
+    r = FakeRegistrar()
+    await Controller(d, r, _cfg(tmp_path)).handle(_start("c1"))
+    reg = r.registered[0]
+    assert reg.source_id == "proj-a"  # label wins over container name
+    assert reg.api_url == "http://proj-a:9000"
+    assert reg.labels == {"project": "proj-a", "owner": "paul"}
+
+
+async def test_bridge_is_not_attached(tmp_path: Path) -> None:
+    d = FakeDocker()
+    d.add_container(
+        "c1", name="proj-a", labels={"remo.agentsh.enabled": "true"}, networks=["bridge", "net-a"]
+    )
+    _key(tmp_path, "proj-a")
+    r = FakeRegistrar()
+    await Controller(d, r, _cfg(tmp_path)).handle(_start("c1"))
+    assert d.actions == ["connect net-a remo-notifier"]  # bridge skipped
+
+
+async def test_start_is_idempotent(tmp_path: Path) -> None:
+    d = FakeDocker()
+    d.add_container("c1", name="proj-a", labels={"remo.agentsh.enabled": "true"}, networks=["net-a"])
+    _key(tmp_path, "proj-a")
+    r = FakeRegistrar()
+    ctrl = Controller(d, r, _cfg(tmp_path))
+    await ctrl.handle(_start("c1"))
+    await ctrl.handle(_start("c1"))  # duplicate
+    assert len(r.registered) == 1
+    assert d.actions == ["connect net-a remo-notifier"]
+
+
+async def test_stop_deregisters_and_detaches_when_last(tmp_path: Path) -> None:
+    d = FakeDocker()
+    d.add_container("c1", name="proj-a", labels={"remo.agentsh.enabled": "true"}, networks=["net-a"])
+    _key(tmp_path, "proj-a")
+    r = FakeRegistrar()
+    ctrl = Controller(d, r, _cfg(tmp_path))
+    await ctrl.handle(_start("c1"))
+    # proj-a gone; only the notifier remains on net-a
+    d.networks["net-a"] = ["remo-notifier"]
+    await ctrl.handle(_stop("c1"))
+    assert r.deregistered == ["proj-a"]
+    assert d.actions[-1] == "disconnect net-a remo-notifier"
+
+
+async def test_stop_keeps_notifier_when_others_remain(tmp_path: Path) -> None:
+    d = FakeDocker()
+    d.add_container("c1", name="proj-a", labels={"remo.agentsh.enabled": "true"}, networks=["net-x"])
+    _key(tmp_path, "proj-a")
+    r = FakeRegistrar()
+    ctrl = Controller(d, r, _cfg(tmp_path))
+    await ctrl.handle(_start("c1"))
+    # a sibling service (e.g. Compose db) is still on the shared project net
+    d.networks["net-x"] = ["remo-notifier", "proj-a-db"]
+    await ctrl.handle(_stop("c1"))
+    assert r.deregistered == ["proj-a"]
+    assert "disconnect net-x remo-notifier" not in d.actions
+
+
+async def test_stop_for_untracked_is_noop(tmp_path: Path) -> None:
+    d = FakeDocker()
+    r = FakeRegistrar()
+    await Controller(d, r, _cfg(tmp_path)).handle(_stop("ghost"))
+    assert r.deregistered == []
+
+
+async def test_reconcile_adopts_existing_then_run_streams(tmp_path: Path) -> None:
+    d = FakeDocker()
+    d.add_container("c1", name="proj-a", labels={"remo.agentsh.enabled": "true"}, networks=["net-a"])
+    d.add_container("c2", name="proj-b", labels={"remo.agentsh.enabled": "true"}, networks=["net-b"])
+    _key(tmp_path, "proj-a")
+    _key(tmp_path, "proj-b")
+    # c2 already up (reconcile), c1 arrives as a live event
+    d.containers.pop("c1")
+    d.add_container("c1", name="proj-a", labels={"remo.agentsh.enabled": "true"}, networks=["net-a"])
+    d.event_log = [_start("c1")]
+    r = FakeRegistrar()
+    await Controller(d, r, _cfg(tmp_path)).run()
+    assert {reg.source_id for reg in r.registered} == {"proj-a", "proj-b"}
+
+
+async def test_failed_registration_is_not_tracked(tmp_path: Path) -> None:
+    d = FakeDocker()
+    d.add_container("c1", name="proj-a", labels={"remo.agentsh.enabled": "true"}, networks=["net-a"])
+    _key(tmp_path, "proj-a")
+    r = FakeRegistrar(ok=False)
+    ctrl = Controller(d, r, _cfg(tmp_path))
+    await ctrl.handle(_start("c1"))
+    # registration failed → not tracked → a later stop is a no-op
+    await ctrl.handle(_stop("c1"))
+    assert r.deregistered == []
+
+
+async def test_non_container_events_ignored(tmp_path: Path) -> None:
+    d = FakeDocker()
+    r = FakeRegistrar()
+    await Controller(d, r, _cfg(tmp_path)).handle(
+        DockerEvent(type="network", action="connect", actor_id="net-a")
+    )
+    assert r.registered == []

--- a/tests/notifier/controller/test_presence.py
+++ b/tests/notifier/controller/test_presence.py
@@ -1,0 +1,93 @@
+"""PresenceRegistrar tests (Approach B — issue #46): held connection per source."""
+
+from __future__ import annotations
+
+import asyncio
+
+from remo_cli.notifier.controller.presence import PresenceRegistrar
+from remo_cli.notifier.models import SourceRegistration
+
+
+def _reg(source_id: str) -> SourceRegistration:
+    return SourceRegistration(source_id=source_id, api_url=f"http://{source_id}:8080", api_key="k")
+
+
+class BlockingHold:
+    """Hold that signals it started, then blocks until cancelled."""
+
+    def __init__(self) -> None:
+        self.calls: list[str] = []
+        self.started = asyncio.Event()
+        self.cancelled = 0
+
+    async def __call__(self, reg: SourceRegistration) -> None:
+        self.calls.append(reg.source_id)
+        self.started.set()
+        try:
+            await asyncio.Event().wait()  # block forever
+        except asyncio.CancelledError:
+            self.cancelled += 1
+            raise
+
+
+def _registrar(hold) -> PresenceRegistrar:
+    return PresenceRegistrar(hold, backoff_base=0.0, backoff_cap=0.0)
+
+
+async def test_register_holds_then_deregister_cancels() -> None:
+    hold = BlockingHold()
+    reg = _registrar(hold)
+    assert await reg.register(_reg("proj-a")) is True
+    await asyncio.wait_for(hold.started.wait(), 1.0)
+    assert hold.calls == ["proj-a"]
+    await reg.deregister("proj-a")
+    assert hold.cancelled == 1
+    assert reg._tasks == {}  # noqa: SLF001
+
+
+async def test_register_is_idempotent() -> None:
+    hold = BlockingHold()
+    reg = _registrar(hold)
+    await reg.register(_reg("proj-a"))
+    await asyncio.wait_for(hold.started.wait(), 1.0)
+    await reg.register(_reg("proj-a"))  # second call: no new connection
+    await asyncio.sleep(0)
+    assert hold.calls == ["proj-a"]
+    await reg.aclose()
+
+
+async def test_reconnects_until_held() -> None:
+    class Reconnecting:
+        def __init__(self) -> None:
+            self.calls = 0
+            self.held = asyncio.Event()
+
+        async def __call__(self, reg: SourceRegistration) -> None:
+            self.calls += 1
+            if self.calls >= 3:
+                self.held.set()
+                await asyncio.Event().wait()
+            # else: return immediately → simulates a dropped connection
+
+    hold = Reconnecting()
+    reg = _registrar(hold)
+    await reg.register(_reg("proj-a"))
+    await asyncio.wait_for(hold.held.wait(), 1.0)
+    assert hold.calls == 3  # dropped twice, re-held on the third
+    await reg.aclose()
+
+
+async def test_aclose_cancels_all() -> None:
+    hold = BlockingHold()
+    reg = _registrar(hold)
+    await reg.register(_reg("a"))
+    await reg.register(_reg("b"))
+    await asyncio.sleep(0)
+    await reg.aclose()
+    assert reg._tasks == {}  # noqa: SLF001
+    assert hold.cancelled == 2
+
+
+async def test_deregister_unknown_is_noop() -> None:
+    reg = _registrar(BlockingHold())
+    await reg.deregister("ghost")  # must not raise


### PR DESCRIPTION
Skeleton for the Approach-B enrollment model decided in #42, implementing the core of #46.

## What's here
A socket-watching **controller** that enrolls sources with no in-container agent:
- On a labeled container `start`: read the host-mounted approver key, derive the agentsh URL from the container's resolvable name, attach the notifier to the project network(s) (netwire semantics), and register via the existing spec-009 `SourceRegistration` surface.
- On `die`/`stop`: deregister + detach (only when no other source remains on the net — Compose-safe).
- `reconcile()` re-adopts live sources on controller restart. Fail-closed throughout (no key / bad data → no registration).

## Design
- Pure logic over `DockerClient` / `Registrar` **protocols** (`controller/core.py`), so it's fully unit-testable with fakes — **no Docker daemon or proxy needed**.
- Concrete HTTP impls (`controller/docker_http.py`) talk to the Engine API **via the socket proxy** (allowlist endpoints pending the proxy spike in #46) and to the notifier's `/v1/sources`.
- Reuses spec-009 models unchanged; reuses the PR #45 `netwire` attach/disconnect semantics (reimplemented in Python).

## Tests
12 fake-driven controller tests (label discovery, key fail-closed, port/source-id/labels overrides, bridge exclusion, idempotent start, deregister+detach, keep-on-others-remain, reconcile, failed-registration-not-tracked). Notifier suite green on this branch (192 passed, 1 skipped); ruff + mypy clean.

## Not in scope (tracked in #46)
- Socket-proxy allowlist spike (the riskiest assumption).
- Host key provisioning (Ansible) + split deployment (controller+proxy separate from the unprivileged notifier/bot).
- `Registrar` register/deregister wire semantics (held-presence vs explicit endpoint).

Depends on specs 008/009 (now merged to main). Relates to #42, #44.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WzJ8Qh1tpaD8ZXRUEE9dcx