### PR TITLE
chore(devcontainer): add copilot and codex AI CLIs

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -16,7 +16,7 @@
         "ghcr.io/eitsupi/devcontainer-features/jq-likes:2": {},
         "ghcr.io/devcontainers-extra/features/starship:1": {},
         "ghcr.io/get2knowio/devcontainer-features/ai-clis:2": {
-            "install": "claudeCode,specifyCli"
+            "install": "claudeCode,specifyCli,copilot,codex"
         },
         "ghcr.io/get2knowio/devcontainer-features/modern-cli-tools:2": {},
         "ghcr.io/get2knowio/devcontainer-features/python-tools:2": {
@@ -41,7 +41,7 @@
         "source=${localEnv:HOME}/.claude,target=/home/vscode/.claude,type=bind,consistency=cached",
 	"source=${localEnv:HOME}/.aws,target=/home/vscode/.aws,type=bind,consistency=cached",
         "source=${localEnv:HOME}/.ssh,target=/home/vscode/.ssh,type=bind,consistency=cached",
-        "source=${localWorkspaceFolder}/../site,target=/workspaces/site,type=bind,consistency=cached",
+        "source=${localWorkspaceFolder}/../site,target=/workspaces/site,type=bind,consistency=cached"
     ],
     "postCreateCommand": "python3 --version && node --version"
 }


### PR DESCRIPTION
## Summary

Adds the `copilot` and `codex` AI CLIs to the devcontainer's `ai-clis` feature install list (alongside the existing `claudeCode,specifyCli`). Also drops a stray trailing comma on the last `mounts` entry.

Tooling-only change to the dev environment — no effect on the `remo` package or runtime.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018SrwtyNKt4Y24pU748URrT