### PR TITLE
feat(deacon): experimental opt-in for Deacon devcontainer runtime (Proxmox pilot)

### DIFF
--- a/README.md
+++ b/README.md
@@ -303,6 +303,7 @@ See platform-specific docs for full options:
 | Variable | Description |
 |----------|-------------|
 | `REMO_HOME` | Config directory for remo state (default: `~/.config/remo`) |
+| `REMO_DEVCONTAINER_RUNTIME` | Default devcontainer runtime for new deployments: `devcontainer` (default) or `deacon` (experimental). Overridden per-deployment by `--devcontainer-runtime`. See [Proxmox docs](docs/proxmox.md#experimental-deacon-runtime). |
 
 ---
 

--- a/ansible/roles/deacon/defaults/main.yml
+++ b/ansible/roles/deacon/defaults/main.yml
@@ -1,0 +1,7 @@
+---
+# Deacon — experimental single-binary (Rust) devcontainer runtime.
+# Pinned to a specific release; the musl target is used for portability
+# (static binary, no glibc version coupling). No stable release exists yet,
+# so this tracks the latest 0.2.0 release candidate.
+deacon_version: "0.2.0-rc.11"
+deacon_binary_path: /usr/local/bin/deacon

--- a/ansible/roles/deacon/tasks/main.yml
+++ b/ansible/roles/deacon/tasks/main.yml
@@ -1,0 +1,76 @@
+---
+# Install deacon (experimental devcontainer runtime) from its pinned GitHub
+# release. Single static Rust binary — no Node.js runtime required. Mirrors the
+# binary-download pattern in roles/zellij.
+
+- name: Check if deacon is already installed
+  ansible.builtin.command: deacon --version
+  register: deacon_current_version
+  changed_when: false
+  failed_when: false
+
+# Extract the exact semver(+rc) token so idempotency is a precise equality
+# check. A substring test would false-match across RC numbers (e.g. the pin
+# "0.2.0-rc.1" is a substring of an installed "0.2.0-rc.11").
+- name: Determine installed deacon version
+  ansible.builtin.set_fact:
+    deacon_installed_version: >-
+      {{ deacon_current_version.stdout | default('')
+         | regex_search('[0-9]+\.[0-9]+\.[0-9]+(-rc\.[0-9]+)?') | default('') }}
+
+- name: Determine whether deacon needs installing
+  ansible.builtin.set_fact:
+    deacon_needs_install: >-
+      {{ (deacon_current_version.rc | default(1) != 0)
+         or (deacon_installed_version != deacon_version) }}
+
+- name: Install deacon from binary release
+  when: deacon_needs_install | bool
+  block:
+    - name: Get system architecture
+      ansible.builtin.command: uname -m
+      register: deacon_system_arch
+      changed_when: false
+
+    - name: Set architecture mapping
+      ansible.builtin.set_fact:
+        deacon_arch: "{{ 'x86_64' if deacon_system_arch.stdout == 'x86_64' else 'aarch64' }}"
+
+    - name: Create temporary directory for download
+      ansible.builtin.tempfile:
+        state: directory
+      register: deacon_temp_dir
+
+    - name: Download deacon tarball
+      ansible.builtin.get_url:
+        url: >-
+          https://github.com/get2knowio/deacon/releases/download/v{{ deacon_version }}/deacon-v{{ deacon_version }}-{{ deacon_arch }}-unknown-linux-musl.tar.gz
+        dest: "{{ deacon_temp_dir.path }}/deacon.tar.gz"
+        mode: '0644'
+
+    - name: Extract deacon binary
+      ansible.builtin.unarchive:
+        src: "{{ deacon_temp_dir.path }}/deacon.tar.gz"
+        dest: "{{ deacon_temp_dir.path }}"
+        remote_src: true
+
+    - name: Install deacon to /usr/local/bin
+      ansible.builtin.copy:
+        src: "{{ deacon_temp_dir.path }}/deacon"
+        dest: "{{ deacon_binary_path }}"
+        mode: '0755'
+        remote_src: true
+
+    - name: Clean up temporary directory
+      ansible.builtin.file:
+        path: "{{ deacon_temp_dir.path }}"
+        state: absent
+
+- name: Verify deacon installation
+  ansible.builtin.command: deacon --version
+  register: deacon_final_version
+  changed_when: false
+
+- name: Display deacon version
+  ansible.builtin.debug:
+    msg: "deacon: {{ deacon_final_version.stdout | default('unknown') }}"

--- a/ansible/roles/user_setup/defaults/main.yml
+++ b/ansible/roles/user_setup/defaults/main.yml
@@ -12,3 +12,15 @@ zellij_session_name: "main"
 
 # Volume device for persistent home directory (set by hetzner_server role)
 remo_volume_device: ""
+
+# Devcontainer runtime baked into the project-launch scripts.
+#   "devcontainer" -> Node-based @devcontainers/cli (default)
+#   "deacon"       -> experimental single-binary Rust reimplementation
+# Set at provision time via the -e devcontainer_runtime=... extra var.
+# The derived vars are late-bound, so overriding devcontainer_runtime is enough.
+devcontainer_runtime: "devcontainer"
+devcontainer_cli_bin: "{{ 'deacon' if devcontainer_runtime == 'deacon' else 'devcontainer' }}"
+# deacon gates host-side lifecycle hooks (initializeCommand, dotfiles) behind a
+# workspace-trust check. remo's auto-start is non-interactive, so trust+persist
+# the workspace on `up`; later exec calls then pass automatically.
+devcontainer_up_extra_args: "{{ '--trust-workspace-persist' if devcontainer_runtime == 'deacon' else '' }}"

--- a/ansible/roles/user_setup/tasks/main.yml
+++ b/ansible/roles/user_setup/tasks/main.yml
@@ -316,9 +316,9 @@
               fi
               
               echo "Starting devcontainer for $ZELLIJ_SESSION_NAME..."
-              if ! devcontainer up --workspace-folder "$_project_dir" $_rebuild_flag; then
+              if ! {{ devcontainer_cli_bin }} up --workspace-folder "$_project_dir" {{ devcontainer_up_extra_args }} $_rebuild_flag; then
                   echo ""
-                  echo "devcontainer up failed. [Press any key to continue]"
+                  echo "{{ devcontainer_cli_bin }} up failed. [Press any key to continue]"
                   read -n 1 -s -r
                   exit 1
               fi
@@ -344,12 +344,12 @@
               fi
 
               # Run devcontainer shell (not exec, so we can stop container after)
-              if ! devcontainer exec --workspace-folder "$_project_dir" \
+              if ! {{ devcontainer_cli_bin }} exec --workspace-folder "$_project_dir" \
                   env REMO_INSTANCE="${REMO_INSTANCE:-$(hostname)}" \
                       REMO_PROJECT="$ZELLIJ_SESSION_NAME" \
                   /bin/bash $_bash_flags "$_exec_cmd"; then
                   echo ""
-                  echo "devcontainer exec failed. [Press any key to continue]"
+                  echo "{{ devcontainer_cli_bin }} exec failed. [Press any key to continue]"
                   read -n 1 -s -r
               fi
               unset _exec_cmd _bash_flags

--- a/ansible/roles/user_setup/templates/devshell.sh.j2
+++ b/ansible/roles/user_setup/templates/devshell.sh.j2
@@ -84,16 +84,16 @@ fi
 
 # Start the devcontainer if not already running
 echo "Starting devcontainer for $REPO_NAME..."
-devcontainer up --workspace-folder "$WORKSPACE_DIR"
+{{ devcontainer_cli_bin }} up --workspace-folder "$WORKSPACE_DIR" {{ devcontainer_up_extra_args }}
 
 # Loop to allow re-entry if there are local changes
 while true; do
     # Execute a shell inside the devcontainer
-    devcontainer exec --workspace-folder "$WORKSPACE_DIR" /bin/bash -c 'if command -v zsh &> /dev/null; then exec zsh; else exec bash; fi'
+    {{ devcontainer_cli_bin }} exec --workspace-folder "$WORKSPACE_DIR" /bin/bash -c 'if command -v zsh &> /dev/null; then exec zsh; else exec bash; fi'
 
     # Check for uncommitted or unpushed changes
-    has_uncommitted=$(devcontainer exec --workspace-folder "$WORKSPACE_DIR" git status --porcelain 2>/dev/null)
-    has_unpushed=$(devcontainer exec --workspace-folder "$WORKSPACE_DIR" git log @{u}.. --oneline 2>/dev/null)
+    has_uncommitted=$({{ devcontainer_cli_bin }} exec --workspace-folder "$WORKSPACE_DIR" git status --porcelain 2>/dev/null)
+    has_unpushed=$({{ devcontainer_cli_bin }} exec --workspace-folder "$WORKSPACE_DIR" git log @{u}.. --oneline 2>/dev/null)
 
     if [ -n "$has_uncommitted" ] || [ -n "$has_unpushed" ]; then
         echo ""

--- a/ansible/roles/user_setup/templates/project-launch.sh.j2
+++ b/ansible/roles/user_setup/templates/project-launch.sh.j2
@@ -96,9 +96,9 @@ if $DETACH; then
 
     if $HAS_DC; then
         echo "Bringing up devcontainer for $PROJECT..."
-        devcontainer up --workspace-folder "$PROJECT_DIR" >/dev/null
+        {{ devcontainer_cli_bin }} up --workspace-folder "$PROJECT_DIR" {{ devcontainer_up_extra_args }} >/dev/null
         printf -- '----- %s detached launch: %s -----\n' "$(date -Iseconds)" "$EXEC_CMD" >>"$LOG_FILE"
-        nohup setsid devcontainer exec --workspace-folder "$PROJECT_DIR" \
+        nohup setsid {{ devcontainer_cli_bin }} exec --workspace-folder "$PROJECT_DIR" \
             env REMO_INSTANCE="$REMO_INSTANCE" REMO_PROJECT="$PROJECT" \
             bash -lc "$EXEC_CMD" >>"$LOG_FILE" 2>&1 </dev/null &
     else

--- a/ansible/tasks/configure_dev_tools.yml
+++ b/ansible/tasks/configure_dev_tools.yml
@@ -56,10 +56,23 @@
     name: nodejs
   when: configure_nodejs | default(true) | bool
 
-- name: Install Dev Containers CLI
+# Devcontainer runtime is selectable via `devcontainer_runtime`
+# (default: devcontainer). "deacon" is an experimental single-binary Rust
+# reimplementation. Both remain governed by the `configure_devcontainers`
+# tool toggle so --only/--skip keep working.
+- name: Install Dev Containers CLI (devcontainer runtime)
   ansible.builtin.include_role:
     name: devcontainers
-  when: configure_devcontainers | default(true) | bool
+  when:
+    - configure_devcontainers | default(true) | bool
+    - (devcontainer_runtime | default('devcontainer')) != 'deacon'
+
+- name: Install Deacon (experimental devcontainer runtime)
+  ansible.builtin.include_role:
+    name: deacon
+  when:
+    - configure_devcontainers | default(true) | bool
+    - (devcontainer_runtime | default('devcontainer')) == 'deacon'
 
 - name: Install GitHub CLI
   ansible.builtin.include_role:

--- a/docs/proxmox.md
+++ b/docs/proxmox.md
@@ -92,6 +92,7 @@ remo proxmox info --name dev1
 | `--volume-size <GiB>` | `20` | Rootfs size. When the container exists, grows the rootfs via `pct resize`. |
 | `--unprivileged/--privileged` | `--unprivileged` | Container privilege mode |
 | `--domain <domain>` | (none) | FQDN suffix for the container |
+| `--devcontainer-runtime <name>` | `devcontainer` | Devcontainer runtime to install/use: `devcontainer` or `deacon` (experimental). See [Experimental: Deacon runtime](#experimental-deacon-runtime). |
 
 ### Update Options
 
@@ -104,6 +105,7 @@ remo proxmox info --name dev1
 | `--memory <MiB>` | Set memory limit via `pct set` (live) |
 | `--host <host>` | Proxmox host (auto-detected from registry if omitted) |
 | `--user <user>` | SSH user for the Proxmox host |
+| `--devcontainer-runtime <name>` | `devcontainer` or `deacon` (experimental). Re-provisions the launcher scripts to use the chosen runtime. |
 
 Available tools: `docker`, `user_setup`, `nodejs`, `devcontainers`, `github_cli`, `fzf`, `zellij`
 
@@ -125,6 +127,72 @@ Available tools: `docker`, `user_setup`, `nodejs`, `devcontainers`, `github_cli`
 | **Unprivileged + Nesting** | Default security posture; Docker-in-Docker works out of the box |
 | **Auto-start on boot** | `--onboot 1` — survives node reboots |
 | **Same dev tools as Incus/Hetzner** | Docker, Node.js, fzf, github_cli, devcontainers, zellij, user_setup |
+
+## Experimental: Deacon runtime
+
+By default remo installs the Node-based [`@devcontainers/cli`](https://github.com/devcontainers/cli)
+and invokes `devcontainer up` / `devcontainer exec` from the project launcher
+scripts. You can opt a deployment into
+[**Deacon**](https://github.com/get2knowio/deacon) instead — a single-binary
+Rust reimplementation of the devcontainer CLI that needs no Node.js runtime:
+
+```bash
+# Per deployment (overrides the global default)
+remo proxmox create --name dev1 --host prox01 --user root --devcontainer-runtime deacon
+
+# Switch an existing container's runtime
+remo proxmox update --name dev1 --devcontainer-runtime deacon
+
+# As a global default for every new deployment
+export REMO_DEVCONTAINER_RUNTIME=deacon
+```
+
+Resolution order: `--devcontainer-runtime` flag → `REMO_DEVCONTAINER_RUNTIME`
+env → built-in default (`devcontainer`).
+
+When `deacon` is selected, the `deacon` binary is installed (in place of the
+npm CLI) and the launcher scripts call `deacon up` / `deacon exec`. remo's
+container lifecycle (config-hash rebuild, container-stop on exit) works
+unchanged because Deacon sets the spec-canonical `devcontainer.local_folder`
+label. Because Deacon's non-interactive workspace-trust gate would otherwise
+block host-side lifecycle hooks (`initializeCommand`, dotfiles), remo passes
+`--trust-workspace-persist` on `up`.
+
+> **Experimental.** Deacon is opt-in and not yet the default. Known gaps versus
+> the reference CLI: feature installation is supported for Dockerfile-based
+> configs only (Docker-Compose / image-reference configs with `features` error
+> out), and GPU passthrough on Podman is unwired. Validate your projects before
+> relying on it.
+
+### Switching an existing deployment
+
+You do **not** need to recreate a container to try Deacon — `update`
+re-provisions the runtime in place. Data, projects, and container config are
+untouched.
+
+```bash
+# Flip to Deacon (installs the binary + re-points the launcher scripts)
+remo proxmox update --name dev1 --devcontainer-runtime deacon
+
+# Revert to the Node CLI (symmetric; the switch is just a re-provision)
+remo proxmox update --name dev1 --devcontainer-runtime devcontainer
+```
+
+After switching, force one clean rebuild per project the first time you open it,
+so Deacon builds a container it fully owns rather than adopting one the previous
+runtime started:
+
+```bash
+touch ~/projects/<project>/.devcontainer-rebuild   # honored on next launch
+remo shell -p <project>                             # Deacon rebuilds fresh
+```
+
+Notes:
+
+- The previously-installed runtime is left in place (not uninstalled), so
+  reverting only re-points the launcher scripts — low risk, fully reversible.
+- `update` re-runs the dev-tools roles idempotently; expect it to take about as
+  long as the original configure step.
 
 ## Bootstrap
 

--- a/src/remo_cli/cli/providers/proxmox.py
+++ b/src/remo_cli/cli/providers/proxmox.py
@@ -7,6 +7,7 @@ import sys
 import click
 
 from remo_cli.core.completion import proxmox_name as _complete_name
+from remo_cli.core.config import DEVCONTAINER_RUNTIMES
 from remo_cli.core.known_hosts import get_known_hosts
 from remo_cli.core.output import print_error
 from remo_cli.core.snapshot import (
@@ -50,6 +51,14 @@ def proxmox() -> None:
     is_flag=True,
     help="Store the container's IP address in known_hosts instead of its name (for setups without DNS/MagicDNS).",
 )
+@click.option(
+    "--devcontainer-runtime",
+    type=click.Choice(DEVCONTAINER_RUNTIMES),
+    default=None,
+    help="Devcontainer runtime to install and invoke. 'deacon' is an experimental "
+    "single-binary Rust reimplementation. Overrides REMO_DEVCONTAINER_RUNTIME "
+    "(default: devcontainer).",
+)
 @click.option("--yes", "-y", is_flag=True, help="Auto-confirm prompts.")
 @click.option("-v", "--verbose", is_flag=True, help="Verbose output.")
 def create(
@@ -68,6 +77,7 @@ def create(
     only: tuple[str, ...],
     skip: tuple[str, ...],
     use_ip: bool,
+    devcontainer_runtime: str | None,
     yes: bool,
     verbose: bool,
 ) -> None:
@@ -88,6 +98,7 @@ def create(
         tools_only=only,
         tools_skip=skip,
         use_ip=use_ip,
+        devcontainer_runtime=devcontainer_runtime,
         verbose=verbose,
     )
     sys.exit(rc)
@@ -147,6 +158,14 @@ def destroy(
 )
 @click.option("--only", multiple=True, help="Only install these tools.")
 @click.option("--skip", multiple=True, help="Skip these tools.")
+@click.option(
+    "--devcontainer-runtime",
+    type=click.Choice(DEVCONTAINER_RUNTIMES),
+    default=None,
+    help="Devcontainer runtime to install and invoke. 'deacon' is an experimental "
+    "single-binary Rust reimplementation. Overrides REMO_DEVCONTAINER_RUNTIME "
+    "(default: devcontainer).",
+)
 @click.option("-v", "--verbose", is_flag=True, help="Verbose output.")
 def update(
     name: str,
@@ -157,6 +176,7 @@ def update(
     memory: int,
     only: tuple[str, ...],
     skip: tuple[str, ...],
+    devcontainer_runtime: str | None,
     verbose: bool,
 ) -> None:
     """Update tools on a Proxmox LXC container."""
@@ -169,6 +189,7 @@ def update(
         memory=memory,
         tools_only=only,
         tools_skip=skip,
+        devcontainer_runtime=devcontainer_runtime,
         verbose=verbose,
     )
     sys.exit(rc)

--- a/src/remo_cli/core/config.py
+++ b/src/remo_cli/core/config.py
@@ -87,3 +87,21 @@ def get_known_hosts_path() -> Path:
 def is_verbose() -> bool:
     """Return True if REMO_VERBOSE is set to '1'."""
     return os.environ.get("REMO_VERBOSE") == "1"
+
+
+# Supported devcontainer runtimes. "deacon" is an experimental single-binary
+# Rust reimplementation opted into per deployment; "devcontainer" is the
+# default Node-based @devcontainers/cli.
+DEVCONTAINER_RUNTIMES: tuple[str, ...] = ("devcontainer", "deacon")
+DEFAULT_DEVCONTAINER_RUNTIME = "devcontainer"
+
+
+def get_devcontainer_runtime() -> str:
+    """Return the default devcontainer runtime.
+
+    Reads REMO_DEVCONTAINER_RUNTIME, falling back to "devcontainer". An empty
+    or unset value resolves to the default. Callers may override this per
+    deployment (e.g. the --devcontainer-runtime flag).
+    """
+    value = os.environ.get("REMO_DEVCONTAINER_RUNTIME", "").strip()
+    return value or DEFAULT_DEVCONTAINER_RUNTIME

--- a/src/remo_cli/core/validation.py
+++ b/src/remo_cli/core/validation.py
@@ -81,6 +81,27 @@ def validate_tool_name(tool: str, flag: str = "--tools") -> None:
         )
 
 
+def resolve_devcontainer_runtime(override: str | None) -> str:
+    """Resolve and validate the devcontainer runtime.
+
+    Precedence: explicit *override* (CLI flag) > REMO_DEVCONTAINER_RUNTIME env >
+    built-in default. Unlike the --devcontainer-runtime flag (guarded by
+    click.Choice), the env-var path is otherwise unchecked, so a mis-cased or
+    bogus value would silently fall back to the Node runtime; validate it here.
+    """
+    # Imported lazily to keep core.config free of validation dependencies.
+    from remo_cli.core.config import DEVCONTAINER_RUNTIMES, get_devcontainer_runtime
+
+    runtime = override or get_devcontainer_runtime()
+    if runtime not in DEVCONTAINER_RUNTIMES:
+        valid = ", ".join(DEVCONTAINER_RUNTIMES)
+        raise click.BadParameter(
+            f"Invalid devcontainer runtime: '{runtime}'. Valid runtimes are: {valid}. "
+            "Check the --devcontainer-runtime flag or REMO_DEVCONTAINER_RUNTIME.",
+        )
+    return runtime
+
+
 def build_tool_args(only: tuple[str, ...], skip: tuple[str, ...]) -> list[str]:
     for tool in only:
         validate_tool_name(tool)

--- a/src/remo_cli/providers/proxmox.py
+++ b/src/remo_cli/providers/proxmox.py
@@ -32,7 +32,12 @@ from remo_cli.core.snapshot import (
     validate_name as validate_snapshot_name,
 )
 from remo_cli.core.ssh import detect_timezone
-from remo_cli.core.validation import build_tool_args, parse_volume_size, validate_name
+from remo_cli.core.validation import (
+    build_tool_args,
+    parse_volume_size,
+    resolve_devcontainer_runtime,
+    validate_name,
+)
 from remo_cli.core.version import get_current_version
 from remo_cli.models.host import KnownHost
 from remo_cli.models.snapshot import Snapshot, SnapshotStatus
@@ -188,6 +193,7 @@ def create(
     tools_only: tuple[str, ...] = (),
     tools_skip: tuple[str, ...] = (),
     use_ip: bool = False,
+    devcontainer_runtime: str | None = None,
     verbose: bool = False,
 ) -> int:
     """Create a new Proxmox LXC container and configure dev tools.
@@ -236,6 +242,9 @@ def create(
         extra_vars.extend(["-e", f"timezone={tz}"])
 
     extra_vars.extend(build_tool_args(tools_only, tools_skip))
+
+    runtime = resolve_devcontainer_runtime(devcontainer_runtime)
+    extra_vars.extend(["-e", f"devcontainer_runtime={runtime}"])
 
     current = get_current_version()
     if current != "unknown":
@@ -377,6 +386,7 @@ def update(
     memory: int = 0,
     tools_only: tuple[str, ...] = (),
     tools_skip: tuple[str, ...] = (),
+    devcontainer_runtime: str | None = None,
     verbose: bool = False,
 ) -> int:
     """Re-configure dev tools on an existing Proxmox LXC container.
@@ -447,6 +457,9 @@ def update(
     extra_vars: list[str] = ["-e", f"container_ip={container_ip}"]
 
     extra_vars.extend(build_tool_args(tools_only, tools_skip))
+
+    runtime = resolve_devcontainer_runtime(devcontainer_runtime)
+    extra_vars.extend(["-e", f"devcontainer_runtime={runtime}"])
 
     tz = detect_timezone()
     if tz:

--- a/tests/unit/providers/test_proxmox_devcontainer_runtime.py
+++ b/tests/unit/providers/test_proxmox_devcontainer_runtime.py
@@ -1,0 +1,80 @@
+"""Tests for devcontainer-runtime resolution in providers/proxmox.create.
+
+The runtime resolves as: explicit flag > REMO_DEVCONTAINER_RUNTIME env >
+built-in default ("devcontainer"). The resolved value is passed to Ansible as
+`-e devcontainer_runtime=<value>`.
+"""
+
+from __future__ import annotations
+
+import click
+import pytest
+
+from remo_cli.providers import proxmox as providers_proxmox
+
+
+def _extra_value(extra_vars: list[str], key: str) -> str | None:
+    """Return the value of the last `-e key=value` entry, or None."""
+    prefix = f"{key}="
+    found: str | None = None
+    for item in extra_vars:
+        if item.startswith(prefix):
+            found = item[len(prefix):]
+    return found
+
+
+@pytest.fixture
+def capture_runtime(mocker):
+    """Patch create's side effects; return a getter for the runtime extra-var.
+
+    run_playbook returns rc=1 so create() skips all post-provision work
+    (vmid lookup, known_hosts save) and returns immediately.
+    """
+    captured: dict[str, list[str]] = {}
+
+    def fake_run(playbook, extra_vars=None, **kwargs):
+        captured["extra_vars"] = extra_vars or []
+        return 1
+
+    mocker.patch("remo_cli.providers.proxmox.run_playbook", side_effect=fake_run)
+    mocker.patch("remo_cli.providers.proxmox.detect_timezone", return_value="")
+    mocker.patch(
+        "remo_cli.providers.proxmox.get_current_version", return_value="unknown"
+    )
+    mocker.patch("remo_cli.providers.proxmox.remove_known_host")
+
+    def run(devcontainer_runtime=None):
+        providers_proxmox.create(
+            name="dev1", host="pve", devcontainer_runtime=devcontainer_runtime
+        )
+        return _extra_value(captured["extra_vars"], "devcontainer_runtime")
+
+    return run
+
+
+def test_default_runtime_is_devcontainer(capture_runtime, monkeypatch):
+    monkeypatch.delenv("REMO_DEVCONTAINER_RUNTIME", raising=False)
+    assert capture_runtime() == "devcontainer"
+
+
+def test_explicit_flag_selects_deacon(capture_runtime, monkeypatch):
+    monkeypatch.delenv("REMO_DEVCONTAINER_RUNTIME", raising=False)
+    assert capture_runtime(devcontainer_runtime="deacon") == "deacon"
+
+
+def test_env_var_default_selects_deacon(capture_runtime, monkeypatch):
+    monkeypatch.setenv("REMO_DEVCONTAINER_RUNTIME", "deacon")
+    assert capture_runtime() == "deacon"
+
+
+def test_flag_overrides_env_var(capture_runtime, monkeypatch):
+    monkeypatch.setenv("REMO_DEVCONTAINER_RUNTIME", "deacon")
+    assert capture_runtime(devcontainer_runtime="devcontainer") == "devcontainer"
+
+
+def test_invalid_env_var_is_rejected(capture_runtime, monkeypatch):
+    # A mis-cased/bogus env value must not silently fall back to the Node
+    # runtime; the flag path is guarded by click.Choice, the env path here.
+    monkeypatch.setenv("REMO_DEVCONTAINER_RUNTIME", "Deacon")
+    with pytest.raises(click.BadParameter):
+        capture_runtime()


### PR DESCRIPTION
## What

Adds an **experimental, off-by-default** opt-in to use [`get2knowio/deacon`](https://github.com/get2knowio/deacon) — a single-binary Rust reimplementation of the devcontainer CLI (no Node runtime) — instead of the Node-based `@devcontainers/cli`. Piloted on the **Proxmox** provider; the shared Ansible plumbing is written so other providers are just per-provider flag wiring later.

## How you select it

Resolution order: `--devcontainer-runtime` flag → `REMO_DEVCONTAINER_RUNTIME` env → built-in default (`devcontainer`).

```bash
remo proxmox create --name dev1 --host prox01 --devcontainer-runtime deacon
remo proxmox update --name dev1 --devcontainer-runtime deacon   # flip an existing container in place
export REMO_DEVCONTAINER_RUNTIME=deacon                         # global default
```

## Why it's a near drop-in

remo only ever calls `devcontainer up/exec/--version`. Deacon matches that surface: `--workspace-folder` is global, `up` supports `--remove-existing-container`, `exec` passes the trailing `env … /bin/bash -lc` command through verbatim, and it sets the spec-canonical `devcontainer.local_folder` label — so remo's config-hash rebuild and container-stop-on-exit work **unchanged**. The one behavioral gap (Deacon's non-interactive workspace-trust gate) is handled by passing `--trust-workspace-persist` on `up`.

## Changes

- **`ansible/roles/deacon`** (new) — installs the pinned static musl binary (mirrors the `zellij` role); exact-version idempotency check.
- **`configure_dev_tools.yml`** — installs the Node CLI *or* deacon based on `devcontainer_runtime`, both still under the existing `configure_devcontainers` toggle (so `--only/--skip` keep working).
- **`user_setup`** — the `.bashrc` block, `project-launch`, and `devshell` launchers call `{{ devcontainer_cli_bin }}`; other providers with no runtime set fall back to `devcontainer` (no regression).
- **Proxmox provider + `core.validation.resolve_devcontainer_runtime`** — resolves and validates the runtime (the env path is validated too, not just the `click.Choice` flag).
- **Docs** — `docs/proxmox.md` gains a Deacon section + a "Switching an existing deployment" guide (in-place flip, forced first rebuild, symmetric revert); README env-var table updated.
- **Tests** — runtime resolution precedence + rejection of invalid values.

## Known limitations (why it stays experimental)

Feature installation is supported for Dockerfile-based configs only (Docker-Compose / image-reference configs with `features` error out); GPU passthrough on Podman is unwired. Deacon has no stable release yet — pinned to `0.2.0-rc.11`.

## Verification

`pytest tests/unit` (566 passed), `ruff`, `mypy` all clean; deacon role + `proxmox_site.yml`/`proxmox_configure.yml` syntax-check; launcher templates render for both runtimes. Not yet exercised end-to-end against a live Proxmox node.

🤖 Generated with [Claude Code](https://claude.com/claude-code)