### PR TITLE
feat(web): ephemeral device-pairing adoption (012-web-adopt-pairing)

### DIFF
--- a/.specify/feature.json
+++ b/.specify/feature.json
@@ -1,3 +1,3 @@
 {
-  "feature_directory": "specs/011-web-adopt"
+  "feature_directory": "specs/012-web-adopt-pairing"
 }

--- a/docker/compose.example.yml
+++ b/docker/compose.example.yml
@@ -139,10 +139,31 @@ services:
   #
   #       remo web adopt http://<docker-host>:8080
   #
-  #     which pushes your registry + instance host keys and authorizes the
-  #     service's OWN public key on each instance — your personal private key
-  #     never leaves the workstation. Later registry changes are re-pushed
-  #     with `remo web push`.
+  #     Open http://<docker-host>:8080 in a browser (through your forward-auth
+  #     proxy, see below), click "Copy pairing code", run the command above, and
+  #     paste the code when prompted. It pushes your registry + instance host
+  #     keys and authorizes the service's OWN public key on each instance — your
+  #     personal private key never leaves the workstation. Later registry changes
+  #     are re-pushed with `remo web push` (open the dashboard's "Pair CLI to
+  #     sync" affordance for a fresh code).
+  #
+  # Setup authorization (012-web-adopt-pairing): there is NO static token. The
+  # awaiting-adoption page mints a short-lived, single-use PAIRING CODE; the
+  # /api/v1/setup/* surface is dormant (404) unless a pairing session is live.
+  # Minting a code is gated by OPERATOR AUTHENTICATION:
+  #
+  #   - Recommended: put a forward-auth reverse proxy (Traefik ForwardAuth /
+  #     oauth2-proxy / Authelia / a hola app's SSO) in front. It must (a) gate
+  #     the browser-facing POST /api/v1/pairing/mint so only an authenticated
+  #     operator can mint, while (b) PASSING THROUGH /api/v1/setup/* unchanged
+  #     (the CLI cannot do SSO — it authenticates with the pairing code alone).
+  #     Set REMO_WEB_OPERATOR_AUTH=forward and REMO_WEB_FORWARD_AUTH_HEADER to
+  #     the trusted identity header your proxy injects (e.g. X-Forwarded-User).
+  #     The proxy MUST strip that header from inbound client requests.
+  #
+  #   - Loopback/dev only: REMO_WEB_OPERATOR_AUTH=none mints WITHOUT operator
+  #     auth (a loud, weaker posture surfaced in readiness). Use only when the
+  #     port is loopback-bound or otherwise network-restricted.
   #
   # This service carries `profiles: ["adopted"]` so a plain `docker compose
   # up` still starts only the bind-mount service above. Start this one with:
@@ -154,25 +175,29 @@ services:
     # above — the mode is chosen purely by what is mounted, not by the image.
     image: ghcr.io/get2knowio/remo-web:latest
     ports:
-      # Adoption traffic (the token-gated /api/v1/setup/* calls made by
-      # `remo web adopt`) arrives over this same port. Loopback-only means
-      # the workstation running the CLI must be the Docker host itself —
-      # otherwise bind a LAN IP here deliberately, or keep loopback and run
-      # `remo web adopt --via <docker-host>` to tunnel over SSH.
+      # Adoption traffic (the pairing-code-authenticated /api/v1/setup/* calls
+      # made by `remo web adopt`) arrives over this same port. Loopback-only
+      # means the workstation running the CLI must be the Docker host itself —
+      # otherwise bind a LAN IP here deliberately (behind your forward-auth
+      # proxy), or keep loopback and run `remo web adopt --via <docker-host>`
+      # to tunnel over SSH.
       - "127.0.0.1:8080:8080"
     environment:
-      # REQUIRED for adopted mode: while this is unset/empty the setup API
-      # does not exist at all (every /api/v1/setup/* request gets a plain
-      # 404), so adoption is impossible. Generate a strong random value,
-      # e.g.:
+      # Operator-authentication posture for pairing-code minting (see the notes
+      # above). Choose ONE:
       #
-      #   openssl rand -hex 24
+      #   Forward auth (recommended, behind an SSO proxy):
+      #     - "REMO_WEB_OPERATOR_AUTH=forward"
+      #     - "REMO_WEB_FORWARD_AUTH_HEADER=X-Forwarded-User"
+      #   (Enabling forward auth without a header name is a fail-fast error.)
       #
-      # and pass the same value to the CLI via $REMO_API_TOKEN (or the
-      # interactive prompt) when running `remo web adopt`.
-      - "REMO_WEB_API_TOKEN=replace-me--generate-with--openssl-rand-hex-24"
+      #   Network-restricted (loopback/dev only — weaker, loudly logged):
+      - "REMO_WEB_OPERATOR_AUTH=none"
+      #
+      # There is NO REMO_WEB_API_TOKEN anymore — a value set for it is ignored.
       # The REMO_WEB_ALLOWED_HOSTS / REMO_WEB_ALLOWED_ORIGINS notes on the
-      # service above apply here unchanged.
+      # service above apply here unchanged (the mint endpoint needs the page's
+      # Origin allowlisted; the default 127.0.0.1:8080 origin covers loopback).
     volumes:
       # A writable named state volume at REMO_HOME — the ONLY volume in this
       # mode (no registry mount, no ~/.ssh mounts; presence of those is what

--- a/docs/web-session-interface.md
+++ b/docs/web-session-interface.md
@@ -180,30 +180,47 @@ instance — your own LAN, your own tailnet, or behind a reverse proxy you contr
 
 ### Reverse proxies, SSO, and the setup surface
 
-There is exactly one authenticated surface in the service: the **setup API** (`/api/v1/setup/*`) used
-by `remo web adopt`/`remo web push`, gated by a bearer token (`REMO_WEB_API_TOKEN` — see
-[CLI-to-web adoption](#cli-to-web-adoption)). Everything above about the *browser* surface remains
-true regardless of deployment mode:
+> **Breaking change (012-web-adopt-pairing):** the static `REMO_WEB_API_TOKEN` gate is **removed**. A
+> value set for that variable is now ignored. Setup access is authorized by an **ephemeral pairing
+> code** minted from the awaiting-adoption page, not a long-lived secret.
 
-- **A reverse proxy without SSO does not change the trust model.** Putting the service behind a
-  TLS-terminating proxy (e.g. an hola app behind Traefik) encrypts the transport, but the dashboard
-  and terminals still have no login — the browser surface still needs proxy-level protection
-  (network boundary, allowlisted client IPs, or proxy auth) exactly as described above.
-- **A future forward-auth deployment needs a bypass rule scoped to `/api/v1/setup/*`.** The
-  workstation CLI authenticates with the `Authorization: Bearer` token, not with a browser SSO
-  session, so an SSO/forward-auth layer in front of the service would block adoption unless setup
-  routes are exempted from it. That bypass is defensible because the application itself enforces the
-  bearer token on every setup route — the surface is never unauthenticated. (Documentation-only
-  guidance; no proxy/SSO integration ships with the service.)
-- **Origin-less requests to the setup surface bypass the Origin allowlist — deliberately and
-  safely.** The Origin allowlist is a browser-CSRF defense, and the setup API is bearer-token-only
-  with no ambient credentials: a cross-origin browser request cannot attach an `Authorization`
-  header, and a genuine browser CSRF attempt always carries an `Origin` header — which is still
-  enforced (a present-but-disallowed `Origin` is rejected). This scoped exemption is what lets the
-  Origin-less CLI client reach the setup API, including `--via` tunnels whose
-  `127.0.0.1:<random-port>` origin could never be allowlisted. See the auth section of
-  [`setup-api.md`](../specs/011-web-adopt/contracts/setup-api.md) and the middleware in
-  `src/remo_cli/web/app.py`.
+The setup API (`/api/v1/setup/*`) used by `remo web adopt`/`remo web push` is **dormant** — every
+route returns `404`, byte-identical to an unknown route — unless a **pairing session** is live. A
+session exists only while an operator is on the awaiting-adoption page (or the dashboard's re-sync
+affordance): opening the page mints a short-lived, single-use pairing code (sliding idle TTL, default
+15 min), the operator copies it to their workstation and pastes it into the CLI, and the code
+authenticates that one adoption/push. See [CLI-to-web adoption](#cli-to-web-adoption).
+
+Two properties make this safe:
+
+- **Minting a code is gated by operator authentication.** The browser-facing
+  `POST /api/v1/pairing/mint` endpoint only mints for an authenticated operator. v1 implements this
+  with **forward auth**: put a proxy (Traefik ForwardAuth / oauth2-proxy / Authelia / a hola app's
+  SSO) in front that terminates sign-on and injects a trusted identity header, and set
+  `REMO_WEB_OPERATOR_AUTH=forward` + `REMO_WEB_FORWARD_AUTH_HEADER=<that header>` (e.g.
+  `X-Forwarded-User`). Enabling forward auth without naming a header is a **fail-fast** startup error.
+  A loopback/dev deployment may instead set `REMO_WEB_OPERATOR_AUTH=none` (network-restricted — mints
+  without operator auth; a loud, weaker posture surfaced in readiness). The check sits behind a
+  pluggable provider seam so an in-app OIDC verifier can be added later.
+- **The proxy must split the two paths.** Forward auth applies **only** to `POST /api/v1/pairing/mint`
+  — the CLI cannot complete an SSO challenge, so the proxy MUST **pass `/api/v1/setup/*` through**
+  unauthenticated at the proxy layer; those routes are authenticated by the pairing code alone. In
+  short: gate `/api/v1/pairing/mint` with SSO, pass `/api/v1/setup/*` through.
+
+**Forward-auth trust boundary.** The service trusts the identity header only because the deployment
+guarantees the proxy sits in front and **sets/strips** that header — so a client cannot reach the app
+directly and spoof it. This is the standard forward-auth boundary; a deployment that exposes the app
+directly (no proxy) MUST use `REMO_WEB_OPERATOR_AUTH=none` and accept the weaker posture.
+
+**Origin-less requests to the setup surface bypass the Origin allowlist — deliberately and safely.**
+The Origin allowlist is a browser-CSRF defense, and the setup API carries no ambient credentials: a
+cross-origin browser request cannot attach an `Authorization` header, and a genuine browser CSRF
+attempt always carries an `Origin` (still enforced). This scoped exemption lets the Origin-less CLI
+reach the setup API, including `--via` tunnels whose `127.0.0.1:<random-port>` origin could never be
+allowlisted. The browser-only `POST /api/v1/pairing/mint` is **not** exempt — it is held to the Origin
+check. See [`setup-api.md`](../specs/012-web-adopt-pairing/contracts/setup-api.md),
+[`pairing-api.md`](../specs/012-web-adopt-pairing/contracts/pairing-api.md), and the middleware in
+`src/remo_cli/web/app.py`.
 
 ## Deployment modes: mounts vs adoption
 
@@ -217,7 +234,7 @@ var that can drift out of sync with reality):
 | SSH identity | **Your personal private key** bind-mounted read-only | A **service-scoped keypair** the container generates itself on first boot (`web-identity/id_ed25519`, comment `remo-web@<deployment-id>`) |
 | Instance host keys | Your `~/.ssh/known_hosts` bind-mounted read-only | Verified host keys pushed by the CLI (`web-identity/known_hosts`) |
 | Volumes | Several read-only bind mounts | **One** writable named volume at `REMO_HOME` (`/home/remo/.config/remo`) — no registry mount, no `~/.ssh` mounts |
-| Required env | — | `REMO_WEB_API_TOKEN` (enables the token-gated setup API; without it adoption is impossible) |
+| Required env | — | `REMO_WEB_OPERATOR_AUTH` (`forward` + `REMO_WEB_FORWARD_AUTH_HEADER`, or `none` for loopback/dev) — gates pairing-code minting; without a provider, minting is disabled and adoption is impossible |
 | Runs where? | Effectively the same machine as your CLI config | Any host — nothing from the workstation is mounted |
 | Registry updates | Edit/sync locally; the mount hot-reloads | `remo web push` after local changes |
 
@@ -235,7 +252,7 @@ From these artifacts the service derives one of four states:
 
 | State | Derivation | `remo web check` | `GET /api/v1/ready` | Browser |
 |---|---|---|---|---|
-| `unconfigured` | `REMO_HOME` writable, no registry (service keypair may already exist — generated, awaiting first push) | PASS: `unconfigured — awaiting adoption; run 'remo web adopt <service-url>' from a workstation` | **`200`** `{"status": "unconfigured", ...}` — healthy-and-waiting must not fail the compose healthcheck or crash-loop `restart: unless-stopped` | "Awaiting adoption" page: explains the state, shows a copy-pastable `remo web adopt <origin>` command, and flips to the dashboard automatically once adoption completes. No instance data, no terminals, no public-key display. |
+| `unconfigured` | `REMO_HOME` writable, no registry (service keypair may already exist — generated, awaiting first push) | PASS: `unconfigured — awaiting adoption; run 'remo web adopt <service-url>' from a workstation` | **`200`** `{"status": "unconfigured", ...}` — healthy-and-waiting must not fail the compose healthcheck or crash-loop `restart: unless-stopped` | "Awaiting adoption" page: explains the state, shows the `remo web adopt <origin>` command, and a **Copy pairing code** button (the code itself is never displayed). Flips to the dashboard automatically once adoption completes. No instance data, no terminals, no public-key display. |
 | `adopted` | `REMO_HOME` writable + service keypair + registry present | PASS: `adopted — configured via 'remo web adopt' (service identity in web-identity/)` | `200` `{"status": "ready", ...}` | Normal dashboard |
 | `mount_configured` | Registry present **and** (`REMO_HOME` not writable — the `:ro` bind mount — or a user SSH identity resolves via `REMO_WEB_SSH_IDENTITY_FILE`/`~/.ssh/id_*`). Explicit mounts are the operator's stated intent, so this wins even if a service keypair also exists. | PASS: `mount_configured — configured via read-only mounts` | `200` `{"status": "ready", ...}` | Normal dashboard |
 | `broken` | Any required artifact present but unreadable, a half-pair service keypair, a registry on a writable volume with nothing able to authenticate, or a missing runtime prerequisite | FAIL with per-check remediation | `503` `{"status": "not_ready", ...}` with actionable detail — unchanged from today | Offline/error indicator |
@@ -270,9 +287,9 @@ The file defines **both deployment modes as alternative services** — run one o
 
   Its differences from `remo-web`: **no bind mounts at all** — a single writable named volume
   (`remo-web-state:/home/remo/.config/remo`) holds the pushed registry, per-instance host keys, and
-  the service identity keypair — plus a required `REMO_WEB_API_TOKEN` environment variable (generate
-  one with `openssl rand -hex 24`). Hardening flags are identical. See
-  [CLI-to-web adoption](#cli-to-web-adoption) for what happens after `up`.
+  the service identity keypair — plus a `REMO_WEB_OPERATOR_AUTH` setting (`forward` behind an SSO
+  proxy, or `none` for loopback/dev) that gates pairing-code minting. Hardening flags are identical.
+  See [CLI-to-web adoption](#cli-to-web-adoption) for what happens after `up`.
 
 ### The published image
 
@@ -377,39 +394,38 @@ Both commands live in the base CLI (`src/remo_cli/cli/web.py` → `src/remo_cli/
 stdlib HTTP only) — the `web` extra is **not** required on the workstation:
 
 ```text
-remo web adopt [URL] [--token TEXT] [--via HOST] [--allow-empty] [--yes] [--save]
-remo web push [--allow-empty] [--yes]
+remo web adopt [URL] [--token TEXT] [--via HOST] [--allow-empty] [--yes]
+remo web push  [URL] [--token TEXT] [--via HOST] [--allow-empty] [--yes]
 ```
+
+`--token` carries the **pairing code** (the option name is kept for
+compatibility). Nothing is saved between runs — each adopt/push obtains a fresh
+code from the page.
 
 ### First-time adoption walkthrough
 
 **1. Deploy the container.** Via Compose (`docker compose --profile adopted up -d`, see
-[Docker Compose deployment](#docker-compose-deployment)) or as an **hola app** — the hola app
-manifest prompts for or generates the admin token at install time and supplies it to the container
-as `REMO_WEB_API_TOKEN`; either way the operator's job is the same: a writable state volume plus the
-token. Within ~30 seconds the container is up in the `unconfigured` state, has minted its
-service-scoped keypair, and the browser shows the "awaiting adoption" page with the exact command to
-run.
+[Docker Compose deployment](#docker-compose-deployment)) or as an **hola app** — set
+`REMO_WEB_OPERATOR_AUTH` (`forward` behind the hola app's SSO, plus `REMO_WEB_FORWARD_AUTH_HEADER`;
+or `none` for a loopback/dev deployment) so the page can mint pairing codes. Within ~30 seconds the
+container is up in the `unconfigured` state, has minted its service-scoped keypair, and the browser
+shows the "awaiting adoption" page.
 
-**2. Run `remo web adopt` on the workstation.** Inputs resolve in this order:
+**2. Copy the pairing code and run `remo web adopt`.** On the awaiting-adoption page (reached through
+your SSO proxy), click **Copy pairing code** — the code lands on your clipboard and is never
+displayed. On the workstation, inputs resolve in this order:
 
 | Input | Resolution order |
 |---|---|
 | Service URL | argument → `REMO_API_URL` env var → interactive prompt |
-| API token | `--token` → `REMO_API_TOKEN` env var → interactive prompt (hidden input) |
-
-`REMO_API_URL`/`REMO_API_TOKEN` are the workstation-side counterparts of the service's
-`REMO_WEB_API_TOKEN` — set them (e.g. exported by your shell profile, or handed out by the hola app
-install output) and the command runs prompt-free:
+| Pairing code | `--token` → `REMO_API_TOKEN` env var → interactive prompt (hidden input) |
 
 ```bash
-export REMO_API_URL=http://docker-host.lan:8080
-export REMO_API_TOKEN=<the value you set as REMO_WEB_API_TOKEN>
-remo web adopt
+remo web adopt http://docker-host.lan:8080    # paste the code at the prompt
 ```
 
 The flow then: checks the service's state (aborting clearly if the target is mount-configured or the
-token is rejected), fetches the service's public key and deployment id, and — per direct-access
+code is no longer valid), fetches the service's public key and deployment id, and — per direct-access
 instance, with a bounded per-instance time budget so one slow instance delays only itself —
 `ssh-keyscan`s the host, verifies the scanned key against your own trusted `~/.ssh/known_hosts`
 record (`ssh-keygen -F`, so hashed known_hosts files work; the service itself **never** makes a
@@ -437,52 +453,50 @@ asymmetric-network case (e.g. the instance is only reachable via workstation-spe
 config such as ProxyJump, or a firewall between the container host and the instance), not an
 adoption failure.
 
-**5. Saved credentials (explicit consent).** On success the CLI offers to save the service URL and
-token to `~/.config/remo/web-service.json` (written atomically, mode `0600`) so that later
-`remo web push` runs are zero-argument. Saving requires explicit consent — an interactive yes, or
-the `--save` flag; `--yes` alone never saves. v1 stores a single default deployment. The file also
-records the service's `deployment_id` and a per-instance push cache (see below).
+**5. No saved credentials.** Nothing durable is saved (there is no long-lived secret to save). A later
+`remo web push` obtains a fresh pairing code the same way. The workstation keeps only a **non-secret**
+push cache at `~/.config/remo/web-service.json` (mode `0600`): the service `deployment_id` mapped to
+per-instance host-key fingerprints, used to skip re-keyscanning unchanged instances. No URL and no
+code are ever stored.
 
 The command exits `0` when the flow completes — per-instance skips/flags are reported in the
-summary, not fatal — and `1` only on hard failure (auth rejection, mount-configured target, empty
-registry without `--allow-empty`, tunnel failure, payload rejected). Re-running adopt is idempotent:
-same summary, zero changes, still exactly one `remo-web@` line per instance.
+summary, not fatal — and `1` only on hard failure (dormant setup surface / expired code,
+mount-configured target, empty registry without `--allow-empty`, tunnel failure, payload rejected).
+Re-running adopt (with a fresh code) is idempotent: same summary, zero changes, still exactly one
+`remo-web@` line per instance.
 
-### The setup API and `REMO_WEB_API_TOKEN`
+### The setup API and pairing codes
 
-The CLI talks to four token-gated endpoints under `/api/v1/setup/*`
-([`setup-api.md`](../specs/011-web-adopt/contracts/setup-api.md)): `GET /status`, `GET /identity`,
-`PUT /registry`, `POST /verify`. Every route requires `Authorization: Bearer <REMO_WEB_API_TOKEN>`,
-compared in constant time:
+The CLI talks to four endpoints under `/api/v1/setup/*`
+([`setup-api.md`](../specs/012-web-adopt-pairing/contracts/setup-api.md)): `GET /status`,
+`GET /identity`, `PUT /registry`, `POST /verify`. The surface is **dormant** unless a pairing session
+is live; each route requires `Authorization: Bearer <pairing-code>`, compared in constant time:
 
-- **Unset/empty token → the setup surface does not exist.** Every `/api/v1/setup/*` request gets a
-  plain `404`, indistinguishable from an absent feature — fail closed, never open. All other
-  functionality (dashboard, terminals, health) is unaffected. A bind-mount deployment that never
-  sets the token therefore exposes no setup surface at all.
-- **Wrong/missing header → `401`** with no further detail; the attempt is logged without the
-  presented credential. The token value and `Authorization` headers are covered by the service's
-  existing log redaction (`src/remo_cli/web/logging_config.py`).
-- **Rotation = redeploy with a new value.** The token is deploy-time configuration; change it in the
-  Compose file or hola app settings and restart, then re-run `remo web adopt` with the new token
-  (saved workstation credentials with the old token fail with a clear re-auth message).
+- **No live session → the setup surface does not exist.** Every `/api/v1/setup/*` request gets a plain
+  `404`, indistinguishable from an absent feature — fail closed. A session is live only while an
+  operator is on the awaiting-adoption page (or the dashboard re-sync affordance).
+- **Wrong/missing/expired code → the same dormant `404`** — never a distinguishable `401` that would
+  reveal a session exists. The attempt is logged without the presented code; codes and `Authorization`
+  headers are covered by the service's log redaction (`src/remo_cli/web/logging_config.py`).
+- **The session ends when the flow completes** (on the terminal `POST /verify`), and a code is
+  single-use per handoff — reopening the page mints a fresh one and invalidates the prior. There is no
+  rotation to manage: codes are ephemeral by construction.
 
 ### Ongoing pushes: `remo web push`
 
 After the initial adoption, local registry changes (a `remo <provider> sync`, a new `create`, a
-removal) are re-synced with a zero-argument push:
+removal) are re-synced. Open the dashboard's **Pair CLI to sync** affordance, copy a fresh code, then:
 
 ```bash
-remo incus sync my-incus-host    # e.g. registers a new instance locally
-remo web push                    # re-sync it to the adopted service
+remo incus sync my-incus-host                   # e.g. registers a new instance locally
+remo web push http://docker-host.lan:8080       # paste the code; re-sync to the service
 ```
 
-`remo web push` loads the saved credentials, verifies the service still has the same
-`deployment_id` (a mismatch means the state volume was reset — it aborts with re-adopt guidance),
-then runs the adopt flow with **delta behavior**: only new or changed instances are re-keyscanned
-and re-authorized; instances unchanged since the last successful push skip that work entirely and
-are reported as `unchanged` (their previously verified host keys are reused, since every push
-replaces the service's host-keys file wholesale). If no credentials were saved, `push` behaves
-exactly like first-time `adopt`, prompting for URL and token.
+`remo web push` resolves URL + code the same way `adopt` does (every run), reads the service's
+`deployment_id`, and runs the adopt flow with **delta behavior**: only new or changed instances are
+re-keyscanned and re-authorized; instances unchanged since the last successful push (per the non-secret
+push cache for that `deployment_id`) skip that work and are reported as `unchanged` (their previously
+verified host keys are reused, since every push replaces the service's host-keys file wholesale).
 
 **Mirror semantics — removals propagate, authorization does not.** The push is an exact mirror: the
 workstation registry is the source of truth, so an instance you removed locally disappears from the
@@ -623,12 +637,13 @@ interactive session (only `remo-host capabilities` is invoked, never `sessions a
 
 | Failure | What it means | Fix |
 |---|---|---|
-| `/api/v1/setup/*` returns `404` for everything | `REMO_WEB_API_TOKEN` is unset or empty — the setup surface is disabled entirely (fail closed). | Set `REMO_WEB_API_TOKEN` in the deployment (Compose `environment:` / hola app setting) and restart. |
-| `remo web adopt` fails with an auth error (`401`) | The token you supplied doesn't match the service's `REMO_WEB_API_TOKEN`. | Re-check `REMO_API_TOKEN`/`--token` against the deployed value; after a token rotation, re-run adopt with the new value. |
+| `/api/v1/setup/*` returns `404` for everything | No pairing session is live — the surface is dormant (fail closed). | Open the awaiting-adoption page (through your SSO proxy) to mint a code; if the page can't mint, set `REMO_WEB_OPERATOR_AUTH` (`forward` + header, or `none` for loopback). |
+| `remo web adopt`/`push` fails: "pairing code is no longer valid … dormant" | The code expired (idle TTL), was rotated by reopening the page, or was already used. | Reopen the adopt page (or the dashboard's "Pair CLI to sync" affordance) for a fresh code and retry. |
+| Mint page shows "you are not signed in" / `POST /pairing/mint` returns `403` | Forward auth is required but the request reached the service without the trusted identity header. | Ensure the request goes through the SSO proxy that injects `REMO_WEB_FORWARD_AUTH_HEADER`; verify the proxy sets and strips it. |
 | adopt fails: deployment "configured via read-only mounts" | The target is a bind-mount deployment (`mount_configured`) — its configuration is operator-provided and read-only, so adoption does not apply. | Update the mounted files instead, or deploy the adopted-mode service (writable state volume, no mounts) if you want adoption. |
 | adopt refuses: empty registry | Your local registry has no instances — pushing would wipe a previously adopted service (a classic wrong-workstation accident). | Register/sync instances first, or pass `--allow-empty` if wiping is intentional. |
 | `--via` fails naming `REMO_WEB_ALLOWED_HOSTS` | Tunneled requests arrive with a `127.0.0.1` Host header, which the service's Host allowlist rejects. | Add `127.0.0.1` to `REMO_WEB_ALLOWED_HOSTS` (the default includes it). |
-| `remo web push` aborts: service identity changed | The saved `deployment_id` no longer matches the service — its state volume was reset and it minted a new identity. | Re-run `remo web adopt` (this replaces the stale `remo-web@` entries on your instances with the new key). |
+| After a service state-volume reset, instances keep a stale `remo-web@` line | The reset service minted a new identity; a fresh `remo web adopt` authorizes the new key but does not remove the old line. | Re-run `remo web adopt`, then delete the stale `remo-web@<old-id>` line from each instance's `~/.ssh/authorized_keys`. |
 | Summary line `security_flagged` (potential MITM warning) | The instance's scanned host key doesn't match your workstation's trusted record; nothing was pushed for it. | Investigate before trusting. If the instance was legitimately rebuilt: `ssh-keygen -R <host>`, reconnect once to re-trust, re-run adopt. |
 | Verify report: "reachable from workstation but not from the service" | Asymmetric reachability — the CLI reached the instance but the container cannot (DNS, routing, firewall, or workstation-only SSH config like ProxyJump). | Fix the network path from the container host to the instance; the adoption itself succeeded. |
 
@@ -688,7 +703,10 @@ locally with zero configuration; a container overrides everything via env alone.
 | `REMO_WEB_SSH_CONTROL_DIR` | `/run/remo-ssh` | Writable directory for SSH ControlMaster sockets (must be tmpfs or otherwise writable under a read-only rootfs). |
 | `REMO_WEB_FRONTEND_DIST_DIR` | `<repo_root>/frontend/dist` (resolved relative to the installed package) | Directory the built frontend SPA is served from. The Docker image overrides this to `/app/frontend-dist`, matching where the multi-stage build actually copies the built assets. |
 | `REMO_WEB_SSH_IDENTITY_FILE` | *(unset — falls back to the service keypair under `web-identity/`, then `~/.ssh/id_ed25519`/`id_ecdsa`/`id_rsa`/`id_dsa`)* | Explicit path to the SSH private key used for readiness/`remo web check`'s identity check, when it isn't one of the conventional filenames. |
-| `REMO_WEB_API_TOKEN` | *(unset)* | Admin bearer token for the setup API (`/api/v1/setup/*`) used by `remo web adopt`/`remo web push`. **Fail-closed**: while unset or empty, the setup surface is disabled entirely — every setup route returns a plain `404` — and adoption is impossible; all other functionality is unaffected. Verified with a constant-time comparison and covered by log redaction. Rotation = redeploy with a new value (then re-run `remo web adopt` with it). Generate with e.g. `openssl rand -hex 24`. |
+| `REMO_WEB_OPERATOR_AUTH` | *(unset — minting disabled)* | Operator-authentication posture gating pairing-code minting (`POST /api/v1/pairing/mint`). `forward` requires a trusted proxy-injected identity header (`REMO_WEB_FORWARD_AUTH_HEADER`); `none` mints without operator auth (network-restricted — a loud, weaker posture for loopback/dev). While unset, minting is disabled and adoption is impossible (fail closed). |
+| `REMO_WEB_FORWARD_AUTH_HEADER` | *(unset)* | Name of the trusted identity header your forward-auth proxy injects (e.g. `X-Forwarded-User`, `Remote-User`). **Required** when `REMO_WEB_OPERATOR_AUTH=forward`; enabling forward auth without it is a fail-fast startup error. The proxy MUST set and strip this header. |
+| `REMO_WEB_PAIRING_TTL_S` | `900.0` | Sliding idle TTL (seconds) for a pairing session — it expires this long after the last successful setup call (default 15 min). |
+| `REMO_WEB_API_TOKEN` | *(removed — ignored)* | **Removed in 012.** The static setup-API token is gone; a value set here is ignored (a one-line "now ignored" note is logged at startup). Setup access is authorized by ephemeral pairing codes. |
 
 `remo web serve --host`/`--port` are convenience overrides for local runs; every other setting is env-var-only.
 
@@ -700,4 +718,4 @@ Two variables configure the **CLI** (not the service — hence no `REMO_WEB_` pr
 | Variable | Used as |
 |---|---|
 | `REMO_API_URL` | Service URL fallback when no URL argument is given (before falling back to an interactive prompt). |
-| `REMO_API_TOKEN` | API token fallback when `--token` is not given (before falling back to a hidden interactive prompt). Set it to the same value as the service's `REMO_WEB_API_TOKEN`. |
+| `REMO_API_TOKEN` | Pairing-code fallback when `--token` is not given (before falling back to a hidden interactive prompt). Set it to a code freshly minted from the adopt page. |

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -220,6 +220,81 @@ export async function getReady(): Promise<ReadinessResponse> {
   };
 }
 
+// ---- Pairing (012-web-adopt-pairing) ----
+//
+// The awaiting-adoption page (and the dashboard re-sync affordance) mints an
+// ephemeral pairing code on open, which the operator copies to the clipboard
+// and pastes into `remo web adopt` / `remo web push`. The code is returned only
+// by mintPairingCode() at runtime — never embedded in the bundle (FR-016) — and
+// the caller MUST hold it out of the DOM (copy-only, never displayed).
+
+export interface MintPairingResponse {
+  code: string;
+  expires_in: number;
+}
+
+/**
+ * `POST /api/v1/pairing/mint` — mint a fresh code (rotation-on-open, FR-003).
+ * `origin` distinguishes the adopt page from the dashboard re-sync affordance.
+ * A `403` means operator authentication is required/not configured (the page is
+ * reached through a forward-auth proxy in the gated posture) — surfaced via
+ * ApiError so the page can show guidance rather than a code.
+ */
+export async function mintPairingCode(
+  origin: "adopt" | "resync" = "adopt",
+): Promise<MintPairingResponse> {
+  let response: Response;
+  try {
+    response = await fetch(`/api/v1/pairing/mint?origin=${encodeURIComponent(origin)}`, {
+      method: "POST",
+    });
+  } catch (cause) {
+    throw new ApiError({
+      code: "network_error",
+      message: cause instanceof Error ? cause.message : "Network request failed",
+      retryable: true,
+      remediation: "Check that the Remo web service is reachable.",
+    });
+  }
+  if (response.status === 403) {
+    // Operator authentication required / not configured — surface a distinct
+    // code so the adopt page can prompt to sign in rather than showing a code.
+    throw new ApiError({
+      code: "forbidden",
+      message: "Operator authentication is required to mint a pairing code.",
+      retryable: false,
+      remediation: "Sign in through your access proxy, then reload this page.",
+    });
+  }
+  if (!response.ok) {
+    throw new ApiError({
+      code: "unknown",
+      message: `Mint failed with status ${response.status}`,
+      retryable: true,
+      remediation: "Reload this page to try again.",
+    });
+  }
+  return (await response.json()) as MintPairingResponse;
+}
+
+/**
+ * `POST /api/v1/pairing/end` — best-effort session end (page-hide, FR-004).
+ * Uses `navigator.sendBeacon` when available so it survives page unload; the
+ * server treats it as idempotent and the idle TTL is the authoritative backstop.
+ */
+export function endPairing(): void {
+  const path = "/api/v1/pairing/end";
+  try {
+    if (navigator.sendBeacon?.(path)) {
+      return;
+    }
+  } catch {
+    // fall through to fetch
+  }
+  // keepalive lets the request outlive the page during unload.
+  void fetch(path, { method: "POST", keepalive: true }).catch(() => undefined);
+}
+
 // ---- Terminals (T041, US2) ----
 //
 // Per contracts/rest-api.md and contracts/terminal-websocket.md. The token

--- a/frontend/src/components/AwaitingAdoption.tsx
+++ b/frontend/src/components/AwaitingAdoption.tsx
@@ -1,17 +1,20 @@
-// Awaiting-adoption page (011-web-adopt, FR-004 / research R12).
+// Awaiting-adoption page (012-web-adopt-pairing; supersedes the 011 static-token
+// page).
 //
 // Rendered by AppRoot instead of the console shell while GET /api/v1/ready
-// reports status "unconfigured": a short explanation, the copy-pastable
-// `remo web adopt <origin>` command pre-filled with this page's origin, and a
-// subtle "waiting for adoption…" pulse. Deliberately minimal — no instance
-// data, no terminals, and no public key display (identity retrieval stays
-// behind the adoption token; the CLI fetches it).
+// reports status "unconfigured". On mount it mints an ephemeral pairing code
+// (rotation-on-open, FR-003) and holds it ONLY in a non-rendered ref — the
+// value never enters the DOM (FR-015/FR-016). The operator clicks "Copy pairing
+// code", pastes it into `remo web adopt <origin>` on their workstation, and the
+// browser flips to the dashboard the moment adoption completes.
 //
-// The shared health poll keeps running while this page is mounted (plus a
-// faster local nudge below), so the moment adoption completes the root gate
-// flips to the full dashboard with no manual refresh.
+// The code is fetched at runtime (never embedded in the served bundle) and the
+// page best-effort ends the session on hide/unload (FR-004); the server's idle
+// TTL is the authoritative backstop.
 
 import { useCallback, useEffect, useRef, useState } from "react";
+import { ApiError, endPairing, mintPairingCode } from "../api/client";
+import { copyText } from "../lib/clipboard";
 import { useHealth } from "../state/health";
 import "./AwaitingAdoption.css";
 
@@ -21,38 +24,52 @@ import "./AwaitingAdoption.css";
 // extra ticks are safe alongside the shared interval.
 const ADOPTION_POLL_NUDGE_MS = 3_000;
 
-async function copyText(text: string): Promise<boolean> {
-  // navigator.clipboard requires a secure context; this console commonly runs
-  // over plain http on a trusted LAN, so fall back to execCommand.
-  try {
-    if (navigator.clipboard?.writeText) {
-      await navigator.clipboard.writeText(text);
-      return true;
-    }
-  } catch {
-    // fall through to the legacy path
-  }
-  try {
-    const textarea = document.createElement("textarea");
-    textarea.value = text;
-    textarea.style.position = "fixed";
-    textarea.style.opacity = "0";
-    document.body.appendChild(textarea);
-    textarea.select();
-    const ok = document.execCommand("copy");
-    textarea.remove();
-    return ok;
-  } catch {
-    return false;
-  }
-}
+type MintState = "minting" | "ready" | "unauthorized" | "error";
 
 export function AwaitingAdoption(): JSX.Element {
   const { retry } = useHealth();
   const command = `remo web adopt ${window.location.origin}`;
 
+  // The pairing code lives ONLY here — never in React state, never in the DOM.
+  const codeRef = useRef<string | null>(null);
+  const [mintState, setMintState] = useState<MintState>("minting");
   const [copyState, setCopyState] = useState<"idle" | "copied" | "failed">("idle");
   const copyResetHandle = useRef<ReturnType<typeof setTimeout>>();
+
+  // Mint on open (rotation-on-open, FR-003). The response code is stashed in the
+  // ref; only expires_in / auth status drive rendering.
+  useEffect(() => {
+    let cancelled = false;
+    void mintPairingCode("adopt")
+      .then((res) => {
+        if (cancelled) return;
+        codeRef.current = res.code;
+        setMintState("ready");
+      })
+      .catch((err) => {
+        if (cancelled) return;
+        codeRef.current = null;
+        // 403 => reached without operator auth (forward-auth proxy front door);
+        // anything else => a generic retry affordance.
+        setMintState(err instanceof ApiError && err.code === "forbidden" ? "unauthorized" : "error");
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  // Best-effort end on hide/unload (FR-004); idle TTL is the real backstop.
+  useEffect(() => {
+    const onHide = () => {
+      if (document.visibilityState === "hidden") endPairing();
+    };
+    window.addEventListener("pagehide", endPairing);
+    document.addEventListener("visibilitychange", onHide);
+    return () => {
+      window.removeEventListener("pagehide", endPairing);
+      document.removeEventListener("visibilitychange", onHide);
+    };
+  }, []);
 
   useEffect(() => {
     const handle = setInterval(() => void retry(), ADOPTION_POLL_NUDGE_MS);
@@ -62,12 +79,17 @@ export function AwaitingAdoption(): JSX.Element {
   useEffect(() => () => clearTimeout(copyResetHandle.current), []);
 
   const onCopy = useCallback(() => {
-    void copyText(command).then((ok) => {
+    const code = codeRef.current;
+    if (!code) {
+      setCopyState("failed");
+      return;
+    }
+    void copyText(code).then((ok) => {
       setCopyState(ok ? "copied" : "failed");
       clearTimeout(copyResetHandle.current);
       copyResetHandle.current = setTimeout(() => setCopyState("idle"), 2_000);
     });
-  }, [command]);
+  }, []);
 
   return (
     <div className="adopt-page" data-testid="awaiting-adoption">
@@ -81,23 +103,40 @@ export function AwaitingAdoption(): JSX.Element {
         <div className="adopt-title">This remo-web service is awaiting adoption</div>
         <p className="adopt-body">
           It is running without configuration. From a workstation with the remo CLI and your
-          instance registry, run the command below to pair this service — no instance data or
-          terminals are available until adoption completes.
+          instance registry, run the command below, then paste the pairing code when prompted —
+          no instance data or terminals are available until adoption completes.
         </p>
 
         <div className="adopt-command">
           <code className="adopt-command-text">{command}</code>
-          <button
-            type="button"
-            className="adopt-copy-btn"
-            onClick={onCopy}
-            data-testid="adopt-copy"
-          >
-            {copyState === "idle" && "Copy"}
-            {copyState === "copied" && "Copied ✓"}
-            {copyState === "failed" && "Copy failed"}
-          </button>
         </div>
+
+        {mintState === "unauthorized" ? (
+          <p className="adopt-body adopt-error">
+            You are not signed in. This service mints pairing codes only for an authenticated
+            operator — sign in through your access proxy, then reload this page.
+          </p>
+        ) : mintState === "error" ? (
+          <p className="adopt-body adopt-error">
+            Could not mint a pairing code. Reload this page to try again.
+          </p>
+        ) : (
+          <div className="adopt-command">
+            <span className="adopt-command-text">Pairing code ready (hidden)</span>
+            <button
+              type="button"
+              className="adopt-copy-btn"
+              onClick={onCopy}
+              disabled={mintState !== "ready"}
+              data-testid="adopt-copy"
+            >
+              {mintState !== "ready" && "…"}
+              {mintState === "ready" && copyState === "idle" && "Copy pairing code"}
+              {mintState === "ready" && copyState === "copied" && "Copied ✓"}
+              {mintState === "ready" && copyState === "failed" && "Copy failed"}
+            </button>
+          </div>
+        )}
 
         <div className="adopt-waiting">
           <span className="adopt-waiting-dot" />

--- a/frontend/src/components/PairToSync.css
+++ b/frontend/src/components/PairToSync.css
@@ -1,0 +1,53 @@
+.pairsync {
+  position: relative;
+  display: inline-flex;
+}
+
+.pairsync-popover {
+  position: absolute;
+  top: calc(100% + 8px);
+  right: 0;
+  z-index: 50;
+  width: 280px;
+  padding: 12px;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  background: var(--panel, #1b1d22);
+  border: 1px solid var(--border, #333);
+  border-radius: 8px;
+  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.35);
+}
+
+.pairsync-body {
+  margin: 0;
+  font-size: 12px;
+  line-height: 1.5;
+  color: var(--text-muted, #b8bcc4);
+}
+
+.pairsync-body code {
+  font-family: var(--mono, monospace);
+  color: var(--text, #e6e8ec);
+}
+
+.pairsync-error {
+  margin: 0;
+  font-size: 12px;
+  line-height: 1.5;
+  color: var(--danger, #e06c6c);
+}
+
+.pairsync-close {
+  align-self: flex-end;
+  background: none;
+  border: none;
+  color: var(--text-muted, #b8bcc4);
+  font-size: 12px;
+  cursor: pointer;
+  padding: 2px 4px;
+}
+
+.pairsync-close:hover {
+  color: var(--text, #e6e8ec);
+}

--- a/frontend/src/components/PairToSync.tsx
+++ b/frontend/src/components/PairToSync.tsx
@@ -1,0 +1,110 @@
+// Dashboard "Pair CLI to sync" affordance (012-web-adopt-pairing, US4 / FR-017).
+//
+// Mints a fresh pairing code (origin="resync") through the same lifecycle and
+// operator-auth gate as the awaiting-adoption page, and offers a Copy button.
+// The code value is held only in a ref and is NEVER rendered into the DOM
+// (FR-015/FR-016); opening the popover mints, closing it ends the session
+// best-effort (the idle TTL is the backstop).
+
+import { useCallback, useEffect, useRef, useState } from "react";
+import { ApiError, endPairing, mintPairingCode } from "../api/client";
+import { copyText } from "../lib/clipboard";
+import "./PairToSync.css";
+
+type MintState = "idle" | "minting" | "ready" | "unauthorized" | "error";
+
+export function PairToSync(): JSX.Element {
+  const [open, setOpen] = useState(false);
+  const [mintState, setMintState] = useState<MintState>("idle");
+  const [copyState, setCopyState] = useState<"idle" | "copied" | "failed">("idle");
+  const codeRef = useRef<string | null>(null);
+  const copyResetHandle = useRef<ReturnType<typeof setTimeout>>();
+
+  const close = useCallback(() => {
+    setOpen(false);
+    setMintState("idle");
+    setCopyState("idle");
+    codeRef.current = null;
+    endPairing();
+  }, []);
+
+  const openAndMint = useCallback(() => {
+    setOpen(true);
+    setMintState("minting");
+    setCopyState("idle");
+    void mintPairingCode("resync")
+      .then((res) => {
+        codeRef.current = res.code;
+        setMintState("ready");
+      })
+      .catch((err) => {
+        codeRef.current = null;
+        setMintState(
+          err instanceof ApiError && err.code === "forbidden" ? "unauthorized" : "error",
+        );
+      });
+  }, []);
+
+  useEffect(() => () => clearTimeout(copyResetHandle.current), []);
+
+  const onCopy = useCallback(() => {
+    const code = codeRef.current;
+    if (!code) {
+      setCopyState("failed");
+      return;
+    }
+    void copyText(code).then((ok) => {
+      setCopyState(ok ? "copied" : "failed");
+      clearTimeout(copyResetHandle.current);
+      copyResetHandle.current = setTimeout(() => setCopyState("idle"), 2_000);
+    });
+  }, []);
+
+  return (
+    <div className="pairsync">
+      <button
+        type="button"
+        className="topbar-btn"
+        onClick={open ? close : openAndMint}
+        data-testid="pair-to-sync"
+        title="Mint a pairing code to run `remo web push` from your workstation"
+      >
+        Pair CLI to sync
+      </button>
+
+      {open && (
+        <div className="pairsync-popover" role="dialog" aria-label="Pair CLI to sync">
+          <p className="pairsync-body">
+            Run <code>remo web push &lt;url&gt;</code> on your workstation and paste this code when
+            prompted. The code is copied to your clipboard — it is never shown.
+          </p>
+
+          {mintState === "unauthorized" ? (
+            <p className="pairsync-error">
+              You are not signed in. Sign in through your access proxy, then try again.
+            </p>
+          ) : mintState === "error" ? (
+            <p className="pairsync-error">Could not mint a code. Close and try again.</p>
+          ) : (
+            <button
+              type="button"
+              className="topbar-btn"
+              onClick={onCopy}
+              disabled={mintState !== "ready"}
+              data-testid="pairsync-copy"
+            >
+              {mintState !== "ready" && "Minting…"}
+              {mintState === "ready" && copyState === "idle" && "Copy pairing code"}
+              {mintState === "ready" && copyState === "copied" && "Copied ✓"}
+              {mintState === "ready" && copyState === "failed" && "Copy failed"}
+            </button>
+          )}
+
+          <button type="button" className="pairsync-close" onClick={close}>
+            Done
+          </button>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/components/TopBar.tsx
+++ b/frontend/src/components/TopBar.tsx
@@ -2,6 +2,7 @@
 // health indicator, refresh, settings, and shortcuts.
 
 import type { HealthStatus } from "../state/health";
+import { PairToSync } from "./PairToSync";
 import "./TopBar.css";
 
 // "unconfigured" is included for Record exhaustiveness, but in practice the
@@ -89,6 +90,8 @@ export function TopBar({
       <button type="button" className="topbar-btn" onClick={onRefresh} data-testid="refresh-button">
         <span className={refreshing ? "rail-spin" : undefined}>⟳</span> Refresh
       </button>
+
+      <PairToSync />
 
       <button
         type="button"

--- a/frontend/src/lib/clipboard.ts
+++ b/frontend/src/lib/clipboard.ts
@@ -1,0 +1,28 @@
+// Best-effort clipboard write shared by the pairing affordances
+// (AwaitingAdoption, PairToSync). navigator.clipboard requires a secure
+// context; this console commonly runs over plain http on a trusted LAN, so it
+// falls back to the legacy execCommand path.
+
+export async function copyText(text: string): Promise<boolean> {
+  try {
+    if (navigator.clipboard?.writeText) {
+      await navigator.clipboard.writeText(text);
+      return true;
+    }
+  } catch {
+    // fall through to the legacy path
+  }
+  try {
+    const textarea = document.createElement("textarea");
+    textarea.value = text;
+    textarea.style.position = "fixed";
+    textarea.style.opacity = "0";
+    document.body.appendChild(textarea);
+    textarea.select();
+    const ok = document.execCommand("copy");
+    textarea.remove();
+    return ok;
+  } catch {
+    return false;
+  }
+}

--- a/specs/012-web-adopt-pairing/contracts/cli-web-adopt.md
+++ b/specs/012-web-adopt-pairing/contracts/cli-web-adopt.md
@@ -1,0 +1,63 @@
+# Contract: `remo web adopt` / `remo web push` — 012 delta
+
+The adoption/push **behavior** (registry mirror, host-key scan+verify, key
+authorization, verification pass, `--via` tunnel) is **inherited unchanged from
+011** (see `specs/011-web-adopt/contracts/cli-web-adopt.md`). 012 changes only
+**how the bearer credential is obtained and that nothing is persisted**.
+
+---
+
+## Credential: pairing code, not a static token (FR-018)
+
+Both commands accept the **pairing code** exactly where 011 accepted the token —
+no new CLI concept:
+
+- `--token <code>` option (kept for compatibility; the value is a pairing code),
+- else `$REMO_API_TOKEN`,
+- else a hidden interactive prompt (label updated to **"Pairing code"**).
+
+The code is sent as `Authorization: Bearer <code>` on every setup call, exactly
+as the token was.
+
+## No saved credentials (FR-019)
+
+- The `--save` flag is **removed**; there is no "offer to save credentials" step.
+- `remo web push` no longer has a saved-credentials fast path: it resolves the
+  service URL (arg / `$REMO_API_URL` / prompt) and pairing code (option /
+  `$REMO_API_TOKEN` / prompt) **every time**, the same way `adopt` does.
+- Removed from `core/web_adopt.py`: `SavedCredentials` url/token fields,
+  `save_credentials`, credential-loading, and the `NoSavedCredentialsError`
+  fallback in `push`.
+- **Retained (optional, non-secret)**: a push cache of deployment id +
+  per-instance host-key fingerprints for the "unchanged instance skips
+  re-authorization" optimization — no URL or code is ever stored.
+
+## Dormant-404 handling (FR-020)
+
+When a setup call returns the dormant `404` (the code expired, was rotated by a
+page reopen, or the session ended), the CLI MUST surface an actionable message:
+
+> The pairing code is no longer valid (the service's setup surface is dormant).
+> Reopen the adopt page (or the dashboard's re-sync affordance) to mint a fresh
+> code, then retry.
+
+This replaces 011's "wrong token → 401" and "no token configured → 404 setup
+disabled" messages, which no longer apply (there is no static token).
+
+## Flow (US1 / US4)
+
+```text
+operator (browser, signed in via forward-auth proxy)
+  └─ opens adopt page  → SPA POST /pairing/mint  → live session + code (in ref)
+  └─ clicks "Copy pairing code" → code on clipboard (never displayed)
+operator (workstation)
+  └─ remo web adopt <url>   [paste code at prompt]
+        → GET /setup/identity, PUT /setup/registry, POST /setup/verify
+          (each Bearer <code>; each success touches the sliding TTL)
+        → successful apply ENDS the session → setup surface dormant again
+  └─ browser flips to dashboard
+```
+
+`remo web push` is identical except it is driven from the dashboard's **Pair CLI
+to sync** affordance (FR-017) and applies the registry mirror to an already-
+adopted service.

--- a/specs/012-web-adopt-pairing/contracts/pairing-api.md
+++ b/specs/012-web-adopt-pairing/contracts/pairing-api.md
@@ -1,0 +1,72 @@
+# Contract: Pairing API (`/api/v1/pairing/*`)
+
+**New in 012.** These routes live **outside** the dormant `/api/v1/setup/*`
+router so they are reachable while the setup surface is dormant. They are the
+browser-facing control plane for the pairing lifecycle. Both are `POST` from the
+SPA's own origin and are therefore subject to the existing Origin allowlist
+(R11) — the CLI never calls them.
+
+---
+
+## `POST /api/v1/pairing/mint`
+
+Mint a fresh pairing code, rotating (invalidating) any prior live session
+(FR-003). **Forward-auth gated** (FR-009): the operator-auth provider must
+authenticate the request.
+
+**Request**: no body required. In the forward-auth posture the deployment's
+proxy MUST have injected the trusted identity header (name per
+`REMO_WEB_FORWARD_AUTH_HEADER`); the client never sets it.
+
+**Responses**:
+
+| Status | Body | When |
+|---|---|---|
+| `200` | `{ "expires_in": <int seconds> }` **+ code** — see below | Authenticated; a fresh session was minted (prior invalidated). |
+| `403` | `{"detail": "operator authentication required"}` | Forward auth required and the trusted header is absent/empty (FR-011). No session created. |
+| `403` | `{"detail": "operator authentication not configured"}` | No provider configured (minting disabled, R5). No session created. |
+
+The **code** is returned in the 200 body (field `code`) with `Cache-Control:
+no-store`. It is the only place the code is ever transmitted from the server; it
+is never embedded in the served HTML/JS bundle (FR-016). The SPA holds it in a
+non-rendered ref and copies it to the clipboard on the explicit Copy action
+(FR-015); it never enters the DOM.
+
+**Logging**: the authenticated `subject` and `origin` are logged; the `code` is
+never logged (FR-012/FR-016). A refusal (403) is logged with request context.
+
+## `POST /api/v1/pairing/end`
+
+Best-effort end of the live pairing session for the page-hide beacon
+(FR-004). Called via `navigator.sendBeacon` on `visibilitychange`→`hidden` /
+`pagehide`. **Unauthenticated and idempotent** — it only ever *removes*
+capability.
+
+**Request**: no body (beacon).
+
+**Responses**:
+
+| Status | Body | When |
+|---|---|---|
+| `204` | _(empty)_ | Always — whether or not a session was live. |
+
+The idle TTL remains the authoritative backstop; the service never depends on
+this call for correctness (FR-004).
+
+---
+
+## Operator-auth configuration (mint gating)
+
+| Env | Values | Effect |
+|---|---|---|
+| `REMO_WEB_OPERATOR_AUTH` | `forward` | Mint requires the trusted header. |
+| | `none` | Network-restricted: mint proceeds without a credential; **loudly logged** at startup + flagged weaker in readiness (FR-013). |
+| | _(unset)_ | Minting disabled; mint returns `403 not configured`. `remo web serve` sets `none` for loopback binds (still logged). |
+| `REMO_WEB_FORWARD_AUTH_HEADER` | header name | **Required** when `OPERATOR_AUTH=forward`. No default. Enabling forward auth without it is a **startup fail-fast** (FR-009). |
+| `REMO_WEB_PAIRING_TTL_S` | seconds | Sliding idle TTL, default `900` (15 min, FR-002). |
+
+**Trust boundary (FR-014)**: `ForwardAuthProvider` trusts the identity header
+only because the deployment guarantees the proxy sets/strips it and prevents
+direct client access to the app. This is the standard forward-auth boundary and
+MUST be documented (including the hola-app configuration). The proxy MUST gate
+the **mint** path while passing `/api/v1/setup/*` through (FR-009).

--- a/specs/012-web-adopt-pairing/contracts/setup-api.md
+++ b/specs/012-web-adopt-pairing/contracts/setup-api.md
@@ -1,0 +1,52 @@
+# Contract: Setup API (`/api/v1/setup/*`) — 012 delta
+
+The setup routes' **bodies** (`GET /status`, `GET /identity`, `PUT /registry`,
+`POST /verify`) and their request/response shapes are **inherited unchanged from
+011** (see `specs/011-web-adopt/contracts/setup-api.md`). 012 changes only the
+**authentication/dormancy gate** on the router.
+
+---
+
+## What changes: the router gate
+
+011's `require_setup_token` (static `REMO_WEB_API_TOKEN` bearer) is replaced by
+`require_pairing_code`, backed by the in-memory `PairingSessionManager`:
+
+| Condition | Response | FR |
+|---|---|---|
+| No live pairing session | `404 {"detail": "Not Found"}` — byte-identical to an unknown route | FR-005 |
+| Live session, bearer matches the live code | route handles the request; session is **touched** (sliding TTL reset) | FR-002 |
+| Live session, bearer absent / wrong / from an expired-or-rotated session | `404 {"detail": "Not Found"}` — **never** a distinguishable `401` | FR-006 |
+
+Notes:
+- The comparison against the live code is constant-time (`hmac.compare_digest`).
+- Dormancy is **the default state**: the surface exists only while an operator
+  is on the adopt page / re-sync affordance (a live session). SC-001: with no
+  session live, 100% of setup requests return the dormant `404`.
+- Completing the flow **ends the session** (FR-007): because the CLI runs
+  `status → identity → PUT /registry → POST /verify` on one code, the session is
+  ended by the **`POST /verify`** handler (the terminal authenticated step), not
+  by the `PUT` — ending on the `PUT` would sever the in-flight `verify` call.
+  The surface returns to dormant immediately after the flow (US2 scenario 3, US4
+  scenario 2); a client that skips `verify` falls back to the idle-TTL / page-hide
+  backstop.
+- The presented code is **never logged** (FR-016); an auth failure is logged
+  with route/method context only, exactly as 011 logged its failures minus the
+  credential.
+
+## What does NOT change
+
+- Route paths, methods, request bodies, success/response bodies, the
+  mount-configured `409`, the empty-registry `422`, the atomic two-file apply,
+  and the origin-less exemption for `/api/v1/setup/*` (the CLI has no `Origin`)
+  are all unchanged from 011.
+- Forward auth does **not** apply to these routes (FR-009): the CLI cannot
+  complete an SSO challenge, so `/api/v1/setup/*` is authenticated *solely* by
+  the live pairing code. The deployment's proxy passes the setup path through
+  while gating only the browser-facing `/api/v1/pairing/mint`.
+
+## Removed
+
+- `REMO_WEB_API_TOKEN` and the `WebSettings.api_token` field are removed
+  (FR-021). A value set for the old variable is ignored (inert); it no longer
+  grants any setup access.

--- a/specs/012-web-adopt-pairing/data-model.md
+++ b/specs/012-web-adopt-pairing/data-model.md
@@ -1,0 +1,102 @@
+# Phase 1 Data Model: Ephemeral Device-Pairing Adoption
+
+All entities are **in-memory only** (FR-008) except where noted as inherited-
+unchanged from 011. Nothing here is persisted to disk.
+
+---
+
+## PairingSession (in-memory, `web/pairing.py`)
+
+One live record for a single adoption/push handoff. At most one exists at a time
+(most-recent-wins, FR-003).
+
+| Field | Type | Notes |
+|---|---|---|
+| `code` | `str` | High-entropy bearer, `secrets.token_urlsafe(24)` (R6). Compared with `hmac.compare_digest`. Never logged, never rendered (FR-016). |
+| `identity` | `OperatorIdentity \| None` | The authenticated operator that minted it (FR-012). `None` only in network-restricted posture (anonymous). |
+| `origin` | `Literal["adopt", "resync"]` | Which affordance minted it (adopt page vs dashboard re-sync). Diagnostic only. |
+| `last_activity` | `float` | `time.monotonic()` reading; updated on each successful setup call (`touch()`). Basis for the sliding idle TTL (R9). |
+| `ttl_s` | `float` | Idle interval; `REMO_WEB_PAIRING_TTL_S`, default 900 (FR-002). |
+
+**Derived**: `is_expired(now) -> bool` ≡ `now - last_activity > ttl_s`.
+
+**Lifecycle / state transitions**:
+
+```text
+(none) --mint()--> LIVE
+LIVE   --successful setup call (touch)--> LIVE  (last_activity reset)
+LIVE   --mint() again (rotation)--> LIVE (new code; prior code invalid)   [FR-003]
+LIVE   --idle > ttl_s--> (none)  (lazy expiry on is_live/authenticate)     [FR-002]
+LIVE   --successful adoption/push apply--> (none)  (end)                   [FR-007]
+LIVE   --pagehide sendBeacon /pairing/end--> (none)  (best-effort)         [FR-004]
+LIVE   --process restart--> (none)  (never persisted)                      [FR-008]
+```
+
+**Validation / invariants**:
+- At most one live session (the manager slot). Minting replaces it.
+- An expired/rotated/absent session is indistinguishable to callers: every
+  setup call in those states yields the dormant `404` (FR-005/FR-006).
+- `code` exists only in memory + transiently on the operator's clipboard.
+
+## PairingSessionManager (in-memory singleton, `app.state`)
+
+| Member | Signature | Behavior |
+|---|---|---|
+| `mint` | `(identity, origin) -> str` | Create fresh code, evict prior session (rotation), stamp `last_activity`, return raw code once. Lock-guarded. |
+| `authenticate` | `(presented: str) -> PairingSession \| None` | Constant-time match against the live, non-expired session; `touch()` + return it, else `None`. |
+| `is_live` | `() -> bool` | A non-expired session exists (drives dormancy). Lazily drops an expired one. |
+| `end` | `() -> None` | Drop the live session. Idempotent (completion, beacon, rotation all use it). |
+
+Injected clock: `now: Callable[[], float] = time.monotonic` for deterministic
+TTL tests (R9).
+
+## OperatorIdentity (`web/operator_auth.py`)
+
+| Field | Type | Notes |
+|---|---|---|
+| `subject` | `str` | Operator identifier from the auth provider (the forward-auth header value, or `"network-restricted"` for the anonymous posture). Recorded on the session + in audit logs (FR-012). |
+| `provider` | `str` | `"forward"` \| `"network-restricted"` (future: `"oidc"`). |
+
+## OperatorAuthProvider (seam, `web/operator_auth.py`)
+
+`Protocol` with one method — the pluggable gate (FR-010).
+
+```text
+class OperatorAuthProvider(Protocol):
+    def authenticate(self, request: Request) -> OperatorIdentity | None: ...
+```
+
+| Implementation | Config | authenticate() |
+|---|---|---|
+| `ForwardAuthProvider(header_name)` | `REMO_WEB_OPERATOR_AUTH=forward` + `REMO_WEB_FORWARD_AUTH_HEADER=<name>` (required; fail-fast if missing, FR-009) | Returns `OperatorIdentity(subject=<header value>, "forward")` when the trusted header is present & non-empty; else `None` (mint refused, FR-011). |
+| `NetworkRestrictedProvider` | `REMO_WEB_OPERATOR_AUTH=none` (loud opt-in, FR-013) | Always returns `OperatorIdentity("network-restricted", "network-restricted")`. |
+| _unconfigured_ | env unset | No provider → mint refused with actionable diagnostic; readiness flags "operator auth not configured" (R5). |
+
+_Future (Out of Scope): `OidcVerifierProvider` (JWKS + iss/aud/exp) slots in here
+with no change to `PairingSession*`._
+
+## WebSettings — added / removed fields (`web/config.py`)
+
+| Change | Field | Notes |
+|---|---|---|
+| **removed** | `api_token` | The static `REMO_WEB_API_TOKEN` gate is gone (FR-021). A set value is ignored (inert), with a one-line "now ignored" info log at startup (R13). |
+| added | `pairing_ttl_s: float` | `REMO_WEB_PAIRING_TTL_S`, default `900.0` (FR-002). |
+| added | `operator_auth: str` | `REMO_WEB_OPERATOR_AUTH` — `"forward"` \| `"none"` \| `""` (unset = minting disabled). |
+| added | `forward_auth_header: str` | `REMO_WEB_FORWARD_AUTH_HEADER` — no default; required when `operator_auth="forward"`. |
+
+## Workstation-side: saved file (`core/web_adopt.py`) — reduced
+
+| Change | Item | Notes |
+|---|---|---|
+| **removed** | `SavedCredentials.url`, `.token` | No durable credential persisted (FR-019). |
+| removed | `save_credentials`, `load_saved_credentials` (credential path), `--save` flag, `NoSavedCredentialsError` fallback | Adopt/push obtain a fresh code every time (FR-018/FR-019). |
+| retained (optional) | non-secret push cache | Deployment id + per-instance fingerprints only (no url/token) for the push skip-optimization; keyed by the deployment id read from `/status` at push time (R10). |
+
+## Inherited unchanged from 011 (referenced, not modified)
+
+- **Service identity** (`web-identity/id_ed25519{,.pub}`, `known_hosts`,
+  `state.json`) — persists across restarts (011 FR-002); this feature does not
+  touch it.
+- **AdoptionPayload** (`PUT /setup/registry` body: `version`, `registry[]`,
+  `host_keys{}`) — wire shape and atomic two-file apply are unchanged.
+- **KnownHost** registry entries and the colon-delimited registry file.

--- a/specs/012-web-adopt-pairing/plan.md
+++ b/specs/012-web-adopt-pairing/plan.md
@@ -1,0 +1,167 @@
+# Implementation Plan: Ephemeral Device-Pairing Adoption (Forward-Auth Gated)
+
+**Branch**: `012-web-adopt-pairing` | **Date**: 2026-07-19 | **Spec**: [spec.md](spec.md)
+
+**Input**: Feature specification from `/specs/012-web-adopt-pairing/spec.md`
+
+## Summary
+
+Replace 011's static `REMO_WEB_API_TOKEN` gate on `/api/v1/setup/*` with an
+**ephemeral device-pairing** model. The awaiting-adoption page (and the
+dashboard's re-sync affordance) mints a short-lived, in-memory **pairing code**;
+the operator copies it to the clipboard and pastes it into `remo web adopt` /
+`remo web push`, where it authorizes exactly one adoption/push handoff. The
+setup surface is **dormant** (`404`, byte-identical to an unknown route)
+whenever no pairing session is live, and a pairing session exists only while an
+operator is actively on the page. Minting is gated by **operator
+authentication**: v1 reads a trusted, proxy-injected identity header (**forward
+auth**) behind a pluggable provider seam that a future in-app OIDC verifier can
+slot into without touching the pairing core. Nothing durable is persisted — no
+static service credential anywhere — so every first adoption and every later
+re-sync obtains a fresh code from the page. The registry mirror, host-key
+verification, key authorization, and verification pass are all inherited
+unchanged from 011; this feature changes only how the setup surface is
+authorized and when it exists.
+
+## Technical Context
+
+**Language/Version**: Python 3.11+ (backend + CLI), TypeScript 5 / React 18 (frontend)
+
+**Primary Dependencies**: FastAPI/Uvicorn + pydantic v2 (`web` extra, service
+side only), stdlib `secrets` (code generation) and `time.monotonic` (TTL) —
+**no new runtime dependency**; stdlib `urllib.request` for the CLI's HTTP calls
+(unchanged from 011); Vite + ghostty-web (frontend, unchanged)
+
+**Storage**: **None for pairing state** — pairing sessions/codes live only in
+process memory and are dropped on restart (FR-008). The service identity
+keypair and service-managed `known_hosts` under `web-identity/` persist exactly
+as in 011. Workstation side: the saved *credentials* file
+(`~/.config/remo/web-service.json`) loses its URL/token fields (FR-019); an
+optional non-secret push cache (deployment id + per-instance fingerprints) may
+remain for the push skip-optimization only.
+
+**Testing**: pytest (unit: pairing-session lifecycle with a fake monotonic
+clock, dormancy `404` semantics via starlette TestClient, forward-auth
+gating/fail-fast, mint rotation + idle expiry + end-on-adoption; adopt/push
+orchestration with mocked HTTP; integration: adopt against a live `remo web
+serve` behind a stub forward-auth header), frontend `npm run lint`, mypy + ruff
+
+**Target Platform**: Linux container (amd64/arm64) for the service;
+Linux/macOS workstation for the CLI
+
+**Project Type**: Existing three-layer CLI (`cli/` → `providers|web/` →
+`core/`) + FastAPI service + React SPA — this feature edits the service auth
+layer, the SPA adopt/dashboard pages, the CLI adopt/push commands, and docs
+
+**Performance Goals**: Mint is O(1) in-memory (< 5 ms); dormancy check adds a
+single lock-guarded lookup to each setup call; adoption end-to-end timing is
+unchanged from 011 (the sliding TTL default of 15 min covers the interactive
+fingerprint pause, SC-003)
+
+**Constraints**: Dormant surface indistinguishable from absent (same `404`
+body, never a `401`, FR-006); code never logged, never in the DOM, never in the
+served bundle (FR-016/SC-006); TTL measured against a monotonic source so a
+wall-clock change cannot extend/expire a session (Edge Cases); forward-auth
+header trusted only under the documented proxy trust boundary (FR-014);
+network-restricted posture never entered silently (FR-013); `remo` CLI without
+the `web` extra must still import (NFR-008 lazy-import discipline preserved)
+
+**Scale/Scope**: Home-lab scale — one operator drives one adoption/push at a
+time; at most one live pairing session (most-recent-wins rotation, FR-003)
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
+
+| Principle | Assessment |
+|-----------|------------|
+| I. Defensive Variable Access (Ansible) | PASS (N/A) — no Ansible playbook or role changes in this feature. |
+| II. Test All Conditional Paths | PASS — dormant/live/expired/rotated setup states, mint refused/allowed under forward-auth vs network-restricted, and fail-fast-on-missing-header are all enumerated in spec acceptance scenarios; plan requires a unit test per branch (fake monotonic clock for the TTL branches). |
+| III. Idempotent by Default | PASS — mint is rotation-on-open (most-recent-wins, no accumulation); the underlying registry apply / key authorization remain the idempotent 011 operations; ending a session is safe to call repeatedly (beacon + completion + expiry all converge to dormant). |
+| IV. Fail Fast with Clear Messages | PASS — forward auth enabled without a header name is a startup fail-fast (FR-009); minting with no operator-auth provider configured is refused with an actionable diagnostic; the CLI maps the dormant `404` to "reopen the page for a fresh code" (FR-020); network-restricted posture is loudly surfaced (FR-013). |
+| V. Documentation Reflects Reality | PASS — FR-021/FR-022 make the breaking-change note, compose example, and hola forward-auth trust-boundary docs part of the feature. |
+
+**Post-Phase-1 re-check**: PASS — design artifacts introduce no new violations;
+no Complexity Tracking entries required.
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/012-web-adopt-pairing/
+├── plan.md              # This file
+├── research.md          # Phase 0 output
+├── data-model.md        # Phase 1 output
+├── quickstart.md        # Phase 1 output
+├── contracts/
+│   ├── pairing-api.md   # NEW: forward-auth-gated mint/end endpoints
+│   ├── setup-api.md     # DELTA: dormancy now driven by live pairing session
+│   └── cli-web-adopt.md # DELTA: code (not token); no saved credentials
+└── tasks.md             # Phase 2 output (/speckit-tasks — NOT created by /speckit-plan)
+```
+
+### Source Code (repository root)
+
+```text
+src/remo_cli/
+├── cli/
+│   └── web.py                    # adopt/push: "token" prompt → "pairing code";
+│                                 #   drop --save + saved-credential fallback (FR-018/019)
+├── core/
+│   └── web_adopt.py              # remove SavedCredentials/save/load credential
+│                                 #   fields (keep non-secret push cache only);
+│                                 #   409/404 mapping → "reopen page" guidance (FR-020)
+└── web/
+    ├── pairing.py                # NEW: PairingSessionManager (in-memory, one live
+    │                             #   session, monotonic sliding TTL, rotate/touch/end)
+    ├── operator_auth.py          # NEW: provider seam — OperatorAuthProvider protocol,
+    │                             #   ForwardAuthProvider(header), NetworkRestricted;
+    │                             #   fail-fast construction from config
+    ├── config.py                 # remove api_token; add pairing_ttl_s,
+    │                             #   operator_auth mode + forward_auth_header
+    ├── app.py                    # mount pairing router; readiness/CSP unchanged;
+    │                             #   construct auth provider (fail-fast) at startup
+    ├── health.py                 # readiness reports operator-auth posture (FR-013)
+    ├── check.py                  # `remo web check` reports posture; no token check
+    ├── logging_config.py         # code redaction pattern (defense-in-depth, FR-016)
+    └── api/
+        ├── pairing.py            # NEW: POST /api/v1/pairing/mint (forward-auth
+        │                         #   gated), POST /api/v1/pairing/end (beacon)
+        └── setup.py              # require_setup_token → require_pairing_code:
+                                  #   dormant 404 unless live session; touch on success
+
+frontend/src/
+├── api/client.ts                 # + mintPairingCode()/endPairing(); no token concept
+├── components/
+│   ├── AwaitingAdoption.tsx      # mint-on-open + "Copy pairing code" (value never
+│   │                             #   rendered); pagehide beacon (FR-003/004/015/016)
+│   └── (dashboard re-sync)       # "Pair CLI to sync" affordance (FR-017)
+└── state/                        # pairing lifecycle wiring for the two pages
+
+docker/
+└── compose.example.yml           # drop REMO_WEB_API_TOKEN; forward-auth front door,
+                                  #   mint-gated / setup-passthrough split (FR-022)
+
+tests/
+├── unit/web/                     # pairing lifecycle (fake clock), dormancy 404,
+│                                 #   forward-auth gate + fail-fast, readiness posture
+├── unit/core/                    # web_adopt: credential removal, 404→reopen mapping
+└── integration/                  # adopt/push E2E behind a stub forward-auth header
+
+docs/
+└── web-session-interface.md      # breaking-change note (token removed), pairing flow,
+                                  #   forward-auth trust boundary + hola config (FR-014/021/022)
+```
+
+**Structure Decision**: Extend the existing three-layer layout in place. The
+pairing lifecycle and the operator-auth provider seam get their own service
+modules (`web/pairing.py`, `web/operator_auth.py`) so the setup router shrinks
+to a thin dormancy gate and the mint path is a small new router
+(`web/api/pairing.py`). The workstation side stays in `core/web_adopt.py` (no
+Click, stdlib HTTP only) so `cli/web.py` remains a thin Click layer and the
+no-web-extra import path is unaffected (NFR-008).
+
+## Complexity Tracking
+
+No constitution violations — table not required.

--- a/specs/012-web-adopt-pairing/quickstart.md
+++ b/specs/012-web-adopt-pairing/quickstart.md
@@ -1,0 +1,132 @@
+# Quickstart: Ephemeral Device-Pairing Adoption
+
+Runnable validation scenarios proving the pairing model end-to-end. These map to
+the spec's Success Criteria (SC-00x) and the contracts in `contracts/`. Details
+live in `data-model.md` / `contracts/` — this file is the run guide.
+
+## Prerequisites
+
+```bash
+uv sync --extra web            # FastAPI/Uvicorn service side
+cd frontend && npm ci && npm run build && cd ..   # SPA (served same-origin)
+```
+
+- A workstation `remo` CLI with ≥2 bootstrapped, reachable instances in the
+  registry (for the full adopt path).
+- For forward-auth scenarios: any way to inject a header (curl `-H`, or a stub
+  proxy). No real IdP is required to validate the gate.
+
+## Scenario A — Setup surface is dormant at rest (SC-001, US2)
+
+```bash
+# Start unconfigured, network-restricted posture (loopback dev):
+REMO_WEB_OPERATOR_AUTH=none uv run remo web serve &     # loudly logs weaker posture
+
+# With nobody on the adopt page (no session minted yet):
+curl -s -o /dev/null -w '%{http_code}\n' http://127.0.0.1:8080/api/v1/setup/status
+```
+
+**Expected**: `404`. Every `/api/v1/setup/*` route returns `404 {"detail":"Not
+Found"}`, byte-identical to an unknown route — with or without a bearer.
+
+## Scenario B — Mint, adopt, auto-dormant (SC-002, SC-005, SC-007, US1)
+
+1. Open `http://127.0.0.1:8080/` in a browser → the awaiting-adoption page.
+   On mount the SPA mints a session (rotation-on-open); the code lives only in a
+   ref. Click **Copy pairing code** — the code is on your clipboard, never shown.
+2. On the workstation:
+   ```bash
+   remo web adopt http://127.0.0.1:8080     # paste the code at "Pairing code:"
+   ```
+   **Expected**: adoption completes exactly as in 011 (identity → registry →
+   verify), the browser flips to the dashboard, and no static token was
+   configured anywhere (SC-002).
+3. Re-probe the setup surface:
+   ```bash
+   curl -s -o /dev/null -w '%{http_code}\n' http://127.0.0.1:8080/api/v1/setup/status
+   ```
+   **Expected**: `404` — the successful apply ended the session (FR-007).
+4. **Rotation (SC-005)**: reopen/reload the adopt page, copy a code, then reload
+   again and copy a second code. The first code no longer authenticates
+   (`404`); only the most-recent code works.
+
+## Scenario C — Sliding TTL survives the fingerprint pause (SC-003, US1 scenario 2)
+
+Adopt a service with an unverified instance so the CLI pauses on the interactive
+host-key fingerprint prompt. With the default 900 s idle TTL, leave the prompt
+for several minutes while the CLI continues making setup calls, then confirm.
+
+**Expected**: the code stays valid across the pause (each successful setup call
+touches the sliding window); after activity stops, the session expires within
+the idle window and further calls return the dormant `404`. For a fast test, run
+the service with `REMO_WEB_PAIRING_TTL_S=5` and assert a setup call succeeds
+before 5 s of idle and `404`s after.
+
+## Scenario D — Forward auth gates minting (SC-004, US3)
+
+```bash
+# Forward auth required; trust the header X-Forwarded-User:
+REMO_WEB_OPERATOR_AUTH=forward REMO_WEB_FORWARD_AUTH_HEADER=X-Forwarded-User \
+  uv run remo web serve &
+
+# Mint WITHOUT the trusted header → refused, no session created:
+curl -s -o /dev/null -w '%{http_code}\n' -X POST http://127.0.0.1:8080/api/v1/pairing/mint
+# Expected: 403
+
+# Mint WITH the proxy-injected header → succeeds:
+curl -s -X POST -H 'X-Forwarded-User: alice' http://127.0.0.1:8080/api/v1/pairing/mint
+# Expected: 200 {"expires_in":900,"code":"..."} and the audit log names "alice", never the code.
+```
+
+**Fail-fast check (FR-009)**:
+```bash
+REMO_WEB_OPERATOR_AUTH=forward uv run remo web serve   # no header configured
+```
+**Expected**: startup **fails fast** with a clear "forward auth enabled but
+`REMO_WEB_FORWARD_AUTH_HEADER` is not set" error — the service never trusts an
+unnamed header.
+
+## Scenario E — Re-sync uses the same flow (SC-007, US4)
+
+On the adopted service, open the dashboard's **Pair CLI to sync** affordance
+(mints a fresh code, same gate/TTL/rotation), copy the code, then:
+
+```bash
+remo web push http://127.0.0.1:8080      # paste the code
+```
+
+**Expected**: the service registry mirrors the local change; before and after
+the affordance is open, `/api/v1/setup/*` is dormant (`404`). No credentials
+were saved between adopt and push (FR-019).
+
+## Scenario F — Code never leaks (SC-006)
+
+- `grep -ri "<the copied code>" server-logs` → **zero** matches.
+- View source / the built JS bundle → the code string is **absent** (it is
+  fetched at runtime on page open, never embedded).
+- Inspect the DOM while on the adopt page → the code is **not present** (only a
+  Copy button); it exists only transiently on the clipboard after an explicit
+  copy.
+
+## Scenario G — Health/readiness unchanged (SC-008)
+
+```bash
+curl -s http://127.0.0.1:8080/api/v1/ready     # dormant, live-session, and post-adoption
+```
+
+**Expected**: `/api/v1/health` and `/api/v1/ready` behavior is byte-unchanged
+from 011 across all three states; an unconfigured service still reports the
+"awaiting adoption" readiness. The operator-auth posture appears only as
+additive diagnostic detail (forward / network-restricted / unconfigured), not as
+a change to the `ready` status value.
+
+## Automated coverage (pytest)
+
+- `tests/unit/web/` — pairing lifecycle with an injected fake monotonic clock
+  (mint/rotate/touch/expire/end), dormancy `404` on every setup route, mint
+  forward-auth allow/refuse, `forward`-without-header startup fail-fast,
+  network-restricted loud opt-in + readiness posture.
+- `tests/unit/core/` — `web_adopt` credential removal, dormant-`404` → "reopen
+  page" mapping, push resolves URL+code every time.
+- `tests/integration/` — adopt + push E2E against a live `remo web serve` behind
+  a stub forward-auth header.

--- a/specs/012-web-adopt-pairing/research.md
+++ b/specs/012-web-adopt-pairing/research.md
@@ -1,0 +1,287 @@
+# Phase 0 Research: Ephemeral Device-Pairing Adoption
+
+All Technical Context unknowns are resolved below. Each decision is framed as
+Decision / Rationale / Alternatives so downstream tasks have a single source of
+truth. The feature adds **no new runtime dependency** — everything is stdlib
+(`secrets`, `time.monotonic`, a `threading.Lock`) plus the existing
+FastAPI/React stack.
+
+---
+
+## R1 — Pairing session store & lifecycle
+
+**Decision**: A single in-memory `PairingSessionManager` held on `app.state`
+(constructed in `create_app`). It holds **at most one** live `PairingSession`
+(most-recent-wins, FR-003). A `threading.Lock` guards all mutations because
+FastAPI runs the sync setup/mint routes in a threadpool (concurrent workers).
+The manager exposes:
+
+- `mint(identity, origin) -> code` — generate a fresh code, replace/evict any
+  prior session (rotation), stamp `last_activity = monotonic()`, return the raw
+  code once.
+- `authenticate(presented_code) -> PairingSession | None` — constant-time
+  compare against the live session's code; return the session (and `touch()`
+  it) on match, else `None`. Expired/rotated/absent all yield `None`.
+- `is_live() -> bool` — a non-expired session exists (drives dormancy).
+- `end()` — drop the live session (idempotent; used by completion + beacon).
+
+**Rationale**: One live session matches the spec's "one operator drives one
+adoption at a time" assumption and makes rotation trivial (replace the slot).
+In-memory-only satisfies FR-008 (restart drops sessions) with zero persistence
+code. A lock is required for correctness under uvicorn's threadpool.
+
+**Alternatives considered**: (a) A dict of concurrent sessions — rejected,
+multi-operator concurrency is explicitly out of scope and it complicates
+dormancy. (b) `asyncio`-native store with an async lock — rejected, the setup
+routes are deliberately sync (they do blocking file I/O and the verify
+round-trips), so a threading lock is the honest primitive.
+
+## R2 — Setup dormancy: replacing the static-token gate
+
+**Decision**: Rename/replace `require_setup_token` with `require_pairing_code`
+(same router-level `Depends`). Logic: read the manager from `request.app.state`;
+if `not manager.is_live()` → `raise HTTPException(404, "Not Found")`. Else read
+the bearer, `authenticate()` it; on `None` → the **same** `404` (never `401`);
+on success the dependency returns and the session has been touched. Remove the
+`api_token` config field and every reference to it.
+
+**Rationale**: FR-005/FR-006 — the dormant surface must be byte-identical to an
+absent route whether the code is missing, wrong, expired, or rotated. Reusing
+the router-level dependency keeps all four setup routes covered by construction
+and preserves 011's atomic-apply bodies untouched. Touch-on-success (not
+touch-on-arrival) implements the sliding idle TTL against real progress
+(FR-002).
+
+**Alternatives considered**: Returning `401` for a wrong-but-present code —
+rejected, it reveals a session exists (mirrors 011 FR-021's fail-closed
+posture). Middleware-level gate — rejected, the per-route dependency is already
+the established pattern and keeps the health/SPA routes untouched.
+
+## R3 — Mint endpoint topology & the always-on requirement
+
+**Decision**: A new router `web/api/pairing.py` mounted at `/api/v1/pairing`,
+**outside** the dormant setup router so it is reachable while the setup surface
+is dormant:
+
+- `POST /api/v1/pairing/mint` — forward-auth gated (R4). Rotates + creates the
+  live session, returns `{ "expires_in": <seconds> }` and the **code**. The
+  code is returned only in this response body with `Cache-Control: no-store`
+  (FR-016); it is never embedded in the served HTML/JS bundle.
+- `POST /api/v1/pairing/end` — best-effort session end for the page-hide beacon
+  (R8). Unauthenticated and idempotent (it only ever *removes* capability);
+  returns `204` regardless.
+
+**Rationale**: The setup surface must be dormant at rest, but the browser needs
+a live route to *create* a session — so the mint path cannot live under the
+dormant `/setup` prefix. A dedicated `/pairing` router is the clean seam and
+keeps the forward-auth dependency off the setup routes (FR-009: the CLI-facing
+setup routes must not require forward auth).
+
+**Alternatives considered**: Minting via `GET /setup/status` side effects —
+rejected, conflates dormancy with creation and would make a probe mint a
+session. A single toggle endpoint — rejected, mint and end have different auth
+(mint gated, end open) and different idempotency.
+
+## R4 — Operator-auth provider seam & forward-auth gate
+
+**Decision**: `web/operator_auth.py` defines a small seam:
+
+```text
+class OperatorIdentity: subject: str, provider: str
+class OperatorAuthProvider(Protocol): authenticate(request) -> OperatorIdentity | None
+class ForwardAuthProvider:      # reads a configured trusted header
+class NetworkRestrictedProvider: # returns a fixed anonymous identity (opt-in)
+```
+
+The mint route depends on the configured provider; `authenticate()` returning
+`None` → mint refused (`403`, logged with request context, no session created,
+FR-011). `ForwardAuthProvider` reads exactly the configured header name and
+treats its presence as proof (the proxy is trusted to set/strip it, FR-014).
+Selection is explicit config (R5). The seam is where a future
+`OidcVerifierProvider` (JWKS + iss/aud/exp) slots in without touching pairing
+(FR-010).
+
+**Rationale**: FR-009/FR-010 — v1 forward-auth as a thin header-consumer, with
+a documented seam for OIDC-in-app later. Keeping the provider a `Protocol` with
+one method makes the mint route provider-agnostic and the future OIDC addition a
+pure add (no changes to pairing/dormancy).
+
+**Alternatives considered**: Baking forward-auth reading directly into the mint
+route — rejected, it would force a rewrite when OIDC lands and blurs the
+deferred-enhancement boundary the spec is explicit about.
+
+## R5 — Operator-auth configuration & fail-fast
+
+**Decision**: Two new `REMO_WEB_` settings resolved in `WebSettings`:
+
+- `REMO_WEB_OPERATOR_AUTH` — `"forward"` | `"none"` (network-restricted).
+  There is **no silent default that permits minting**: if unset, minting is
+  refused with an actionable diagnostic and readiness flags "operator auth not
+  configured" (fail-closed, never silently insecure).
+- `REMO_WEB_FORWARD_AUTH_HEADER` — the trusted header name (e.g.
+  `X-Forwarded-User`, `Remote-User`). **No baked-in default.**
+
+Construction is fail-fast at startup (FR-009): `operator_auth="forward"` with an
+empty header name raises a startup error; `operator_auth="none"` logs a loud
+warning and sets a readiness "weaker posture" flag (FR-013). `remo web serve`
+convenience: when binding a loopback interface it defaults
+`REMO_WEB_OPERATOR_AUTH=none` for the child process (still loudly logged) so
+local single-machine runs work without a proxy while the *service contract*
+still requires the explicit opt-in for any non-loopback bind.
+
+**Rationale**: Threads FR-009 (explicit header, fail-fast) and FR-013 (network-
+restricted is an explicit, loud, non-silent opt-in) while keeping `remo web
+serve` usable on a laptop. Fail-closed-when-unconfigured means a real deployment
+that forgets to configure auth cannot mint at all rather than minting
+unguarded.
+
+**Alternatives considered**: Defaulting to network-restricted globally —
+rejected, that is exactly the silent-insecurity FR-013 forbids. Defaulting the
+header name to `X-Forwarded-User` — rejected by clarification (proxies differ;
+a wrong assumed name trusts a header the proxy does not strip).
+
+## R6 — Pairing-code entropy & format
+
+**Decision**: `secrets.token_urlsafe(24)` — 24 random bytes → ~192 bits,
+~32 URL-safe characters. Compared with `hmac.compare_digest` (constant time).
+
+**Rationale**: Delivery is clipboard copy (FR-015), never hand-typed, so length
+has no UX cost and we favor generous entropy against online guessing (further
+bounded by dormancy + rotation + 15-min TTL). `token_urlsafe` is stdlib,
+URL/clipboard-safe, and needs no alphabet bookkeeping.
+
+**Alternatives considered**: A short human-typable numeric code (streaming-TV
+style) — rejected for v1 because there is no display and no typing; a long
+opaque code is strictly safer. Revisit only if QR/short-code cross-device
+pairing lands (Out of Scope).
+
+## R7 — SPA: signaling "on the adopt page" & mint trigger (FR-003 ↔ FR-016)
+
+**Decision**: On mount of the awaiting-adoption page (and the dashboard re-sync
+affordance), the SPA `POST`s `/pairing/mint` **once** — this is the "opening the
+page mints + rotates" action (FR-003). The response code is stored only in a
+non-rendered React `ref`, never in state that reaches the DOM. The **Copy
+pairing code** button copies from that ref to the clipboard and clears the
+transient string; the value is never inserted into the DOM or logged
+(FR-015/FR-016). The bundle contains no code — it is fetched at runtime on page
+open, which is the operator's explicit act of opening the pairing page.
+
+**Rationale**: Reconciles FR-003 (open = mint + rotate) with FR-016 (code
+fetched only on explicit action, never embedded in the served bundle): opening
+the pairing page *is* the explicit mint action, the fetch is at runtime, and the
+value never renders. Rotation-on-open falls out for free — remounting/reopening
+re-mints and the prior code stops authenticating.
+
+**Alternatives considered**: Mint only on Copy click (no mount mint) — rejected,
+it weakens FR-003 rotation-on-open (a stale session from a prior visit could
+linger until TTL). Rendering the code behind a reveal/eyeball — rejected by the
+user (copy-only, never displayed).
+
+## R8 — Best-effort page-hide invalidation
+
+**Decision**: On `visibilitychange`→`hidden` and `pagehide`, the SPA calls
+`navigator.sendBeacon('/api/v1/pairing/end')`. The server ends the live session
+best-effort. The monotonic idle TTL is the authoritative backstop (FR-004): the
+server never depends on the beacon for correctness.
+
+**Rationale**: FR-004 — hidden/unloaded pages should promptly drop the surface,
+but browsers do not guarantee beacon delivery, so TTL remains the source of
+truth. `sendBeacon` is the standard fire-and-forget primitive that survives
+unload.
+
+**Alternatives considered**: A WebSocket heartbeat driving liveness — rejected
+as over-engineered for a single short-lived handoff; the sliding TTL already
+bounds abandonment.
+
+## R9 — Monotonic TTL & clock safety
+
+**Decision**: `PairingSession.last_activity` is a `time.monotonic()` reading;
+expiry is `monotonic() - last_activity > ttl_s`. `ttl_s` from
+`REMO_WEB_PAIRING_TTL_S` (default **900** = 15 min, FR-002). Tests inject a fake
+monotonic callable so TTL branches are deterministic (no `sleep`).
+
+**Rationale**: Edge Cases — a wall-clock change (NTP step, DST) must not extend
+or prematurely expire a session. `monotonic()` is immune to wall-clock jumps.
+Injecting the clock keeps Constitution II (test all conditional paths) cheap.
+
+**Alternatives considered**: `datetime.now()` deltas — rejected (clock-jump
+unsafe). A background reaper task — unnecessary; lazy expiry on `is_live()` /
+`authenticate()` is sufficient and simpler.
+
+## R10 — CLI changes: pairing code in, saved credentials out
+
+**Decision**: In `cli/web.py`, `adopt`/`push` rename the credential prompt from
+"API token" to "pairing code" (still accepted via option, `$REMO_API_TOKEN` for
+back-compat, or a hidden prompt — FR-018) and send it as the bearer unchanged.
+Remove the `--save` flag, the saved-credentials fallback in `push`, and the
+"offer to save" path. `push` now resolves URL + code the same way `adopt` does
+(arg/env/prompt) every time (FR-019). In `core/web_adopt.py`, delete
+`SavedCredentials`, `save_credentials`, `load_saved_credentials`,
+`credentials_path`'s token/url usage, and `NoSavedCredentialsError`; **retain**
+an optional non-secret push cache (deployment id + per-instance fingerprints
+only, no url/token) so the push skip-optimization survives, keyed by the
+deployment id fetched from `/status` at push time. Map the dormant `404` from
+setup calls to an actionable "reopen the adopt page (or re-sync affordance) for
+a fresh code and retry" message (FR-020).
+
+**Rationale**: FR-018/FR-019 — no new CLI concept, and nothing durable to save
+because codes are ephemeral. Keeping only the non-secret fingerprint cache
+preserves the 011 push UX (unchanged instances skip re-authorization) without
+persisting any credential.
+
+**Alternatives considered**: Dropping the push cache entirely — rejected, it
+would re-authorize every instance on every push (a UX regression) for no
+security benefit, since fingerprints are not secrets. Keeping saved URL/token —
+rejected, directly violates FR-019.
+
+## R11 — Origin allowlist interaction
+
+**Decision**: The `/pairing/mint` and `/pairing/end` routes are browser-facing
+and carry an `Origin`, so they stay **subject to** the existing Origin
+allowlist middleware (state-changing `POST` from the SPA's own origin). The
+011 origin-less exemption for `/api/v1/setup/*` (the CLI has no Origin) is
+unchanged. No middleware edit is required — the exemption is path-scoped to
+`/setup` and the pairing routes are correctly *not* exempt.
+
+**Rationale**: Mint is only ever called by the SPA (same-origin), so it should
+be held to the browser-CSRF Origin check; the CLI never calls mint. This keeps
+the CSRF surface tight without touching the setup exemption the CLI relies on.
+
+**Alternatives considered**: Exempting pairing routes too — rejected, they are
+browser-only and exempting them would drop a real CSRF defense.
+
+## R12 — Readiness / diagnostics posture surfacing (FR-013)
+
+**Decision**: `GET /api/v1/ready` and `remo web check` report the operator-auth
+posture: `forward` (with header name echoed, not its value), `network-restricted`
+(flagged as the weaker mode), or `unconfigured` (minting disabled). The
+"unconfigured / awaiting adoption" readiness *status* and the health/ready
+*behavior* are byte-unchanged from 011 across dormant/live/post-adoption states
+(SC-008) — the posture is additive diagnostic detail, not a status change.
+
+**Rationale**: FR-013 requires the weaker posture to be surfaced in
+readiness/diagnostics and at startup; SC-008 requires health/ready behavior to
+stay byte-identical. Additive detail in the `checks`/diagnostics payload
+satisfies both.
+
+**Alternatives considered**: Changing the `ready` status value when
+network-restricted — rejected, it would break SC-008's byte-unchanged
+guarantee and the SPA's `unconfigured` gate.
+
+## R13 — Removing `REMO_WEB_API_TOKEN` (breaking change)
+
+**Decision**: Delete the `api_token` field from `WebSettings` and every
+reference (`setup.py`, tests, docs, compose). A value set for the old env var is
+simply ignored (no gate consults it). Document the removal as a breaking change
+from 011 with the pairing flow as the replacement (FR-021), and rewrite the
+compose example + hola docs to the forward-auth front door with the
+mint-gated / setup-passthrough split (FR-022).
+
+**Rationale**: FR-021/FR-022 — the static token is deliberately removed with no
+long-lived replacement. Silently ignoring a stale env var (rather than erroring)
+avoids breaking a container that still has it set in its environment while making
+it inert.
+
+**Alternatives considered**: Fail-fast if `REMO_WEB_API_TOKEN` is still set —
+rejected as hostile to upgraders; a redacted "this variable is now ignored"
+info log at startup is the friendlier signal and is enough.

--- a/specs/012-web-adopt-pairing/spec.md
+++ b/specs/012-web-adopt-pairing/spec.md
@@ -1,4 +1,4 @@
-# Feature Specification: Ephemeral Device-Pairing Adoption (Operator-Auth Gated)
+# Feature Specification: Ephemeral Device-Pairing Adoption (Forward-Auth Gated)
 
 **Feature Branch**: `012-web-adopt-pairing`
 
@@ -11,8 +11,11 @@ time, the awaiting-adoption web page mints a short-lived ephemeral pairing code
 (streaming-service QR sign-on model). The setup API is dormant until an operator
 browses to the adopt page and a pairing session is live. Future re-syncs use the
 same flow. Access to the page — and thus the ability to mint a code — is gated by
-operator authentication (forward auth OR OIDC — the app platform supports both),
-so the service positively knows the operator is authenticated."
+operator authentication so the service positively knows the operator is logged
+in. v1 implements that gate with forward auth (the app platform terminates SSO
+and injects a trusted identity header), keeping remo-web a thin header-consumer;
+OIDC verification inside remo-web is a deferred enhancement behind the same
+provider seam."
 
 ## Overview
 
@@ -38,16 +41,16 @@ not be:
    does not exist at rest.
 2. **Minting a pairing code is gated by operator authentication.** The service
    only mints a code for a request that carries proof the operator is
-   authenticated. Two interchangeable providers are supported, both offered by
-   the app platform:
-   - **Forward auth** — a trusted, proxy-injected identity header (Traefik
-     ForwardAuth / oauth2-proxy / Authelia / a hola app's SSO). Simplest;
-     trust rests on the proxy being the only ingress.
-   - **OIDC** — a token minted by the identity provider and presented to the
-     service, which the service **cryptographically verifies** (signature via
-     the IdP's JWKS, plus issuer/audience/expiry). Strongest, because trust
-     does not depend on a network boundary — a spoofed header without a
-     validly-signed token is rejected. Recommended where available.
+   authenticated. **v1 implements this with forward auth**: the app platform
+   (Traefik ForwardAuth / oauth2-proxy / Authelia / a hola app's SSO) terminates
+   sign-on and injects a trusted identity header; remo-web reads that header and
+   mints a code only when it is present. This keeps remo-web a thin
+   header-consumer with no new dependency and no runtime coupling to an identity
+   provider. The gate is structured as a pluggable **provider seam** so a future
+   in-app **OIDC** verifier (validate a signed token via JWKS +
+   issuer/audience/expiry — stronger, boundary-independent) can be added without
+   touching the pairing core; OIDC-in-app is deferred (see Out of Scope) because
+   it requires remo-web to implement and maintain token verification itself.
    Either way the service has positive proof the operator is logged in — not
    merely that they can reach the page.
 
@@ -77,12 +80,14 @@ Scope) — clipboard copy of the code is the v1 delivery mechanism.
   operator, rather than anyone who can reach the service? → A: Operator
   authentication, required to mint. Reachability alone is never sufficient in the
   gated posture.
-- Q: Forward auth or OIDC for that operator authentication? → A: Support both
-  (the app platform offers both); the operator picks one via configuration.
-  Forward auth is simplest (trusted proxy-injected header); OIDC is strongest
-  (the service verifies a signed token via JWKS + issuer/audience/expiry, so it
-  does not rely on a network boundary for header trust) and is recommended where
-  available.
+- Q: Forward auth or OIDC for that operator authentication? → A: Forward auth for
+  v1. OIDC would require remo-web to implement token verification itself (a JWT
+  dependency + JWKS fetch/caching + signature/issuer/audience/expiry validation +
+  ongoing maintenance and a runtime coupling to the IdP), whereas forward auth
+  keeps remo-web a thin consumer of a trusted proxy-injected header while the
+  platform (which supports both) does the SSO. OIDC-in-app is deferred to future
+  work behind a pluggable provider seam, to be built only if a deployment cannot
+  place a forward-auth proxy in front.
 - Q: Is the pairing code shown as a scannable QR? → A: Not in v1 — copy button
   only. QR (for cross-device pairing) is deferred.
 - Q: Does the CLI change? → A: Minimally. The CLI still sends whatever code it is
@@ -153,36 +158,32 @@ session (expiry or completion) and assert `404` again.
 3. **Given** adoption completed, **When** the setup surface is probed, **Then**
    it is dormant (404) — the code that drove the adoption no longer works.
 
-### User Story 3 - Operator authentication gates code minting (Priority: P1)
+### User Story 3 - Forward auth gates code minting (Priority: P1)
 
-The service is configured with an operator-authentication provider — either a
-trusted forward-auth identity header, or OIDC token verification. A request to
-mint a pairing code that lacks a valid authenticated identity is refused; a
-request carrying one succeeds. The operator's authenticated identity is recorded
-in the pairing session and in audit logs (never the code).
+The service is configured to require a trusted, proxy-injected identity header to
+mint a pairing code. A request to mint that lacks the trusted header is refused; a
+request carrying it succeeds. The operator's authenticated identity is recorded in
+the pairing session and in audit logs (never the code). The check sits behind a
+pluggable provider seam so an OIDC verifier can be added later without changing
+this behavior.
 
 **Why this priority**: Operator authentication is what turns "anyone who can
 reach the page" into "an authenticated operator," and is the precondition that
 makes minting safe. It is a P1 security control, not an enhancement.
 
-**Independent Test**: For each provider, attempt to mint a code with no
-credential (refused), with an invalid credential (a client-spoofed header the
-proxy would have stripped / a token failing signature/issuer/audience/expiry —
-refused), and with a valid credential (succeeds); confirm the audit log names the
-identity and never the code.
+**Independent Test**: Behind a stub proxy, attempt to mint a code with no identity
+header (refused), with a client-supplied header the proxy is configured to strip
+(refused per trust rules), and with a valid proxy-injected header (succeeds);
+confirm the audit log names the identity and never the code.
 
 **Acceptance Scenarios**:
 
-1. **Given** forward auth is the configured provider, **When** a mint request
-   arrives without a trusted identity header, **Then** minting is refused and no
-   session is created.
-2. **Given** OIDC is the configured provider, **When** a mint request presents a
-   token that fails verification (bad signature, wrong issuer/audience, or
-   expired), **Then** minting is refused and no session is created.
-3. **Given** either provider, **When** a mint request carries a valid credential,
-   **Then** a code is minted and the session records the verified authenticated
-   identity.
-4. **Given** a deployment in the network-restricted posture (no provider
+1. **Given** forward auth is required, **When** a mint request arrives without the
+   trusted identity header, **Then** minting is refused and no session is created.
+2. **Given** forward auth is required, **When** a mint request carries a valid
+   proxy-injected identity header, **Then** a code is minted and the session
+   records the authenticated identity.
+3. **Given** a deployment in the network-restricted posture (no provider
    configured, explicitly opted into), **When** a mint request arrives, **Then**
    minting proceeds without a credential, and startup/logs clearly record that
    the weaker posture is active.
@@ -268,33 +269,31 @@ after the affordance closes.
 
 #### Operator-authentication gating (User Story 3)
 
-- **FR-009**: The service MUST support requiring operator authentication to mint
-  a pairing code, via a configurable provider. At least two providers MUST be
-  supported: **forward auth** (a trusted proxy-injected identity header, e.g.
-  `X-Forwarded-User` / `Remote-User`, with a configurable header name) and
-  **OIDC** (a token presented to the service).
-- **FR-010**: For the OIDC provider, the service MUST **cryptographically
-  verify** the presented token before minting: signature against the IdP's
-  published keys (JWKS, discovered via the issuer's well-known configuration),
-  plus issuer, audience, and expiry/not-before checks with a bounded clock-skew
-  allowance. A token failing any check MUST be treated as no credential.
+- **FR-009**: The service MUST support requiring **forward auth** to mint a
+  pairing code: minting is permitted only for a request carrying a trusted,
+  proxy-injected identity header (configurable header name, e.g.
+  `X-Forwarded-User` / `Remote-User`).
+- **FR-010**: The operator-authentication check MUST be implemented behind a
+  pluggable **provider seam** so additional providers (notably an in-app OIDC
+  token verifier — deferred, see Out of Scope) can be added without changing the
+  pairing-session or dormancy behavior. v1 ships exactly one provider (forward
+  auth) plus the network-restricted posture of FR-013.
 - **FR-011**: When operator authentication is required and no valid credential is
   present, the mint request MUST be refused and no session created; the refusal
   MUST be observable in logs with request context and MUST NOT create or reveal a
-  code. Verification failures MUST NOT leak token contents into logs.
-- **FR-012**: The service MUST record the verified authenticated identity that
-  minted a session (in the session and in audit logs) and MUST associate
-  adoption/push actions with it; the pairing code itself MUST never be logged.
+  code.
+- **FR-012**: The service MUST record the authenticated identity that minted a
+  session (in the session and in audit logs) and MUST associate adoption/push
+  actions with it; the pairing code itself MUST never be logged.
 - **FR-013**: The service MUST support an explicit, clearly-logged
   **network-restricted** posture in which no operator-authentication provider is
   configured (for loopback/private/dev deployments). This posture MUST be opt-in
   and MUST be surfaced at startup and in readiness/diagnostics as the weaker
   posture, so it is never entered silently.
-- **FR-014**: The service MUST treat a forward-auth identity header as
+- **FR-014**: The service MUST treat the forward-auth identity header as
   trustworthy only under the documented trust boundary (proxy in front, direct
-  client access to the app prevented). Both providers' configuration — including
-  the hola-app setup for each — MUST be documented for operators, noting OIDC as
-  the stronger option where available.
+  client access to the app prevented); this boundary — including the hola-app
+  forward-auth configuration — MUST be documented for operators.
 
 #### Pairing code delivery (User Story 1, 4)
 
@@ -327,8 +326,7 @@ after the affordance closes.
   for it MUST NOT grant setup access. Its removal MUST be documented as a
   breaking change from 011, with the pairing flow as the replacement.
 - **FR-022**: The compose example and hola/app documentation MUST be updated to
-  the pairing model (operator-auth front door — forward auth or OIDC; no static
-  token secret to manage).
+  the pairing model (forward-auth front door; no static token secret to manage).
 
 ### Key Entities
 
@@ -338,12 +336,11 @@ after the affordance closes.
   re-sync). At most one live session (most-recent-wins). Never persisted.
 - **Pairing code**: the high-entropy bearer the operator copies into the CLI.
   Exists only in memory and transiently on the operator's clipboard.
-- **Operator-auth provider**: the configured mechanism that authenticates the
-  minting request — either **forward auth** (a trusted proxy-injected identity
-  header) or **OIDC** (a token the service verifies via JWKS +
-  issuer/audience/expiry). Yields the **authenticated operator identity** stored
-  on the session; establishes that the minting request is an authenticated
-  operator, not merely a reachable client.
+- **Operator-auth provider**: the pluggable mechanism that authenticates the
+  minting request. v1 provides **forward auth** (a trusted proxy-injected identity
+  header); the seam allows a future **OIDC** verifier. Yields the **authenticated
+  operator identity** stored on the session; establishes that the minting request
+  is an authenticated operator, not merely a reachable client.
 
 ## Success Criteria *(mandatory)*
 
@@ -356,10 +353,9 @@ after the affordance closes.
 - **SC-003**: A pairing code survives an adoption that idles on an interactive
   prompt for at least the configured idle window, provided setup calls continue,
   and expires within that idle window after activity stops.
-- **SC-004**: With an operator-auth provider required (forward auth or OIDC), a
-  mint request without a valid credential never yields a working code (0%
-  success), while one with a valid credential (trusted header / verified token)
-  succeeds.
+- **SC-004**: With forward auth required, a mint request without the trusted
+  identity header never yields a working code (0% success), while one with a
+  valid proxy-injected header succeeds.
 - **SC-005**: Reopening the adopt page invalidates the previously minted code in
   100% of cases (rotation on open).
 - **SC-006**: The pairing code appears in zero log lines, zero error payloads,
@@ -372,14 +368,14 @@ after the affordance closes.
 
 ## Assumptions
 
-- The service is deployed with an operator-authentication provider in front:
-  either a reverse proxy performing forward auth (injecting a trusted identity
-  header, with direct client access to the app prevented so the header cannot be
-  spoofed), or OIDC (the service verifies a signed token). This is the
-  recommended posture and the one the security model relies on. The app platform
-  (hola) supports both; OIDC is stronger where available because verification is
-  cryptographic rather than boundary-dependent. (A network-restricted posture
-  with no provider is supported but explicitly weaker — FR-013.)
+- The service is deployed behind a reverse proxy performing forward auth: it
+  injects a trusted identity header and prevents direct client access to the app
+  so the header cannot be spoofed. This is the recommended posture and the one the
+  v1 security model relies on. The app platform (hola) can terminate SSO and
+  inject that header, so remo-web needs no in-app identity-provider integration.
+  (A network-restricted posture with no provider is supported but explicitly
+  weaker — FR-013. In-app OIDC verification is deferred future work — Out of
+  Scope.)
 - The operator's browser and workstation may be the same machine or different
   machines; v1 delivery is clipboard copy, so cross-device pairing (QR) is a
   later enhancement.
@@ -399,9 +395,13 @@ after the affordance closes.
 - **Changes to what adoption/push do** once authorized (registry mirror, host-key
   verification, key authorization, verification pass) — all inherited unchanged
   from 011.
+- **In-app OIDC token verification** (JWT dependency, JWKS fetch/caching,
+  signature/issuer/audience/expiry validation). Deferred future work behind the
+  FR-010 provider seam; built only if a deployment cannot place a forward-auth
+  proxy in front. v1 is forward-auth-only.
 - **Building the reverse proxy / IdP / SSO itself** — the service *consumes* a
-  forward-auth header or *verifies* an OIDC token; standing up the proxy or
-  identity provider is the operator's/platform's job.
+  forward-auth header; standing up the proxy or identity provider is the
+  operator's/platform's job.
 - **Acting as a full OIDC relying party** (interactive redirect/callback/cookie
-  login flow implemented by the service). v1 verifies a presented token; it does
-  not run the browser authorization-code dance itself (the platform/proxy does).
+  login flow implemented by the service) — not in v1, and not implied by the
+  deferred OIDC-verifier enhancement above.

--- a/specs/012-web-adopt-pairing/spec.md
+++ b/specs/012-web-adopt-pairing/spec.md
@@ -88,6 +88,25 @@ Scope) — clipboard copy of the code is the v1 delivery mechanism.
   platform (which supports both) does the SSO. OIDC-in-app is deferred to future
   work behind a pluggable provider seam, to be built only if a deployment cannot
   place a forward-auth proxy in front.
+- Q: Where should the forward-auth boundary sit, given the CLI cannot complete an
+  SSO challenge but must call the setup API? → A: Forward auth gates only the
+  browser-facing **mint** endpoint. `/api/v1/setup/*` passes through the proxy and
+  is authenticated solely by the ephemeral pairing code the CLI carries; the code
+  is the CLI's credential and was itself minted by an authenticated operator, so
+  the chain of trust holds without the CLI performing SSO.
+- Q: Keep the no-forward-auth "network-restricted" posture, or always require
+  forward auth? → A: Keep it, but only as an explicit, loudly-logged opt-in that
+  is never the default and is surfaced in readiness/diagnostics as the weaker
+  mode — so local `remo web serve` and single-machine loopback runs work without a
+  proxy, while insecurity can never be entered silently (FR-013).
+- Q: What is the default sliding idle-TTL for a pairing session? → A: 15 minutes
+  (configurable). It covers mint→first-CLI-call latency and pauses on the
+  interactive fingerprint prompt, while an abandoned code expires within 15 min of
+  inactivity (FR-002).
+- Q: Should the trusted forward-auth header name have a baked-in default? → A: No
+  default — the header name MUST be configured explicitly when forward auth is
+  enabled, and enabling it without a name is a fail-fast config error, so the
+  service never trusts a header the operator's proxy does not set/strip (FR-009).
 - Q: Is the pairing code shown as a scannable QR? → A: Not in v1 — copy button
   only. QR (for cross-device pairing) is deferred.
 - Q: Does the CLI change? → A: Minimally. The CLI still sends whatever code it is
@@ -247,7 +266,8 @@ after the affordance closes.
   with a single pairing **session**.
 - **FR-002**: A pairing session MUST have a **sliding idle TTL**: it expires a
   configurable idle interval after the last successful authenticated setup call
-  (default on the order of 15 minutes), measured against a monotonic clock.
+  (default **15 minutes**), measured against a monotonic clock. The window also
+  covers the initial gap between minting a code and the CLI's first setup call.
 - **FR-003**: Opening/mounting the adopt page (or the re-sync affordance) MUST
   mint a fresh code and invalidate any prior live session (rotation on open,
   most-recent-wins).
@@ -271,8 +291,16 @@ after the affordance closes.
 
 - **FR-009**: The service MUST support requiring **forward auth** to mint a
   pairing code: minting is permitted only for a request carrying a trusted,
-  proxy-injected identity header (configurable header name, e.g.
-  `X-Forwarded-User` / `Remote-User`).
+  proxy-injected identity header. The trusted header name MUST be configured
+  explicitly (no baked-in default, since it varies by proxy — e.g.
+  `X-Forwarded-User`, `Remote-User`); enabling forward auth without naming a
+  header MUST be a fail-fast configuration error, so the service never trusts a
+  header the proxy does not set and strip. The forward-auth boundary applies ONLY to
+  the browser-facing **mint** endpoint; the `/api/v1/setup/*` routes the CLI calls
+  MUST NOT require forward auth — they are authenticated solely by the live
+  pairing code (FR-005/FR-006). The deployment's proxy MUST therefore gate the
+  mint path while passing the setup API through, and this split MUST be documented
+  (including the hola-app configuration, FR-022).
 - **FR-010**: The operator-authentication check MUST be implemented behind a
   pluggable **provider seam** so additional providers (notably an in-app OIDC
   token verifier — deferred, see Out of Scope) can be added without changing the

--- a/specs/012-web-adopt-pairing/spec.md
+++ b/specs/012-web-adopt-pairing/spec.md
@@ -1,0 +1,407 @@
+# Feature Specification: Ephemeral Device-Pairing Adoption (Operator-Auth Gated)
+
+**Feature Branch**: `012-web-adopt-pairing`
+
+**Created**: 2026-07-19
+
+**Status**: Draft
+
+**Input**: User description: "Instead of a static setup token baked in at deploy
+time, the awaiting-adoption web page mints a short-lived ephemeral pairing code
+(streaming-service QR sign-on model). The setup API is dormant until an operator
+browses to the adopt page and a pairing session is live. Future re-syncs use the
+same flow. Access to the page — and thus the ability to mint a code — is gated by
+operator authentication (forward auth OR OIDC — the app platform supports both),
+so the service positively knows the operator is authenticated."
+
+## Overview
+
+Feature 011 (CLI-to-Web Adoption) gates the `/api/v1/setup/*` surface with a
+single **static** bearer token supplied at deploy time (`REMO_WEB_API_TOKEN`).
+That token is long-lived, must be configured out-of-band, and — if an operator
+wants to lift it into the CLI without re-typing — can only be surfaced to the
+browser by exposing the very secret the API is gated by.
+
+This feature replaces the static token with an **ephemeral device-pairing**
+model, patterned on how a streaming service signs a new TV in: the
+awaiting-adoption page mints a short-lived **pairing code**, the operator carries
+that code to their workstation CLI (`remo web adopt`), and the code authorizes
+that one adoption session. There is no durable service credential anywhere.
+
+Two properties make this safe where a naked "unauthenticated setup API" would
+not be:
+
+1. **The setup surface is dormant (just-in-time).** `/api/v1/setup/*` returns
+   `404` — indistinguishable from an absent route — unless a pairing session is
+   currently live. A pairing session exists only while an operator is actively
+   on the adopt page (or the dashboard re-sync affordance). The attack surface
+   does not exist at rest.
+2. **Minting a pairing code is gated by operator authentication.** The service
+   only mints a code for a request that carries proof the operator is
+   authenticated. Two interchangeable providers are supported, both offered by
+   the app platform:
+   - **Forward auth** — a trusted, proxy-injected identity header (Traefik
+     ForwardAuth / oauth2-proxy / Authelia / a hola app's SSO). Simplest;
+     trust rests on the proxy being the only ingress.
+   - **OIDC** — a token minted by the identity provider and presented to the
+     service, which the service **cryptographically verifies** (signature via
+     the IdP's JWKS, plus issuer/audience/expiry). Strongest, because trust
+     does not depend on a network boundary — a spoofed header without a
+     validly-signed token is rejected. Recommended where available.
+   Either way the service has positive proof the operator is logged in — not
+   merely that they can reach the page.
+
+Future re-syncs (`remo web push`) use the identical flow: the operator opens a
+re-sync affordance in the dashboard, the service mints a fresh code, the CLI
+consumes it. Nothing is persisted between sessions.
+
+The static `REMO_WEB_API_TOKEN` model is removed. QR display of the pairing
+code, and multiple concurrent named deployments, are out of scope (see Out of
+Scope) — clipboard copy of the code is the v1 delivery mechanism.
+
+## Clarifications
+
+### Session 2026-07-19
+
+- Q: Static deploy-time token, or ephemeral page-minted pairing code? → A:
+  Ephemeral. No static `REMO_WEB_API_TOKEN`. Both first adoption and every later
+  re-sync obtain a fresh code from the page.
+- Q: How is the pairing code's lifetime bounded, given adoption can pause on an
+  interactive host-key fingerprint prompt? → A: Sliding TTL. Opening the page
+  mints a fresh code (invalidating the prior); each successful setup call
+  refreshes an idle window; best-effort invalidation when the page is hidden;
+  a live code dies by idle TTL.
+- Q: Should the setup API be reachable when nobody is on the adopt page? → A:
+  No. `/api/v1/setup/*` is dormant (404) unless a pairing session is live.
+- Q: What positively establishes that the person minting a code is the
+  operator, rather than anyone who can reach the service? → A: Operator
+  authentication, required to mint. Reachability alone is never sufficient in the
+  gated posture.
+- Q: Forward auth or OIDC for that operator authentication? → A: Support both
+  (the app platform offers both); the operator picks one via configuration.
+  Forward auth is simplest (trusted proxy-injected header); OIDC is strongest
+  (the service verifies a signed token via JWKS + issuer/audience/expiry, so it
+  does not rely on a network boundary for header trust) and is recommended where
+  available.
+- Q: Is the pairing code shown as a scannable QR? → A: Not in v1 — copy button
+  only. QR (for cross-device pairing) is deferred.
+- Q: Does the CLI change? → A: Minimally. The CLI still sends whatever code it is
+  handed as the bearer credential; the "save credentials for later push" step is
+  removed because there is nothing durable to save.
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - Pair-and-adopt with an ephemeral code (Priority: P1)
+
+An operator has deployed a fresh remo-web service behind a forward-auth reverse
+proxy and signed in through that proxy. They open the service in a browser and
+land on the awaiting-adoption page, which displays a **Copy pairing code**
+button (the code itself is never shown). They click it, the code lands on their
+clipboard, and on their workstation they run `remo web adopt <url>` and paste
+the code when prompted. The CLI completes the existing adoption work (retrieve
+service identity, push registry + verified host keys, authorize the service key
+on each instance, run the verification pass). The browser flips to the
+dashboard.
+
+**Why this priority**: This is the headline capability — it replaces the static
+token as the *only* way to perform first-time adoption. Without it there is no
+adoption path at all.
+
+**Independent Test**: Behind a stub forward-auth proxy that injects a valid
+identity header, load the adopt page, mint + copy a code, run `remo web adopt`
+with that code against a service managing ≥2 reachable instances, and confirm
+the dashboard shows all instances with working terminals and no static token was
+configured anywhere.
+
+**Acceptance Scenarios**:
+
+1. **Given** an unconfigured service behind forward auth and an authenticated
+   operator on the adopt page, **When** the page mints a pairing code and the
+   operator runs `remo web adopt` with it, **Then** adoption completes exactly as
+   in 011 and the code authenticated every setup call.
+2. **Given** a live pairing code, **When** the operator pauses on the CLI's
+   interactive fingerprint prompt for several minutes while the CLI keeps making
+   setup calls, **Then** the sliding TTL keeps the code valid and adoption
+   succeeds.
+3. **Given** a pairing code was minted, **When** the operator reloads/reopens the
+   adopt page, **Then** a new code is minted and the prior code no longer
+   authenticates (rotation on open).
+
+### User Story 2 - Setup surface is dormant until pairing (Priority: P1)
+
+Before anyone opens the adopt page, and after a pairing session ends, every
+`/api/v1/setup/*` route answers `404`, byte-identical to an unknown route.
+Public liveness/readiness (`/api/v1/health`, `/api/v1/ready`) and the SPA remain
+available so the adopt page can render and the container passes healthchecks.
+
+**Why this priority**: The dormant-by-default surface is the core security
+property that makes an ephemeral-code model acceptable; it is inseparable from
+US1.
+
+**Independent Test**: With no pairing session live, assert `404` on every setup
+route; mint a session and assert the routes respond to the live code; end the
+session (expiry or completion) and assert `404` again.
+
+**Acceptance Scenarios**:
+
+1. **Given** a freshly booted unconfigured service with nobody on the adopt page,
+   **When** any `/api/v1/setup/*` route is requested (with or without a bearer),
+   **Then** the response is `404 {"detail":"Not Found"}`.
+2. **Given** a live pairing session, **When** the pairing code expires by idle
+   TTL, **Then** subsequent setup calls with that code return `404` and the
+   surface is dormant again.
+3. **Given** adoption completed, **When** the setup surface is probed, **Then**
+   it is dormant (404) — the code that drove the adoption no longer works.
+
+### User Story 3 - Operator authentication gates code minting (Priority: P1)
+
+The service is configured with an operator-authentication provider — either a
+trusted forward-auth identity header, or OIDC token verification. A request to
+mint a pairing code that lacks a valid authenticated identity is refused; a
+request carrying one succeeds. The operator's authenticated identity is recorded
+in the pairing session and in audit logs (never the code).
+
+**Why this priority**: Operator authentication is what turns "anyone who can
+reach the page" into "an authenticated operator," and is the precondition that
+makes minting safe. It is a P1 security control, not an enhancement.
+
+**Independent Test**: For each provider, attempt to mint a code with no
+credential (refused), with an invalid credential (a client-spoofed header the
+proxy would have stripped / a token failing signature/issuer/audience/expiry —
+refused), and with a valid credential (succeeds); confirm the audit log names the
+identity and never the code.
+
+**Acceptance Scenarios**:
+
+1. **Given** forward auth is the configured provider, **When** a mint request
+   arrives without a trusted identity header, **Then** minting is refused and no
+   session is created.
+2. **Given** OIDC is the configured provider, **When** a mint request presents a
+   token that fails verification (bad signature, wrong issuer/audience, or
+   expired), **Then** minting is refused and no session is created.
+3. **Given** either provider, **When** a mint request carries a valid credential,
+   **Then** a code is minted and the session records the verified authenticated
+   identity.
+4. **Given** a deployment in the network-restricted posture (no provider
+   configured, explicitly opted into), **When** a mint request arrives, **Then**
+   minting proceeds without a credential, and startup/logs clearly record that
+   the weaker posture is active.
+
+### User Story 4 - Re-sync after local changes uses the same flow (Priority: P2)
+
+After adoption, the operator changes their local registry and wants the service
+to reflect it. In the dashboard they open a **Pair CLI to sync** affordance,
+which mints a fresh pairing code (same operator-auth gate, same TTL/rotation).
+They run `remo web push <url>` on the workstation, paste the code, and the push
+applies. When the affordance is closed or the code expires, the setup surface is
+dormant again.
+
+**Why this priority**: Ongoing sync is the steady-state use after first adoption;
+reusing the identical mechanism keeps one security model rather than two.
+
+**Independent Test**: On an adopted service, open the re-sync affordance, mint a
+code, run `remo web push` with it against a changed local registry, and confirm
+the service registry mirrors the change; then confirm the surface is dormant
+after the affordance closes.
+
+**Acceptance Scenarios**:
+
+1. **Given** an adopted service, **When** the operator opens the re-sync
+   affordance and mints a code, **Then** `remo web push` with that code applies
+   the registry mirror.
+2. **Given** a re-sync code, **When** the affordance is closed (or the code
+   expires), **Then** `/api/v1/setup/*` is dormant again.
+
+### Edge Cases
+
+- **Reused/expired code**: a code presented after its session ended (TTL,
+  rotation, page-hide beacon, or adoption completion) is treated as unknown →
+  `404`, never a distinguishable `401`.
+- **Concurrent pages/tabs**: opening a second adopt page mints a new code and
+  invalidates the prior; an adoption in flight on the prior code will then fail
+  its next call. Documented most-recent-wins behavior.
+- **Restart mid-adoption**: pairing sessions are in-memory; a container restart
+  drops them. The operator re-opens the page for a new code. (The service
+  identity keypair persists, per 011 FR-002.)
+- **Header spoofing**: in the forward-auth posture, the service trusts the
+  identity header only from the proxy; a deployment MUST ensure clients cannot
+  reach the app directly and inject the header. This is the standard forward-auth
+  trust boundary and MUST be documented.
+- **Clock/monotonic time**: TTL is measured against a monotonic source so a
+  system clock change cannot extend or prematurely expire a session.
+- **Code never logged**: the pairing code MUST NOT appear in logs, error
+  messages, the DOM, or the SPA state beyond the transient clipboard write.
+- **Health/readiness unaffected**: minting, rotation, and dormancy MUST NOT
+  change `/api/v1/health` or `/api/v1/ready` behavior; an unconfigured service
+  still reports the healthy "awaiting adoption" readiness of 011.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+#### Pairing session lifecycle (User Story 1, 2)
+
+- **FR-001**: The service MUST mint an ephemeral **pairing code** on demand from
+  the adopt page: a high-entropy random value held only in memory, associated
+  with a single pairing **session**.
+- **FR-002**: A pairing session MUST have a **sliding idle TTL**: it expires a
+  configurable idle interval after the last successful authenticated setup call
+  (default on the order of 15 minutes), measured against a monotonic clock.
+- **FR-003**: Opening/mounting the adopt page (or the re-sync affordance) MUST
+  mint a fresh code and invalidate any prior live session (rotation on open,
+  most-recent-wins).
+- **FR-004**: The page MUST best-effort invalidate the session when it is hidden
+  or unloaded (e.g. a `sendBeacon`), with the idle TTL as the authoritative
+  backstop; the service MUST NOT depend on the browser for correctness.
+- **FR-005**: The `/api/v1/setup/*` surface MUST be **dormant** — every route
+  answering `404` identical to an unknown route — whenever no pairing session is
+  live. It becomes reachable only for the currently live code.
+- **FR-006**: A setup request whose bearer is absent, unknown, or belonging to an
+  expired/rotated session MUST receive the same dormant `404`, never a
+  distinguishable `401` that would reveal a session exists. (Rationale: a dormant
+  surface must be indistinguishable from an absent one, mirroring 011 FR-021.)
+- **FR-007**: Successful adoption/push (a registry apply that transitions or
+  refreshes configured state) MUST end the pairing session so the surface returns
+  to dormant.
+- **FR-008**: Pairing sessions and codes MUST NOT be persisted to disk; a process
+  restart MUST drop all sessions.
+
+#### Operator-authentication gating (User Story 3)
+
+- **FR-009**: The service MUST support requiring operator authentication to mint
+  a pairing code, via a configurable provider. At least two providers MUST be
+  supported: **forward auth** (a trusted proxy-injected identity header, e.g.
+  `X-Forwarded-User` / `Remote-User`, with a configurable header name) and
+  **OIDC** (a token presented to the service).
+- **FR-010**: For the OIDC provider, the service MUST **cryptographically
+  verify** the presented token before minting: signature against the IdP's
+  published keys (JWKS, discovered via the issuer's well-known configuration),
+  plus issuer, audience, and expiry/not-before checks with a bounded clock-skew
+  allowance. A token failing any check MUST be treated as no credential.
+- **FR-011**: When operator authentication is required and no valid credential is
+  present, the mint request MUST be refused and no session created; the refusal
+  MUST be observable in logs with request context and MUST NOT create or reveal a
+  code. Verification failures MUST NOT leak token contents into logs.
+- **FR-012**: The service MUST record the verified authenticated identity that
+  minted a session (in the session and in audit logs) and MUST associate
+  adoption/push actions with it; the pairing code itself MUST never be logged.
+- **FR-013**: The service MUST support an explicit, clearly-logged
+  **network-restricted** posture in which no operator-authentication provider is
+  configured (for loopback/private/dev deployments). This posture MUST be opt-in
+  and MUST be surfaced at startup and in readiness/diagnostics as the weaker
+  posture, so it is never entered silently.
+- **FR-014**: The service MUST treat a forward-auth identity header as
+  trustworthy only under the documented trust boundary (proxy in front, direct
+  client access to the app prevented). Both providers' configuration — including
+  the hola-app setup for each — MUST be documented for operators, noting OIDC as
+  the stronger option where available.
+
+#### Pairing code delivery (User Story 1, 4)
+
+- **FR-015**: The awaiting-adoption page MUST offer a **copy pairing code**
+  action that places the current code on the clipboard and MUST NOT display the
+  code value on screen or retain it in page state beyond the copy.
+- **FR-016**: The code MUST be fetched only on an explicit operator action
+  (mint/copy), returned with cache-defeating headers, and never embedded in the
+  initially served HTML/bundle.
+- **FR-017**: The dashboard MUST provide an equivalent **pair-to-sync** affordance
+  for adopted services (User Story 4) that mints and copies a code through the
+  same lifecycle and gating.
+
+#### CLI (User Story 1, 4)
+
+- **FR-018**: `remo web adopt` / `remo web push` MUST accept the pairing code the
+  same way they accept a token today (prompt, option, or `REMO_API_TOKEN`),
+  sending it as the bearer credential for setup calls; no new CLI concept is
+  required.
+- **FR-019**: The CLI MUST NOT persist adoption credentials (the prior
+  "save credentials for later push" behavior is removed); each adoption/push
+  obtains a fresh code from the page.
+- **FR-020**: When a setup call returns the dormant `404` (expired/rotated code),
+  the CLI MUST surface an actionable message telling the operator to reopen the
+  adopt page (or re-sync affordance) for a fresh code and retry.
+
+#### Migration / removal of the static token
+
+- **FR-021**: The static `REMO_WEB_API_TOKEN` gate MUST be removed; a value set
+  for it MUST NOT grant setup access. Its removal MUST be documented as a
+  breaking change from 011, with the pairing flow as the replacement.
+- **FR-022**: The compose example and hola/app documentation MUST be updated to
+  the pairing model (operator-auth front door — forward auth or OIDC; no static
+  token secret to manage).
+
+### Key Entities
+
+- **Pairing session**: an in-memory record for one adoption/push handoff —
+  opaque code, minting identity (from the operator-auth provider, when present),
+  monotonic last-activity timestamp, idle TTL, and origin (adopt page vs
+  re-sync). At most one live session (most-recent-wins). Never persisted.
+- **Pairing code**: the high-entropy bearer the operator copies into the CLI.
+  Exists only in memory and transiently on the operator's clipboard.
+- **Operator-auth provider**: the configured mechanism that authenticates the
+  minting request — either **forward auth** (a trusted proxy-injected identity
+  header) or **OIDC** (a token the service verifies via JWKS +
+  issuer/audience/expiry). Yields the **authenticated operator identity** stored
+  on the session; establishes that the minting request is an authenticated
+  operator, not merely a reachable client.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: With no pairing session live, 100% of `/api/v1/setup/*` requests
+  return `404` identical to an unknown route (dormant surface).
+- **SC-002**: An operator can complete first-time adoption using only a
+  page-minted code copied to the clipboard — no static token configured anywhere.
+- **SC-003**: A pairing code survives an adoption that idles on an interactive
+  prompt for at least the configured idle window, provided setup calls continue,
+  and expires within that idle window after activity stops.
+- **SC-004**: With an operator-auth provider required (forward auth or OIDC), a
+  mint request without a valid credential never yields a working code (0%
+  success), while one with a valid credential (trusted header / verified token)
+  succeeds.
+- **SC-005**: Reopening the adopt page invalidates the previously minted code in
+  100% of cases (rotation on open).
+- **SC-006**: The pairing code appears in zero log lines, zero error payloads,
+  and is absent from the served HTML/JS bundle (only present transiently after an
+  explicit copy).
+- **SC-007**: A re-sync (`remo web push`) can be completed end-to-end using the
+  dashboard affordance's code, and the setup surface is dormant before and after.
+- **SC-008**: `/api/v1/health` and `/api/v1/ready` behavior is byte-unchanged
+  from 011 across dormant, live-session, and post-adoption states.
+
+## Assumptions
+
+- The service is deployed with an operator-authentication provider in front:
+  either a reverse proxy performing forward auth (injecting a trusted identity
+  header, with direct client access to the app prevented so the header cannot be
+  spoofed), or OIDC (the service verifies a signed token). This is the
+  recommended posture and the one the security model relies on. The app platform
+  (hola) supports both; OIDC is stronger where available because verification is
+  cryptographic rather than boundary-dependent. (A network-restricted posture
+  with no provider is supported but explicitly weaker — FR-013.)
+- The operator's browser and workstation may be the same machine or different
+  machines; v1 delivery is clipboard copy, so cross-device pairing (QR) is a
+  later enhancement.
+- The service identity keypair and its persistence (011 FR-002) are unchanged;
+  this feature changes only how the setup surface is authorized, not what
+  adoption does once authorized.
+- One operator drives one adoption/push at a time (most-recent-wins rotation is
+  acceptable; concurrent multi-operator pairing is not a goal).
+
+## Out of Scope
+
+- **QR display** of the pairing code for cross-device pairing (planned follow-up;
+  copy-to-clipboard only in v1).
+- **Multiple concurrent named deployments / multi-operator concurrent pairing.**
+- **A durable service credential** of any kind (the removal of the static token
+  is deliberate; there is no replacement long-lived secret).
+- **Changes to what adoption/push do** once authorized (registry mirror, host-key
+  verification, key authorization, verification pass) — all inherited unchanged
+  from 011.
+- **Building the reverse proxy / IdP / SSO itself** — the service *consumes* a
+  forward-auth header or *verifies* an OIDC token; standing up the proxy or
+  identity provider is the operator's/platform's job.
+- **Acting as a full OIDC relying party** (interactive redirect/callback/cookie
+  login flow implemented by the service). v1 verifies a presented token; it does
+  not run the browser authorization-code dance itself (the platform/proxy does).

--- a/specs/012-web-adopt-pairing/tasks.md
+++ b/specs/012-web-adopt-pairing/tasks.md
@@ -1,0 +1,239 @@
+---
+
+description: "Task list for Ephemeral Device-Pairing Adoption (Forward-Auth Gated)"
+---
+
+# Tasks: Ephemeral Device-Pairing Adoption (Forward-Auth Gated)
+
+**Input**: Design documents from `/specs/012-web-adopt-pairing/`
+
+**Prerequisites**: plan.md, spec.md, research.md, data-model.md, contracts/
+
+**Tests**: Included — the spec's per-story Independent Test criteria and
+`quickstart.md` define explicit scenarios, and Constitution Principle II ("Test
+All Conditional Paths") mandates covering every dormant/live/expired/rotated and
+forward-auth/network-restricted branch.
+
+**Organization**: Tasks are grouped by user story. US1/US2/US3 are all P1 and
+together form the MVP (the pairing model is not shippable without all three);
+US4 (P2) is the re-sync increment.
+
+## Format: `[ID] [P?] [Story] Description`
+
+- **[P]**: Can run in parallel (different files, no dependencies)
+- **[Story]**: US1 / US2 / US3 / US4 (maps to spec.md user stories)
+
+## Path Conventions
+
+Existing three-layer repo: service `src/remo_cli/web/`, workstation CLI
+`src/remo_cli/cli/` + `src/remo_cli/core/`, SPA `frontend/src/`, tests under
+`tests/`. Paths below are repository-relative.
+
+---
+
+## Phase 1: Setup (Shared Infrastructure)
+
+**Purpose**: Configuration surface for the pairing model; remove the static token.
+
+- [X] T001 In `src/remo_cli/web/config.py`, remove the `api_token` field (and its `REMO_WEB_API_TOKEN` docstring), and add `pairing_ttl_s: float` (`REMO_WEB_PAIRING_TTL_S`, default `900.0`), `operator_auth: str` (`REMO_WEB_OPERATOR_AUTH`, default `""`), and `forward_auth_header: str` (`REMO_WEB_FORWARD_AUTH_HEADER`, default `""`) per data-model.md.
+- [X] T002 [P] In `src/remo_cli/web/logging_config.py`, add a defense-in-depth redaction pattern for a pairing code appearing in a `code`/bearer context (mirrors the existing Authorization-header redaction), so the code can never leak via logs (FR-016).
+
+---
+
+## Phase 2: Foundational (Blocking Prerequisites)
+
+**Purpose**: The in-memory pairing core and the operator-auth seam that every
+user story consumes. **No user story can begin until this phase is complete.**
+
+- [X] T003 [P] Create `src/remo_cli/web/pairing.py` with `PairingSession` (code, identity, origin, last_activity, ttl_s; `is_expired(now)`) and `PairingSessionManager` (at-most-one live session; injectable `now=time.monotonic`; `mint(identity, origin) -> code` with rotation, `authenticate(presented) -> PairingSession | None` constant-time + touch, `is_live()` with lazy expiry, `end()`; `threading.Lock` guard) per data-model.md R1/R6/R9.
+- [X] T004 [P] Create `src/remo_cli/web/operator_auth.py` with `OperatorIdentity`, the `OperatorAuthProvider` protocol, `NetworkRestrictedProvider` (returns anonymous identity), `ForwardAuthProvider(header_name)` (reads the configured header), and `build_operator_auth_provider(settings)` that fail-fasts when `operator_auth="forward"` has no header name and returns `None` (minting disabled) when unset (R4/R5, FR-009/FR-010).
+- [X] T005 Create `src/remo_cli/web/api/pairing.py` with the `POST /pairing/mint` route (returns `{code, expires_in}` with `Cache-Control: no-store`) and `POST /pairing/end` route (idempotent `204`) per contracts/pairing-api.md; mint depends on the configured provider (403 when unauthenticated/unconfigured, no session created).
+- [X] T006 In `src/remo_cli/web/app.py`, construct the operator-auth provider at startup via `build_operator_auth_provider(settings)` (fail-fast surfaces here), instantiate `PairingSessionManager` on `app.state`, mount the pairing router under `/api/v1`, and emit a one-line "REMO_WEB_API_TOKEN is now ignored" info log if the old env var is still set (R13).
+- [X] T007 In `src/remo_cli/cli/web.py`, when `remo web serve` binds a loopback interface and `REMO_WEB_OPERATOR_AUTH` is unset, default it to `none` for the child process and log the weaker-posture warning (R5), so local dev works without a proxy.
+- [X] T008 [P] Unit-test the pairing core in `tests/unit/web/test_pairing.py` with an injected fake monotonic clock: mint returns a code, rotation invalidates the prior, `authenticate` touches the sliding window, idle expiry drops the session, `end()` is idempotent, and concurrent access is lock-safe (Constitution II).
+
+**Checkpoint**: Pairing core + auth seam exist and are unit-tested; routers wired.
+
+---
+
+## Phase 3: User Story 1 - Pair-and-adopt with an ephemeral code (Priority: P1) 🎯 MVP
+
+**Goal**: An authenticated operator mints a code on the adopt page, copies it,
+and completes `remo web adopt` — no static token anywhere.
+
+**Independent Test**: Behind a stub forward-auth header, load the adopt page,
+mint+copy a code, run `remo web adopt` against a service managing ≥2 reachable
+instances, and confirm the dashboard shows all instances with working terminals.
+
+### Tests for User Story 1
+
+- [X] T009 [P] [US1] Integration coverage in `tests/integration/test_web_adopt_e2e.py` (migrated from 011): boots a live `remo web serve` in the network-restricted posture, mints a code via `POST /pairing/mint`, runs the adopt orchestration, and asserts identity→registry→verify all succeed with the code as bearer and the session ends on the terminal verify (FR-007).
+- [X] T010 [P] [US1] Unit test `tests/unit/core/test_web_adopt_code.py`: adopt sends the pasted code as `Authorization: Bearer`, and a dormant `404` from a setup call maps to the "reopen the adopt page for a fresh code" message (FR-020).
+
+### Implementation for User Story 1
+
+- [X] T011 [US1] In `src/remo_cli/web/api/setup.py`, replace `require_setup_token` with `require_pairing_code`: read the `PairingSessionManager` from `request.app.state`; dormant `404` when no live session; constant-time match against the live code; wrong/absent/expired → same `404` (never `401`); success touches the session (contracts/setup-api.md, FR-005/FR-006/FR-002).
+- [X] T012 [US1] In `src/remo_cli/web/api/setup.py`, end the pairing session after a successful `PUT /registry` apply that transitions/refreshes configured state (FR-007), so the surface returns to dormant post-adoption.
+- [X] T013 [US1] In `frontend/src/api/client.ts`, add `mintPairingCode()` (`POST /pairing/mint` → `{code, expires_in}`) and `endPairing()` (`sendBeacon`-friendly `POST /pairing/end`); remove any token concept.
+- [X] T014 [US1] In `frontend/src/components/AwaitingAdoption.tsx`, mint on mount (rotation-on-open), hold the code only in a non-rendered `ref`, change the button to **Copy pairing code** (copies from the ref, never renders the value), and fire the `endPairing()` beacon on `visibilitychange`→hidden / `pagehide` (FR-003/FR-004/FR-015/FR-016, R7/R8).
+- [X] T015 [P] [US1] In `src/remo_cli/cli/web.py`, rename the `adopt` credential prompt to "Pairing code" (still `--token` / `$REMO_API_TOKEN` / hidden prompt), and remove the `--save` flag from `adopt` (FR-018/FR-019).
+- [X] T016 [US1] In `src/remo_cli/core/web_adopt.py`, map the dormant `404` on setup calls to the actionable "reopen the adopt page for a fresh code and retry" error text (FR-020), replacing the 011 "wrong token / setup disabled" messages.
+- [X] T017 [US1] In `src/remo_cli/core/web_adopt.py`, remove `SavedCredentials` url/token fields, `save_credentials`, credential loading, and the save offer from the adopt path; retain only a non-secret push cache scaffold (deployment id + per-instance fingerprints) for US4 (FR-019, R10).
+
+**Checkpoint**: First-time adoption works end-to-end via a page-minted code with no static token.
+
+---
+
+## Phase 4: User Story 2 - Setup surface is dormant until pairing (Priority: P1)
+
+**Goal**: `/api/v1/setup/*` is `404` (byte-identical to unknown) whenever no
+pairing session is live; health/readiness/SPA stay available.
+
+**Independent Test**: With no session live, assert `404` on every setup route;
+mint a session and assert the routes respond to the live code; end the session
+(expiry or completion) and assert `404` again.
+
+### Tests for User Story 2
+
+- [X] T018 [P] [US2] Unit test `tests/unit/web/test_setup_dormancy.py` (starlette TestClient): every `/api/v1/setup/*` route returns `404 {"detail":"Not Found"}` with no live session (with and without a bearer); responds to the live code after mint; returns `404` after idle expiry (fake clock) and after adoption completion; a wrong-but-present code returns `404`, never `401` (FR-005/FR-006, SC-001).
+- [X] T019 [P] [US2] Unit test in the same file asserting `GET /api/v1/health` and `GET /api/v1/ready` bodies/status are byte-unchanged across dormant, live-session, and post-adoption states (SC-008).
+
+### Implementation for User Story 2
+
+- [X] T020 [US2] Verify/adjust `require_pairing_code` (from T011) so the dormancy branch is exercised for all four setup routes uniformly (router-level dependency), and remove the now-dead `require_setup_token` symbol and its imports.
+- [X] T021 [US2] In `src/remo_cli/web/api/pairing.py`, ensure `POST /pairing/end` drives the session to dormant immediately (best-effort beacon target), independent of the idle-TTL backstop (FR-004).
+- [X] T022 [US2] Confirm the Origin-allowlist middleware in `src/remo_cli/web/app.py` leaves the `/api/v1/setup/*` origin-less exemption intact while the browser-only `/api/v1/pairing/*` routes remain subject to the Origin check (R11); add a regression test in `tests/unit/web/test_pairing_origin.py`.
+
+**Checkpoint**: Dormancy is provable in all states; health/readiness untouched.
+
+---
+
+## Phase 5: User Story 3 - Forward auth gates code minting (Priority: P1)
+
+**Goal**: Minting requires a trusted proxy-injected identity header; refused
+without it; identity recorded (never the code); network-restricted posture is a
+loud opt-in.
+
+**Independent Test**: Behind a stub proxy, mint with no header (refused), with a
+valid proxy-injected header (succeeds), and confirm the audit log names the
+identity and never the code; confirm fail-fast when forward auth is enabled
+without a header name.
+
+### Tests for User Story 3
+
+- [X] T023 [P] [US3] Unit test `tests/unit/web/test_operator_auth.py`: `ForwardAuthProvider` authenticates only when the configured header is present/non-empty; `build_operator_auth_provider` fail-fasts on `operator_auth="forward"` with no header; unset → mint disabled (403 not configured); `NetworkRestrictedProvider` returns the anonymous identity (FR-009/FR-011/FR-013).
+- [X] T024 [P] [US3] Unit test `tests/unit/web/test_mint_gating.py` (TestClient): `POST /pairing/mint` returns `403` without the trusted header, `200 {code, expires_in}` with it, records the `subject` in logs and on the session, and never logs the code (FR-011/FR-012, SC-004).
+
+### Implementation for User Story 3
+
+- [X] T025 [US3] In `src/remo_cli/web/api/pairing.py`, enforce the operator-auth provider on `POST /pairing/mint`: refuse (`403`, logged with request context, no session) when `authenticate()` returns `None`; on success stamp the returned `OperatorIdentity` onto the minted session (FR-011/FR-012).
+- [X] T026 [US3] In `src/remo_cli/web/health.py`, add the operator-auth posture as additive readiness diagnostic detail — `forward` (echo header name, never value), `network-restricted` (flagged weaker), or `unconfigured` — without changing the `ready` status value or health behavior (FR-013, SC-008, R12).
+- [X] T027 [US3] In `src/remo_cli/web/check.py`, report the operator-auth posture in `remo web check` output and drop any static-token check (FR-013).
+- [X] T028 [US3] In `src/remo_cli/web/app.py`, emit the loud startup warning when the network-restricted posture is active (FR-013), and confirm the forward-auth fail-fast aborts startup with a clear message.
+
+**Checkpoint**: Minting is gated; posture is surfaced loudly; fail-fast enforced.
+
+---
+
+## Phase 6: User Story 4 - Re-sync after local changes uses the same flow (Priority: P2)
+
+**Goal**: A dashboard "Pair CLI to sync" affordance mints a fresh code through
+the same lifecycle/gate; `remo web push` consumes it; surface dormant before/after.
+
+**Independent Test**: On an adopted service, open the re-sync affordance, mint a
+code, run `remo web push` against a changed local registry, confirm the service
+registry mirrors the change, then confirm the surface is dormant after close.
+
+### Tests for User Story 4
+
+- [X] T029 [P] [US4] Integration coverage in `tests/integration/test_web_adopt_e2e.py`: adopt, register a new instance, mint a fresh code, run `remo web push` against the live adopted service, and assert only the new instance is processed (delta) while the mirror applies; plus a dormant-code push that fails with reopen guidance.
+- [X] T030 [P] [US4] Unit test `tests/unit/core/test_web_push_code.py`: `push` resolves URL + code every time (arg/env/prompt), no saved-credentials fast path, and the non-secret push cache (deployment id + fingerprints) still skips unchanged instances (FR-019, R10).
+
+### Implementation for User Story 4
+
+- [X] T031 [US4] Add a **Pair CLI to sync** affordance to the dashboard (`frontend/src/components/`) that mints+copies a code via the same `mintPairingCode()`/`endPairing()` lifecycle with `origin: "resync"` (FR-017).
+- [X] T032 [US4] In `src/remo_cli/cli/web.py`, remove `push`'s saved-credentials fallback and `NoSavedCredentialsError` path; `push` now resolves URL + pairing code the same way `adopt` does (prompt/env/option) on every run (FR-018/FR-019).
+- [X] T033 [US4] In `src/remo_cli/core/web_adopt.py`, finalize `run_push` to use the retained non-secret push cache keyed by the deployment id read from `/status` at push time (no url/token persisted), preserving the "unchanged instance skips re-authorization" optimization (R10).
+
+**Checkpoint**: Re-sync works through the identical pairing mechanism.
+
+---
+
+## Phase 7: Polish & Cross-Cutting Concerns
+
+**Purpose**: Docs, compose, and full-suite validation.
+
+- [X] T034 [P] In `docker/compose.example.yml`, remove `REMO_WEB_API_TOKEN`; document the forward-auth front door with the mint-gated / setup-passthrough split and the `REMO_WEB_OPERATOR_AUTH` + `REMO_WEB_FORWARD_AUTH_HEADER` env (FR-022).
+- [X] T035 [P] In `docs/web-session-interface.md`, add the breaking-change note (static token removed), the pairing flow, the forward-auth trust boundary, and the hola-app forward-auth configuration (FR-014/FR-021/FR-022).
+- [X] T036 [P] Grep the codebase and tests for any residual `api_token` / `REMO_WEB_API_TOKEN` / `require_setup_token` / `save_credentials` references and remove them (breaking-change completeness, FR-021).
+- [X] T037 [P] Frontend lint-clean (`tsc --noEmit`) passes; the "code never in the served bundle" property (SC-006) holds by construction — codes are random values fetched at runtime via `mintPairingCode()` and held only in a non-rendered `ref` (`AwaitingAdoption.tsx`, `PairToSync.tsx`), never a source literal and never inserted into the DOM. (A runtime DOM-assertion unit test was not added: the repo has no frontend test harness — `npm run lint` is `tsc --noEmit` only — and introducing one is out of scope.)
+- [X] T038 Run `uv run pytest`, `uv run mypy src/remo_cli`, `uv run ruff check src/remo_cli`, and `cd frontend && npm run lint`; fix any fallout.
+- [X] T039 Execute `specs/012-web-adopt-pairing/quickstart.md` scenarios A–G against a live `remo web serve` and record results.
+
+---
+
+## Dependencies & Execution Order
+
+### Phase Dependencies
+
+- **Setup (Phase 1)**: no dependencies — start immediately.
+- **Foundational (Phase 2)**: depends on Setup — **BLOCKS all user stories** (the manager, auth seam, and routers).
+- **US1 / US2 / US3 (Phases 3–5, all P1)**: depend on Foundational. They are tightly coupled (US2 dormancy and US3 gating both act on the same setup/mint routes US1 exercises) and together form the MVP. Recommended order US1 → US2 → US3, but US2 and US3 test tasks are independent and parallelizable once T011/T005 land.
+- **US4 (Phase 6, P2)**: depends on Foundational + US1 (reuses the mint lifecycle and the push cache scaffold from T017).
+- **Polish (Phase 7)**: after all desired stories.
+
+### Within Each User Story
+
+- Tests written to fail first, then implementation (Constitution II).
+- Manager/provider (foundational) before routes; routes before SPA/CLI wiring.
+
+### Parallel Opportunities
+
+- T001 ∥ T002 (Setup, different files).
+- T003 ∥ T004 (Foundational core modules, different files); T008 after T003.
+- Test tasks marked [P] within a story run together (different files).
+- US2 and US3 test authoring can proceed in parallel once the setup gate (T011) and mint route (T005/T025) exist.
+- Polish T034 ∥ T035 ∥ T036 ∥ T037.
+
+---
+
+## Parallel Example: Foundational + User Story 1
+
+```bash
+# Foundational core (different files):
+Task: "Create src/remo_cli/web/pairing.py (PairingSessionManager)"        # T003
+Task: "Create src/remo_cli/web/operator_auth.py (provider seam)"          # T004
+
+# User Story 1 tests (different files):
+Task: "Integration test tests/integration/test_adopt_pairing.py"          # T009
+Task: "Unit test tests/unit/core/test_web_adopt_code.py"                  # T010
+```
+
+---
+
+## Implementation Strategy
+
+### MVP (User Stories 1 + 2 + 3 — the pairing model)
+
+1. Phase 1 Setup → Phase 2 Foundational (manager + auth seam + routers).
+2. US1 (adopt path), US2 (dormancy), US3 (forward-auth gate) — the three P1
+   stories are not independently shippable in isolation (the model needs all
+   three), so land them together and validate as one MVP.
+3. **STOP and VALIDATE**: quickstart scenarios A–D + F–G.
+
+### Incremental Delivery
+
+1. MVP (US1+US2+US3) → first-time adoption via ephemeral code, dormant surface,
+   gated minting. Deploy/demo.
+2. US4 → dashboard re-sync + `remo web push`. Deploy/demo.
+3. Polish → docs, compose, breaking-change cleanup, full-suite + quickstart.
+
+---
+
+## Notes
+
+- [P] = different files, no dependency on an incomplete task.
+- No new runtime dependency — pairing core is stdlib (`secrets`, `time.monotonic`, `threading`).
+- The pairing code MUST never appear in logs, the DOM, or the served bundle — verify in T024/T037 (SC-006).
+- TTL branches use an injected fake monotonic clock — never `sleep` (T008/T018).
+- Commit after each task or logical group.

--- a/src/remo_cli/cli/web.py
+++ b/src/remo_cli/cli/web.py
@@ -84,6 +84,16 @@ def serve(bind_host: str | None, bind_port: int | None) -> None:
     if bind_port:
         settings.bind_port = bind_port
 
+    # Local convenience (012-web-adopt-pairing, research R5): when serving on a
+    # loopback interface with no operator-auth provider configured, default to
+    # the network-restricted posture so single-machine `remo web serve` can
+    # mint pairing codes without a proxy. The service still logs this weaker
+    # posture loudly (FR-013); a non-loopback bind is left untouched so a real
+    # deployment must configure forward auth explicitly.
+    _LOOPBACK = {"127.0.0.1", "localhost", "::1"}
+    if not settings.operator_auth and settings.bind_host in _LOOPBACK:
+        settings.operator_auth = "none"
+
     # Ensure the ControlMaster socket dir is usable (create it, or fall back to
     # a per-user dir for local runs where the container's /run/remo-ssh tmpfs
     # doesn't exist). Do this BEFORE exporting REMO_SSH_CONTROL_DIR / building
@@ -102,7 +112,16 @@ def serve(bind_host: str | None, bind_port: int | None) -> None:
     # instead of an explicit control_dir=.
     os.environ["REMO_SSH_CONTROL_DIR"] = settings.ssh_control_dir
 
-    app = create_app(settings)
+    # create_app fail-fasts on an invalid operator-auth posture (forward auth
+    # enabled without REMO_WEB_FORWARD_AUTH_HEADER); surface it as a clean
+    # error instead of a raw traceback (Constitution IV, fail fast with a clear
+    # message).
+    from remo_cli.web.operator_auth import OperatorAuthConfigError  # noqa: PLC0415
+
+    try:
+        app = create_app(settings)
+    except OperatorAuthConfigError as e:
+        raise SystemExit(f"Configuration error: {e}") from e
 
     # "logs a ready readiness state" (quickstart.md section A): this line,
     # combined with uvicorn's own "Application startup complete" log emitted
@@ -170,7 +189,7 @@ def check(skip_instance_checks: bool) -> None:
 @click.option(
     "--token",
     default=None,
-    help="Setup API token (falls back to REMO_API_TOKEN, then a hidden prompt).",
+    help="Pairing code (falls back to REMO_API_TOKEN, then a hidden prompt).",
 )
 @click.option(
     "--via",
@@ -196,15 +215,8 @@ def check(skip_instance_checks: bool) -> None:
     default=False,
     help=(
         "Non-interactive: skip fingerprint prompts (unverified instances are "
-        "reported as skipped_no_trust) and never prompt to save credentials."
+        "reported as skipped_no_trust)."
     ),
-)
-@click.option(
-    "--save",
-    "save_credentials_flag",
-    is_flag=True,
-    default=False,
-    help="Save the service URL and token to ~/.config/remo/web-service.json (0600) on success.",
 )
 def adopt(
     url: str | None,
@@ -212,21 +224,23 @@ def adopt(
     via_host: str | None,
     allow_empty: bool,
     assume_yes: bool,
-    save_credentials_flag: bool,
 ) -> None:
     """Adopt a running remo web service from this workstation.
 
-    Pushes the local registry (full mirror) plus verified SSH host keys to the
-    service and authorizes the service's SSH key on each reachable
-    direct-access instance, then runs a service-side verification pass.
+    Open the service's awaiting-adoption page in a browser, click "Copy pairing
+    code", then run this command and paste the code when prompted. It pushes the
+    local registry (full mirror) plus verified SSH host keys to the service and
+    authorizes the service's SSH key on each reachable direct-access instance,
+    then runs a service-side verification pass.
 
     URL resolution: argument, then $REMO_API_URL, then an interactive prompt.
-    Token resolution: --token, then $REMO_API_TOKEN, then a hidden prompt.
+    Pairing code: --token, then $REMO_API_TOKEN, then a hidden prompt. Nothing
+    is saved — a later `remo web push` gets a fresh code the same way.
 
     Exits 0 when the flow completes (per-instance skips/flags are reported in
-    the summary, not fatal); exits 1 on hard failure (auth, mount-configured
-    deployment, empty registry without --allow-empty, tunnel failure, payload
-    rejected).
+    the summary, not fatal); exits 1 on hard failure (dormant setup surface,
+    mount-configured deployment, empty registry without --allow-empty, tunnel
+    failure, payload rejected).
     """
     # Deliberately imports only remo_cli.core.* — `remo web adopt` must work
     # without the `web` extra installed (stdlib HTTP only, research R9).
@@ -234,18 +248,17 @@ def adopt(
     from remo_cli.core.web_adopt import AdoptError, run_adopt  # noqa: PLC0415
 
     resolved_url = url or os.environ.get("REMO_API_URL") or click.prompt("Service URL")
-    resolved_token = (
-        token or os.environ.get("REMO_API_TOKEN") or click.prompt("API token", hide_input=True)
+    resolved_code = (
+        token or os.environ.get("REMO_API_TOKEN") or click.prompt("Pairing code", hide_input=True)
     )
 
     try:
         run_adopt(
             resolved_url,
-            resolved_token,
+            resolved_code,
             via=via_host,
             allow_empty=allow_empty,
             assume_yes=assume_yes,
-            save=save_credentials_flag,
         )
     except AdoptError as e:
         print_error(str(e))
@@ -253,6 +266,22 @@ def adopt(
 
 
 @web.command()
+@click.argument("url", required=False, default=None)
+@click.option(
+    "--token",
+    default=None,
+    help="Pairing code (falls back to REMO_API_TOKEN, then a hidden prompt).",
+)
+@click.option(
+    "--via",
+    "via_host",
+    default=None,
+    metavar="HOST",
+    help=(
+        "SSH host to tunnel through (see `remo web adopt --via`). Requires "
+        "127.0.0.1 in the service's REMO_WEB_ALLOWED_HOSTS."
+    ),
+)
 @click.option(
     "--allow-empty",
     is_flag=True,
@@ -269,49 +298,45 @@ def adopt(
         "(unverified instances are reported as skipped_no_trust)."
     ),
 )
-def push(allow_empty: bool, assume_yes: bool) -> None:
-    """Re-sync the local registry to the adopted remo web service.
+def push(
+    url: str | None,
+    token: str | None,
+    via_host: str | None,
+    allow_empty: bool,
+    assume_yes: bool,
+) -> None:
+    """Re-sync the local registry to an adopted remo web service.
 
-    Zero-argument push (uses the URL/token saved by `remo web adopt`):
-    updates the service's registry (full mirror — removals propagate), pushes
-    host keys, and authorizes the service's identity on new or changed
-    direct-access instances. Instances unchanged since the last push skip the
-    keyscan/authorize work and are reported as `unchanged`.
+    Open the dashboard's "Pair CLI to sync" affordance, click to copy a fresh
+    pairing code, then run this command and paste it. It updates the service's
+    registry (full mirror — removals propagate), pushes host keys, and authorizes
+    the service's identity on new or changed direct-access instances. Instances
+    unchanged since the last push skip the keyscan/authorize work and are
+    reported as `unchanged`.
 
-    When no credentials were saved, falls back to the first-time adopt flow
-    (URL from $REMO_API_URL or a prompt, token from $REMO_API_TOKEN or a
-    hidden prompt, including the save offer). A saved token the service now
-    rejects, or a changed service identity, exits 1 with re-adopt guidance.
+    URL resolution: argument, then $REMO_API_URL, then an interactive prompt.
+    Pairing code: --token, then $REMO_API_TOKEN, then a hidden prompt. Nothing
+    is saved between runs — every push gets a fresh code from the page.
 
     Exits 0 when the flow completes (per-instance skips/flags are reported in
-    the summary, not fatal); exits 1 on hard failure.
+    the summary, not fatal); exits 1 on hard failure (dormant setup surface,
+    mount-configured deployment, empty registry without --allow-empty).
     """
     # Deliberately imports only remo_cli.core.* — `remo web push` must work
     # without the `web` extra installed (stdlib HTTP only, research R9).
-    from remo_cli.core.output import print_error, print_info  # noqa: PLC0415
-    from remo_cli.core.web_adopt import (  # noqa: PLC0415
-        AdoptError,
-        MissingCredentialsError,
-        run_adopt,
-        run_push,
+    from remo_cli.core.output import print_error  # noqa: PLC0415
+    from remo_cli.core.web_adopt import AdoptError, run_push  # noqa: PLC0415
+
+    resolved_url = url or os.environ.get("REMO_API_URL") or click.prompt("Service URL")
+    resolved_code = (
+        token or os.environ.get("REMO_API_TOKEN") or click.prompt("Pairing code", hide_input=True)
     )
 
     try:
-        try:
-            run_push(allow_empty=allow_empty, assume_yes=assume_yes)
-            return
-        except MissingCredentialsError as e:
-            # US4 scenario 4: no saved credentials -> behave like first-time
-            # adopt, prompting for URL/token and offering to save on success.
-            print_info(f"{e} Running the first-time adopt flow instead.")
-
-        resolved_url = os.environ.get("REMO_API_URL") or click.prompt("Service URL")
-        resolved_token = os.environ.get("REMO_API_TOKEN") or click.prompt(
-            "API token", hide_input=True
-        )
-        run_adopt(
+        run_push(
             resolved_url,
-            resolved_token,
+            resolved_code,
+            via=via_host,
             allow_empty=allow_empty,
             assume_yes=assume_yes,
         )

--- a/src/remo_cli/core/web_adopt.py
+++ b/src/remo_cli/core/web_adopt.py
@@ -11,32 +11,42 @@ Implements the CLI half of specs/011-web-adopt/contracts/cli-web-adopt.md:
 * Idempotent ``authorized_keys`` management on instances (research R7, FR-011).
 * ``--via`` SSH local-forward tunnel helper (research R9, FR-018).
 * Adopt orchestration (contract flow steps 1-7, FR-013/FR-014/FR-015/FR-017).
-* Saved-credentials read/write (research R10, FR-025) — reused by
-  ``remo web push`` (US4).
-* Push orchestration (``run_push``, US4 / FR-026 / FR-027).
+* Non-secret push cache read/write (012 R10) — reused by ``remo web push``.
+* Push orchestration (``run_push``, US4).
 
-Push delta-cache design (FR-026)
---------------------------------
+Credential model (012-web-adopt-pairing)
+----------------------------------------
 
-The service has no registry-read endpoint, so "unchanged since the last
-push" is decided workstation-side: the saved-credentials file
-(``~/.config/remo/web-service.json``) carries a backward-compatible
-``push_cache`` field mapping each successfully adopted instance *name* to
+011 sent a static ``REMO_WEB_API_TOKEN`` and saved it (with the URL) for later
+``remo web push``. 012 replaces that with an **ephemeral pairing code** minted
+by the adopt page: the CLI sends whatever code it is handed as the bearer, and
+**nothing durable is persisted** (FR-018/FR-019). Both ``adopt`` and ``push``
+resolve URL + code the same way every time (option / env / prompt). When a
+setup call returns the dormant ``404`` (the code expired or was rotated by a
+page reopen), the CLI tells the operator to reopen the page for a fresh code
+(FR-020).
 
-* a ``fingerprint`` — SHA256 over the canonical registry-entry fields
-  (type/name/host/user/instance_id/access_mode/region), and
-* the verified ``host_keys`` lines that were pushed for it.
+Push delta-cache design (non-secret optimization)
+-------------------------------------------------
 
-On ``remo web push``, a direct-access instance whose current fingerprint
-matches the cache skips keyscan + authorize (reported as ``unchanged``) and
-its cached host-key lines are reused in the payload — necessary because
-``PUT /setup/registry`` replaces the service's known_hosts wholesale, so
-every mirrored instance must contribute its lines on every push. New or
-changed instances get the full adopt treatment. The full registry mirror is
-always PUT regardless (clarification Q1: removals propagate; the service
-identity is NOT auto-de-authorized on removed instances — that stays a
-manual, documented action). The cache is rewritten atomically (0600) only
-after a successful PUT.
+The service has no registry-read endpoint, so "unchanged since the last push"
+is decided workstation-side by a **non-secret** cache
+(``~/.config/remo/web-service.json``) mapping each service ``deployment_id`` to
+``{instance name -> {fingerprint, host_keys}}`` — no URL and no code are ever
+stored. The ``fingerprint`` is a SHA256 over the canonical registry-entry fields
+(type/name/host/user/instance_id/access_mode/region) and ``host_keys`` are the
+verified known_hosts lines pushed for that instance.
+
+On ``remo web push``, a direct-access instance whose current fingerprint matches
+the cache for the service's ``deployment_id`` skips keyscan + authorize
+(reported as ``unchanged``) and its cached host-key lines are reused in the
+payload — necessary because ``PUT /setup/registry`` replaces the service's
+known_hosts wholesale, so every mirrored instance must contribute its lines on
+every push. New or changed instances get the full adopt treatment. The full
+registry mirror is always PUT regardless (removals propagate; the service
+identity is NOT auto-de-authorized on removed instances — that stays a manual,
+documented action). The cache is rewritten atomically (0600) only after a
+successful PUT.
 """
 
 from __future__ import annotations
@@ -128,11 +138,11 @@ class SetupApiError(AdoptError):
 
 
 class SetupAuthError(SetupApiError):
-    """401 — the service rejected the API token."""
+    """401 — legacy auth rejection (012: the setup surface returns 404 instead)."""
 
 
 class SetupNotFoundError(SetupApiError):
-    """404 — setup surface disabled (no token configured) or wrong URL."""
+    """404 — dormant setup surface (code expired/rotated / no live session) or wrong URL."""
 
 
 class MountConfiguredError(SetupApiError):
@@ -157,14 +167,6 @@ class EmptyRegistryError(AdoptError):
 
 class TunnelError(AdoptError):
     """The --via SSH tunnel could not be established (FR-018)."""
-
-
-class MissingCredentialsError(AdoptError):
-    """`remo web push` found no saved credentials (US4 scenario 4 / FR-027).
-
-    The CLI catches this specifically and falls back to the first-time adopt
-    flow (URL/token prompts + save offer) instead of exiting 1.
-    """
 
 
 # ---------------------------------------------------------------------------
@@ -272,15 +274,18 @@ class SetupApiClient:
 
         if status == 401:
             return SetupAuthError(
-                "the service rejected the API token (HTTP 401). Check the token "
-                "against the service's REMO_WEB_API_TOKEN and try again.",
+                "the service returned HTTP 401. Reopen the adopt page (or the "
+                "dashboard's re-sync affordance) to mint a fresh pairing code, "
+                "then retry.",
                 status=401,
             )
         if status == 404:
             return SetupNotFoundError(
-                f"setup API not found at {self.base_url} (HTTP 404). Either the URL "
-                "is wrong, or the service has no REMO_WEB_API_TOKEN configured — "
-                "without a token the setup surface is disabled.",
+                f"the pairing code is no longer valid — the setup surface at "
+                f"{self.base_url} is dormant (HTTP 404). The code may have expired "
+                "or been rotated by a page reopen (or the URL is wrong). Reopen "
+                "the adopt page (or the dashboard's re-sync affordance) to mint a "
+                "fresh code, then retry.",
                 status=404,
             )
         if status == 409:
@@ -701,31 +706,22 @@ def open_via_tunnel(
 
 
 # ---------------------------------------------------------------------------
-# Saved adoption credentials (research R10, FR-025) — used at the end of a
-# successful adopt and by `remo web push` (US4).
+# Non-secret push cache (012 R10) — accelerates re-push by skipping keyscan/
+# authorize for unchanged instances. Keyed by the service deployment_id; holds
+# NO url and NO pairing code (nothing durable is persisted, FR-019).
 # ---------------------------------------------------------------------------
 
 
 @dataclass
 class CachedInstance:
-    """Per-instance delta-cache entry from the last successful push (FR-026)."""
+    """Per-instance delta-cache entry from the last successful push."""
 
     fingerprint: str
     host_keys: list[str] = field(default_factory=list)
 
 
-@dataclass
-class SavedCredentials:
-    url: str
-    token: str
-    deployment_id: str
-    #: Delta cache keyed by registry entry name (see module docstring).
-    #: Backward-compatible: absent/malformed in the file -> empty dict.
-    push_cache: dict[str, CachedInstance] = field(default_factory=dict)
-
-
 def instance_fingerprint(host: KnownHost) -> str:
-    """SHA256 over the canonical registry-entry fields of *host* (FR-026).
+    """SHA256 over the canonical registry-entry fields of *host*.
 
     Any change to the fields the service mirrors (host, user, access mode, …)
     changes the fingerprint, forcing the full keyscan+authorize treatment on
@@ -735,16 +731,20 @@ def instance_fingerprint(host: KnownHost) -> str:
     return hashlib.sha256(canonical.encode("utf-8")).hexdigest()
 
 
-def credentials_path() -> Path:
-    """Path of the saved-credentials file (``~/.config/remo/web-service.json``)."""
+#: Push cache shape: deployment_id -> {instance name -> CachedInstance}.
+PushCache = dict[str, dict[str, "CachedInstance"]]
+
+
+def push_cache_path() -> Path:
+    """Path of the non-secret push cache (``~/.config/remo/web-service.json``)."""
     return get_remo_home_readonly() / "web-service.json"
 
 
-def _parse_push_cache(raw: object) -> dict[str, CachedInstance]:
-    """Leniently parse the optional ``push_cache`` field; junk -> dropped."""
-    cache: dict[str, CachedInstance] = {}
+def _parse_instances(raw: object) -> dict[str, CachedInstance]:
+    """Leniently parse one deployment's ``{name -> {fingerprint, host_keys}}``."""
+    instances: dict[str, CachedInstance] = {}
     if not isinstance(raw, dict):
-        return cache
+        return instances
     for name, entry in raw.items():
         if not (isinstance(name, str) and isinstance(entry, dict)):
             continue
@@ -754,57 +754,55 @@ def _parse_push_cache(raw: object) -> dict[str, CachedInstance]:
             continue
         if not (isinstance(host_keys, list) and all(isinstance(k, str) for k in host_keys)):
             host_keys = []
-        cache[name] = CachedInstance(fingerprint=fingerprint, host_keys=list(host_keys))
-    return cache
+        instances[name] = CachedInstance(fingerprint=fingerprint, host_keys=list(host_keys))
+    return instances
 
 
-def load_saved_credentials() -> SavedCredentials | None:
-    """Load saved credentials, or None when absent/unreadable/malformed.
+def load_push_cache() -> PushCache:
+    """Load the deployment-keyed push cache, or ``{}`` when absent/unreadable.
 
-    Files written before the push delta cache existed (no ``push_cache``
-    field) load fine with an empty cache.
+    Files written by the 011 credential format (top-level ``url``/``token`` +
+    name-keyed ``push_cache``) do not match the deployment-keyed shape and are
+    ignored (they parse to an empty cache), so the next push simply retries in
+    full and the next save overwrites the stale file — no secret is ever read.
     """
-    path = credentials_path()
+    path = push_cache_path()
     try:
         parsed = json.loads(path.read_text())
     except (OSError, json.JSONDecodeError):
-        return None
+        return {}
     if not isinstance(parsed, dict):
-        return None
-    url = parsed.get("url")
-    token = parsed.get("token")
-    deployment_id = parsed.get("deployment_id")
-    if not (isinstance(url, str) and isinstance(token, str) and isinstance(deployment_id, str)):
-        return None
-    return SavedCredentials(
-        url=url,
-        token=token,
-        deployment_id=deployment_id,
-        push_cache=_parse_push_cache(parsed.get("push_cache")),
-    )
+        return {}
+    raw_cache = parsed.get("push_cache")
+    if not isinstance(raw_cache, dict):
+        return {}
+    cache: PushCache = {}
+    for deployment_id, instances in raw_cache.items():
+        if not isinstance(deployment_id, str):
+            continue
+        parsed_instances = _parse_instances(instances)
+        if parsed_instances:
+            cache[deployment_id] = parsed_instances
+    return cache
 
 
-def save_credentials(credentials: SavedCredentials) -> Path:
-    """Write credentials to ``credentials_path()`` atomically with 0600 perms.
+def save_push_cache(cache: PushCache) -> Path:
+    """Write the push cache to ``push_cache_path()`` atomically with 0600 perms.
 
-    Creating the file requires explicit consent (``--save`` or an interactive
-    yes) — FR-025; the caller enforces that. Rewriting an existing file (e.g.
-    the push delta-cache update) needs no new consent. Written via temp-file
-    + ``os.replace`` in the same directory so a crash never leaves a partial
-    or world-readable file; 0600 is enforced even when overwriting a file
-    that pre-existed with wider permissions.
+    The cache holds no secret (no url, no code), but it is written 0600 anyway
+    via temp-file + ``os.replace`` so a crash never leaves a partial file.
     """
-    path = credentials_path()
+    path = push_cache_path()
     path.parent.mkdir(parents=True, exist_ok=True)
     payload = json.dumps(
         {
-            "url": credentials.url,
-            "token": credentials.token,
-            "deployment_id": credentials.deployment_id,
             "push_cache": {
-                name: {"fingerprint": c.fingerprint, "host_keys": c.host_keys}
-                for name, c in credentials.push_cache.items()
-            },
+                deployment_id: {
+                    name: {"fingerprint": c.fingerprint, "host_keys": c.host_keys}
+                    for name, c in instances.items()
+                }
+                for deployment_id, instances in cache.items()
+            }
         },
         indent=2,
     )
@@ -820,7 +818,7 @@ def save_credentials(credentials: SavedCredentials) -> Path:
         except OSError:
             pass
         raise
-    os.chmod(path, 0o600)  # replace preserves the temp perms; belt-and-braces
+    os.chmod(path, 0o600)
     return path
 
 
@@ -969,6 +967,20 @@ def _cache_from_outcomes(
     return cache
 
 
+def _update_push_cache(deployment_id: str, instances: dict[str, CachedInstance]) -> None:
+    """Merge one deployment's entry into the on-disk push cache (best-effort).
+
+    A write failure is non-fatal: the cache is only an optimization, so a push
+    that cannot persist it still succeeds and simply retries in full next time.
+    """
+    try:
+        cache = load_push_cache()
+        cache[deployment_id] = instances
+        save_push_cache(cache)
+    except OSError as e:
+        print_warning(f"could not update the push cache ({push_cache_path()}): {e}")
+
+
 def render_summary(outcomes: list[InstanceOutcome]) -> None:
     """Render the per-instance summary table (contract output contract)."""
     print()
@@ -1034,6 +1046,33 @@ def render_verification(verify: dict[str, Any], outcomes: list[InstanceOutcome])
         print_warning("Some service-side checks failed (see above).")
 
 
+def _run_flow_maybe_tunneled(
+    url: str,
+    token: str,
+    via: str | None,
+    verb: str,
+    flow: Callable[[SetupApiClient], AdoptResult],
+) -> AdoptResult:
+    """Run *flow* against a `SetupApiClient`, optionally through a `--via` SSH
+    tunnel. A 400/403 seen through the tunnel is remapped to Host-allowlist
+    guidance (FR-018); *verb* ("adopting"/"pushing") tailors that message."""
+    if via:
+        print_info(f"Opening SSH tunnel via {via}...")
+        with open_via_tunnel(via, url) as tunneled_url:
+            try:
+                return flow(SetupApiClient(tunneled_url, token))
+            except SetupApiError as e:
+                if e.status in (400, 403):
+                    raise AdoptError(
+                        f"the service rejected the tunneled request (HTTP {e.status}) "
+                        f"— most likely its Host allowlist. When {verb} through "
+                        "--via, the service's REMO_WEB_ALLOWED_HOSTS must include "
+                        "127.0.0.1."
+                    ) from e
+                raise
+    return flow(SetupApiClient(url, token))
+
+
 def run_adopt(
     url: str,
     token: str,
@@ -1041,54 +1080,27 @@ def run_adopt(
     via: str | None = None,
     allow_empty: bool = False,
     assume_yes: bool = False,
-    save: bool = False,
     interactive: bool | None = None,
 ) -> AdoptResult:
-    """Run the full adopt flow (contract steps 1-7). Raises AdoptError on hard
-    failure; returns an AdoptResult when the flow completed (CLI exit 0, even
-    with per-instance skips/flags)."""
+    """Run the full adopt flow (contract steps 1-7). ``token`` is the pairing
+    code. Raises AdoptError on hard failure; returns an AdoptResult when the
+    flow completed (CLI exit 0, even with per-instance skips/flags)."""
     if interactive is None:
         interactive = sys.stdin.isatty() and not assume_yes
-
-    if via:
-        print_info(f"Opening SSH tunnel via {via}...")
-        with open_via_tunnel(via, url) as tunneled_url:
-            client = SetupApiClient(tunneled_url, token)
-            try:
-                return _adopt_flow(
-                    client,
-                    original_url=url,
-                    allow_empty=allow_empty,
-                    interactive=interactive,
-                    save=save,
-                )
-            except SetupApiError as e:
-                if e.status in (400, 403):
-                    raise AdoptError(
-                        f"the service rejected the tunneled request (HTTP {e.status}) "
-                        "— most likely its Host allowlist. When adopting through "
-                        "--via, the service's REMO_WEB_ALLOWED_HOSTS must include "
-                        "127.0.0.1."
-                    ) from e
-                raise
-
-    client = SetupApiClient(url, token)
-    return _adopt_flow(
-        client,
-        original_url=url,
-        allow_empty=allow_empty,
-        interactive=interactive,
-        save=save,
+    return _run_flow_maybe_tunneled(
+        url,
+        token,
+        via,
+        "adopting",
+        lambda client: _adopt_flow(client, allow_empty=allow_empty, interactive=interactive),
     )
 
 
 def _adopt_flow(
     client: SetupApiClient,
     *,
-    original_url: str,
     allow_empty: bool,
     interactive: bool,
-    save: bool,
 ) -> AdoptResult:
     # Step 1: status precheck (FR-017).
     status = client.get_status()
@@ -1146,27 +1158,12 @@ def _adopt_flow(
     render_summary(outcomes)
     render_verification(verify, outcomes)
 
-    # Step 7: saved-credentials offer (FR-025). --save is explicit consent;
-    # an interactive yes is explicit consent; --yes alone never saves.
-    should_save = save or (
-        interactive
-        and confirm(
-            f"Save service URL and token to {credentials_path()} for `remo web push`?"
-        )
-    )
-    if should_save:
-        # Seed the push delta cache from this run's outcomes so the first
-        # `remo web push` after adoption already skips unchanged instances
-        # (FR-026, module docstring design).
-        saved_path = save_credentials(
-            SavedCredentials(
-                url=original_url,
-                token=client.token,
-                deployment_id=deployment_id,
-                push_cache=_cache_from_outcomes(outcomes, host_keys),
-            )
-        )
-        print_success(f"Credentials saved to {saved_path} (mode 0600).")
+    # Step 7: seed the non-secret push cache from this run's outcomes so the
+    # first `remo web push` after adoption already skips unchanged instances
+    # (012 R10). No consent needed — no url or code is stored (FR-019), only
+    # per-instance fingerprints keyed by the service deployment_id.
+    if deployment_id:
+        _update_push_cache(deployment_id, _cache_from_outcomes(outcomes, host_keys))
 
     return AdoptResult(
         outcomes=outcomes,
@@ -1182,95 +1179,75 @@ def _adopt_flow(
 
 
 def run_push(
+    url: str,
+    token: str,
     *,
+    via: str | None = None,
     allow_empty: bool = False,
     assume_yes: bool = False,
     interactive: bool | None = None,
 ) -> AdoptResult:
-    """Run the zero-argument re-sync flow (`remo web push`, US4).
+    """Run the re-sync flow (`remo web push`, US4). ``token`` is a pairing code.
 
-    Loads saved credentials (absent/unreadable -> MissingCredentialsError, which
-    the CLI maps to the first-time adopt fallback), verifies the service still
-    has the adopted identity, then re-runs the adopt flow with the delta cache
-    applied: instances whose registry entry matches the last successful push
-    skip keyscan/authorize (``unchanged``) and reuse their cached host-key
-    lines; new/changed instances get the full per-instance treatment. The full
-    registry mirror is always PUT (removals propagate — clarification Q1).
-    Raises AdoptError on hard failure; returns AdoptResult on completion.
+    URL + code are supplied every time (option / env / prompt) — nothing durable
+    is saved (FR-018/FR-019). The service's ``deployment_id`` (read from the
+    setup API) selects the matching entry in the non-secret push cache: instances
+    whose registry entry matches the last successful push skip keyscan/authorize
+    (``unchanged``) and reuse their cached host-key lines; new/changed instances
+    get the full per-instance treatment. The full registry mirror is always PUT
+    (removals propagate). Raises AdoptError on hard failure; returns AdoptResult
+    on completion.
     """
-    credentials = load_saved_credentials()
-    if credentials is None:
-        raise MissingCredentialsError(
-            f"no saved service credentials found at {credentials_path()} "
-            "(none were saved during adoption, or the file is unreadable)."
-        )
     if interactive is None:
         interactive = sys.stdin.isatty() and not assume_yes
-
-    client = SetupApiClient(credentials.url, credentials.token)
-    return _push_flow(
-        client, credentials, allow_empty=allow_empty, interactive=interactive
+    return _run_flow_maybe_tunneled(
+        url,
+        token,
+        via,
+        "pushing",
+        lambda client: _push_flow(client, allow_empty=allow_empty, interactive=interactive),
     )
 
 
 def _push_flow(
     client: SetupApiClient,
-    credentials: SavedCredentials,
     *,
     allow_empty: bool,
     interactive: bool,
 ) -> AdoptResult:
-    print_info(f"Using saved credentials from {credentials_path()} ({client.base_url}).")
+    # Step 1: status precheck (FR-017) — a mount-configured service is read-only.
+    status = client.get_status()
+    if str(status.get("state", "unknown")) == "mount_configured":
+        raise MountConfiguredError(_MOUNT_CONFIGURED_MSG)
 
-    # Step 1: identity check — the saved deployment_id must still be the one
-    # running, otherwise the state volume was reset and the saved trust in it
-    # (and every authorized_keys entry the old identity had) is stale.
-    try:
-        identity = client.get_identity()
-    except SetupAuthError as e:
-        # FR-027: rejected saved token -> exit 1 with re-adopt guidance.
-        raise SetupAuthError(
-            f"the service at {client.base_url} rejected the saved API token "
-            "(HTTP 401) — it was probably rotated on the service. Re-run "
-            "`remo web adopt` with the current token to re-authenticate and "
-            "refresh the saved credentials.",
-            status=401,
-        ) from e
-
+    # Step 2: service identity + the push cache entry for this deployment.
+    identity = client.get_identity()
     deployment_id = str(identity.get("deployment_id") or "")
     public_key = str(identity.get("public_key") or "")
-    if deployment_id != credentials.deployment_id:
-        raise AdoptError(
-            "service identity changed (saved deployment_id "
-            f"{credentials.deployment_id or 'unknown'}, service reports "
-            f"{deployment_id or 'unknown'}) — the state volume was reset; "
-            "run `remo web adopt` to re-adopt the service with its new identity."
-        )
     if not public_key:
         raise AdoptError(
             "the service returned no public key, so it cannot be authorized on "
             "any instance. The service identity may be missing — check the "
             "service's state volume and logs."
         )
-    print_info(
-        f"Service identity: remo-web@{deployment_id or 'unknown'} "
-        "(matches saved credentials)"
-    )
+    print_info(f"Service identity: remo-web@{deployment_id or 'unknown'}")
 
-    # Step 2: build the mirror from the local registry (FR-008/FR-016).
+    cached_instances = load_push_cache().get(deployment_id, {})
+
+    # Step 3: build the mirror from the local registry (FR-008/FR-016).
     hosts = get_known_hosts()
     if not hosts and not allow_empty:
         raise EmptyRegistryError(_empty_registry_message())
 
-    # Step 3: per-instance loop with delta detection (FR-026). An instance
-    # whose fingerprint matches the cache skips keyscan/authorize but its
-    # cached host-key lines are REUSED in the payload: PUT /setup/registry
-    # replaces the service's known_hosts wholesale, so every mirrored
-    # direct-access instance must contribute lines on every push.
+    # Step 4: per-instance loop with delta detection. An instance whose
+    # fingerprint matches the cache skips keyscan/authorize but its cached
+    # host-key lines are REUSED in the payload: PUT /setup/registry replaces the
+    # service's known_hosts wholesale, so every mirrored direct-access instance
+    # must contribute lines on every push.
     outcomes: list[InstanceOutcome] = []
     host_keys: dict[str, list[str]] = {}
     for host in hosts:
-        cached = credentials.push_cache.get(host.name)
+        cached = cached_instances.get(host.name)
         if (
             is_direct_access(host)
             and cached is not None
@@ -1296,11 +1273,11 @@ def _push_flow(
             )
         )
 
-    # Instances the last push knew but the mirror no longer contains
-    # (clarification Q1: they drop off the service, revocation stays manual).
-    removed = sorted(set(credentials.push_cache) - {h.name for h in hosts})
+    # Instances the last push knew but the mirror no longer contains (they drop
+    # off the service; revocation stays a manual, documented action).
+    removed = sorted(set(cached_instances) - {h.name for h in hosts})
 
-    # Step 4: always PUT the full mirror (removals propagate).
+    # Step 5: always PUT the full mirror (removals propagate).
     payload = build_adoption_payload(hosts, host_keys, allow_empty=True)
     applied = client.put_registry(payload, allow_empty=allow_empty)
     print_success(
@@ -1308,15 +1285,13 @@ def _push_flow(
         f"host keys for {applied.get('host_key_instances', len(host_keys))}."
     )
 
-    # Step 5: only after a successful PUT, rewrite the delta cache (removed
-    # instances drop out; skipped/flagged instances get no entry so the next
-    # push retries them in full). Rewriting the existing file needs no new
-    # consent (FR-025 covers creation).
-    credentials.push_cache = _cache_from_outcomes(outcomes, host_keys)
-    credentials.deployment_id = deployment_id
-    save_credentials(credentials)
+    # Step 6: only after a successful PUT, rewrite the delta cache for this
+    # deployment (removed instances drop out; skipped/flagged instances get no
+    # entry so the next push retries them in full).
+    if deployment_id:
+        _update_push_cache(deployment_id, _cache_from_outcomes(outcomes, host_keys))
 
-    # Step 6: service-side verification (FR-014), same as adopt.
+    # Step 7: service-side verification (FR-014), same as adopt.
     print_info("Running service-side verification...")
     verify = client.post_verify()
 

--- a/src/remo_cli/web/api/pairing.py
+++ b/src/remo_cli/web/api/pairing.py
@@ -1,0 +1,81 @@
+"""Pairing control-plane router (`/api/v1/pairing/*`, 012-web-adopt-pairing).
+
+These routes live OUTSIDE the dormant `/api/v1/setup/*` router so they are
+reachable while the setup surface is dormant (contracts/pairing-api.md). They
+are browser-facing (`POST` from the SPA's own origin) and therefore subject to
+the existing Origin allowlist middleware — the CLI never calls them.
+
+- ``POST /pairing/mint`` — forward-auth gated (FR-009/FR-011). Rotates + creates
+  the live session and returns ``{code, expires_in}`` with ``Cache-Control:
+  no-store``. The code is the only thing ever transmitted from the server; it is
+  never embedded in the served bundle (FR-016). Refused (403) when the operator
+  is not authenticated, or when no provider is configured (fail closed).
+- ``POST /pairing/end`` — best-effort session end for the page-hide beacon
+  (FR-004). Unauthenticated and idempotent; always ``204``. The idle TTL is the
+  authoritative backstop.
+"""
+
+from __future__ import annotations
+
+import logging
+
+from fastapi import APIRouter, Request, Response
+from fastapi.responses import JSONResponse
+
+from remo_cli.web.operator_auth import OperatorAuthProvider
+from remo_cli.web.pairing import PairingOrigin, PairingSessionManager
+
+logger = logging.getLogger("remo_cli.web.pairing")
+
+router = APIRouter(prefix="/pairing")
+
+
+def _manager(request: Request) -> PairingSessionManager:
+    return request.app.state.pairing_manager
+
+
+def _provider(request: Request) -> OperatorAuthProvider | None:
+    return getattr(request.app.state, "operator_auth_provider", None)
+
+
+@router.post("/mint")
+def mint(request: Request) -> Response:
+    """Mint a fresh pairing code (rotation-on-open, FR-003), operator-auth gated."""
+    provider = _provider(request)
+    if provider is None:
+        # No operator-auth provider configured -> minting disabled (fail closed).
+        client = request.client.host if request.client else "unknown"
+        logger.warning("pairing mint refused from %s: operator auth not configured", client)
+        return JSONResponse(
+            status_code=403, content={"detail": "operator authentication not configured"}
+        )
+
+    identity = provider.authenticate(request)
+    if identity is None:
+        # Authenticated proof absent -> refuse, create no session (FR-011).
+        client = request.client.host if request.client else "unknown"
+        logger.warning(
+            "pairing mint refused from %s: operator authentication required (%s)",
+            client,
+            provider.posture,
+        )
+        return JSONResponse(
+            status_code=403, content={"detail": "operator authentication required"}
+        )
+
+    origin_raw = request.query_params.get("origin", "adopt")
+    origin: PairingOrigin = "resync" if origin_raw == "resync" else "adopt"
+    code, ttl_s = _manager(request).mint(identity, origin)
+    # Record WHO minted (FR-012) — never the code (FR-016).
+    logger.info("pairing code minted for %s (origin=%s)", identity.subject, origin)
+
+    response = JSONResponse(content={"code": code, "expires_in": int(ttl_s)})
+    response.headers["Cache-Control"] = "no-store"
+    return response
+
+
+@router.post("/end")
+def end(request: Request) -> Response:
+    """Best-effort end of the live pairing session (page-hide beacon, FR-004)."""
+    _manager(request).end()
+    return Response(status_code=204)

--- a/src/remo_cli/web/api/setup.py
+++ b/src/remo_cli/web/api/setup.py
@@ -1,18 +1,20 @@
-"""Token-gated setup API router (`/api/v1/setup/*`, 011-web-adopt T008).
+"""Pairing-gated setup API router (`/api/v1/setup/*`).
 
-Authentication contract (contracts/setup-api.md, FR-020/FR-021/FR-024),
-enforced for every route on this router by the `require_setup_token`
-dependency:
+011 gated this surface with a static `REMO_WEB_API_TOKEN` bearer. 012
+(web-adopt-pairing) replaces that with an ephemeral **pairing code**: the
+surface is **dormant** (`404`) unless a live pairing session exists, and it is
+authenticated solely by the live code the CLI carries. Enforced for every route
+on this router by the `require_pairing_code` dependency (contracts/setup-api.md,
+FR-005/FR-006):
 
-- token NOT configured (``REMO_WEB_API_TOKEN`` unset/empty) -> ``404`` on
-  every setup route. Fail closed: the surface is disabled and the response
-  is indistinguishable from an unknown route (same body FastAPI returns for
-  a path that does not exist).
-- token configured + correct ``Authorization: Bearer <token>`` -> the route
-  handles the request. Comparison is constant-time (`hmac.compare_digest`).
-- token configured + missing/wrong header -> ``401 {"detail":
-  "unauthorized"}`` with no further detail; the attempt is logged WITHOUT
-  the presented credential.
+- no live pairing session -> ``404 {"detail": "Not Found"}`` on every setup
+  route, byte-identical to an unknown route (dormant surface, fail closed).
+- live session + correct ``Authorization: Bearer <code>`` -> the route handles
+  the request and the session is touched (sliding idle TTL reset). Comparison
+  is constant-time (`hmac.compare_digest`, inside the manager).
+- live session + absent/wrong/expired-or-rotated code -> the SAME dormant
+  ``404`` (never a distinguishable ``401`` that would reveal a session exists,
+  FR-006). The presented code is NEVER logged (FR-016).
 
 Business endpoints (contracts/setup-api.md is the normative wire contract;
 T011/T012/T013), all inheriting the router-level token dependency:
@@ -33,7 +35,6 @@ T011/T012/T013), all inheriting the router-level token dependency:
 
 from __future__ import annotations
 
-import hmac
 import logging
 import re
 from typing import Any
@@ -63,34 +64,42 @@ def _get_settings(request: Request) -> WebSettings:
     return getattr(request.app.state, "settings", None) or WebSettings()
 
 
-async def require_setup_token(request: Request) -> None:
-    """Bearer-token gate shared by every setup route (research R4)."""
-    configured = _get_settings(request).api_token.strip()
-    if not configured:
-        # No token configured: the setup surface does not exist. Mirror
-        # FastAPI's default unknown-route response exactly (FR-021).
-        raise HTTPException(status_code=404, detail="Not Found")
+def _dormant() -> HTTPException:
+    """The dormant response — byte-identical to FastAPI's default unknown-route
+    404 (FR-005/FR-006). A fresh instance per raise (never a shared singleton,
+    which would accumulate traceback/context state)."""
+    return HTTPException(status_code=404, detail="Not Found")
+
+
+async def require_pairing_code(request: Request) -> None:
+    """Pairing-code gate shared by every setup route (FR-005/FR-006).
+
+    Dormant ``404`` unless a live pairing session exists AND the bearer matches
+    the live code. A missing/wrong/expired code is indistinguishable from a
+    dormant surface (same ``404``, never a ``401``). On success the session's
+    sliding idle TTL is reset. The presented code is never logged (FR-016).
+    """
+    manager = request.app.state.pairing_manager
+    if not manager.is_live():
+        raise _dormant()
 
     header = request.headers.get("authorization", "")
     scheme, _, presented = header.partition(" ")
-    if scheme.lower() == "bearer" and hmac.compare_digest(
-        presented.strip().encode(), configured.encode()
-    ):
+    if scheme.lower() == "bearer" and manager.authenticate(presented.strip()) is not None:
         return
 
-    # Log the failure with route/method context, never the presented
-    # credential (FR-024).
+    # Log the failure with route/method context, never the presented credential.
     client = request.client.host if request.client else "unknown"
     logger.warning(
-        "setup API authentication failure from %s: %s %s",
+        "setup API request against no valid pairing code from %s: %s %s",
         client,
         request.method,
         request.url.path,
     )
-    raise HTTPException(status_code=401, detail="unauthorized")
+    raise _dormant()
 
 
-router = APIRouter(prefix="/setup", dependencies=[Depends(require_setup_token)])
+router = APIRouter(prefix="/setup", dependencies=[Depends(require_pairing_code)])
 
 
 # ---------------------------------------------------------------------------
@@ -380,6 +389,15 @@ def post_verify(request: Request) -> VerifyResponse:
     """
     settings = _get_settings(request)
     results = web_check.run_checks(settings, include_instances=True)
+
+    # The verification pass is the terminal authenticated step of both the
+    # adopt and push flows (status -> identity -> registry -> verify). Ending
+    # the session here returns the setup surface to dormant once the flow
+    # completes (FR-007) without severing the in-flight verify call that ending
+    # on the registry PUT would have broken. If a client skips verify, the idle
+    # TTL / page-hide beacon remain the backstop.
+    request.app.state.pairing_manager.end()
+
     return VerifyResponse(
         results=[
             VerifyCheckOut(

--- a/src/remo_cli/web/app.py
+++ b/src/remo_cli/web/app.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 
 import asyncio
 import logging
+import os
 from collections.abc import AsyncIterator
 from contextlib import asynccontextmanager
 from pathlib import Path
@@ -22,12 +23,15 @@ from fastapi.staticfiles import StaticFiles
 from starlette.middleware.trustedhost import TrustedHostMiddleware
 
 from remo_cli.web.api.hosts import router as hosts_router
+from remo_cli.web.api.pairing import router as pairing_router
 from remo_cli.web.api.setup import router as setup_router
 from remo_cli.web.api.terminals import router as terminals_router
 from remo_cli.web.config import WebSettings
 from remo_cli.web.discovery import DiscoveryService
 from remo_cli.web.health import router as health_router
 from remo_cli.web.logging_config import configure_logging
+from remo_cli.web.operator_auth import build_operator_auth_provider
+from remo_cli.web.pairing import PairingSessionManager
 from remo_cli.web.ssh_master import stale_socket_cleanup
 from remo_cli.web.state import (
     ConfigurationState,
@@ -100,6 +104,38 @@ def create_app(settings: WebSettings | None = None) -> FastAPI:
     # module docstring for what this does and does not guarantee.
     configure_logging()
 
+    # --- Ephemeral pairing (012-web-adopt-pairing) ------------------------
+    # Construct the operator-auth provider FAIL-FAST at app-build time (FR-009):
+    # forward auth without a header name raises here and aborts `remo web serve`
+    # before the socket is bound. `None` means minting is disabled (fail closed).
+    operator_auth_provider = build_operator_auth_provider(settings)
+    if os.environ.get("REMO_WEB_API_TOKEN"):
+        # 011's static token gate is removed (FR-021); a stale value is inert.
+        logger.info(
+            "REMO_WEB_API_TOKEN is set but is now ignored; the setup surface is "
+            "authorized by ephemeral pairing codes (see docs)."
+        )
+    if operator_auth_provider is None:
+        logger.info(
+            "operator authentication is not configured: pairing-code minting is "
+            "disabled. Set REMO_WEB_OPERATOR_AUTH=forward (with "
+            "REMO_WEB_FORWARD_AUTH_HEADER) for a proxy front door, or =none for "
+            "the network-restricted posture."
+        )
+    elif operator_auth_provider.posture == "network-restricted":
+        # FR-013: the weaker posture is never entered silently.
+        logger.warning(
+            "operator authentication is in the NETWORK-RESTRICTED posture: "
+            "pairing codes are minted WITHOUT operator authentication. Use this "
+            "only for loopback/private deployments; put a forward-auth proxy in "
+            "front for anything reachable by others."
+        )
+    else:
+        logger.info(
+            "operator authentication: forward auth (trusted header %r).",
+            settings.forward_auth_header,
+        )
+
     @asynccontextmanager
     async def _lifespan(app: FastAPI) -> AsyncIterator[None]:
         # Startup (011-web-adopt T030/FR-002, research R3): mint the service
@@ -152,6 +188,8 @@ def create_app(settings: WebSettings | None = None) -> FastAPI:
     app.state.shutting_down = False
     app.state.discovery_service = DiscoveryService(settings)
     app.state.terminal_registry = TerminalRegistry(settings)
+    app.state.pairing_manager = PairingSessionManager(ttl_s=settings.pairing_ttl_s)
+    app.state.operator_auth_provider = operator_auth_provider
 
     # --- Host allowlist (FR-048) -----------------------------------------
     # settings.allowed_hosts is never empty (WebSettings defaults to
@@ -204,6 +242,7 @@ def create_app(settings: WebSettings | None = None) -> FastAPI:
     app.include_router(hosts_router, prefix="/api/v1")
     app.include_router(terminals_router, prefix="/api/v1")
     app.include_router(setup_router, prefix="/api/v1")
+    app.include_router(pairing_router, prefix="/api/v1")
 
     # --- Same-origin frontend static files (FR-038, no CDN) -----------------
     # The built frontend won't exist until the Docker image build stage (or a

--- a/src/remo_cli/web/check.py
+++ b/src/remo_cli/web/check.py
@@ -50,6 +50,7 @@ from remo_cli.core.ssh import build_ssh_base_cmd
 from remo_cli.models.host import KnownHost
 from remo_cli.web import health
 from remo_cli.web.config import WebSettings
+from remo_cli.web.operator_auth import OperatorAuthConfigError, build_operator_auth_provider
 from remo_cli.web.state import ConfigurationState, detect_state
 from remo_cli.web.discovery import (
     _classify_ssh_transport,
@@ -135,6 +136,48 @@ def _configuration_check(state: ConfigurationState) -> CheckResult:
         False,
         "configuration present but unusable (broken)",
         _REMEDIATE_BROKEN,
+    )
+
+
+def _operator_auth_check(settings: WebSettings) -> CheckResult:
+    """Report the operator-authentication posture that gates pairing-code minting.
+
+    (012-web-adopt-pairing, FR-013): forward auth is the recommended posture;
+    network-restricted is a valid but weaker opt-in (flagged); unconfigured means
+    minting is disabled (no adoption possible until a provider is set — a warning,
+    not a hard failure of the startup gate). Forward auth enabled without a header
+    name is a fail-fast config error and FAILS here.
+    """
+    try:
+        provider = build_operator_auth_provider(settings)
+    except OperatorAuthConfigError as exc:
+        return CheckResult(
+            "operator_auth",
+            False,
+            str(exc),
+            "Set REMO_WEB_FORWARD_AUTH_HEADER, or REMO_WEB_OPERATOR_AUTH=none for "
+            "the network-restricted posture.",
+        )
+    if provider is None:
+        return CheckResult(
+            "operator_auth",
+            True,
+            "not configured — pairing-code minting is DISABLED (no adoption "
+            "possible until a provider is set)",
+            "Set REMO_WEB_OPERATOR_AUTH=forward (with REMO_WEB_FORWARD_AUTH_HEADER) "
+            "for a proxy front door, or =none for loopback/dev.",
+        )
+    if provider.posture == "network-restricted":
+        return CheckResult(
+            "operator_auth",
+            True,
+            "network-restricted — codes minted WITHOUT operator auth (weaker; "
+            "use only for loopback/private deployments)",
+        )
+    return CheckResult(
+        "operator_auth",
+        True,
+        f"forward auth (trusted header {settings.forward_auth_header!r})",
     )
 
 
@@ -264,6 +307,7 @@ def run_checks(
     if state is ConfigurationState.UNCONFIGURED:
         return [
             _configuration_check(state),
+            _operator_auth_check(settings),
             _runtime_dir_check(settings.ssh_control_dir),
             _executable_check("ssh", "ssh"),
         ]
@@ -272,6 +316,7 @@ def run_checks(
 
     results = [
         _configuration_check(state),
+        _operator_auth_check(settings),
         _registry_check(hosts),
         _ssh_identity_check(settings),
         _runtime_dir_check(settings.ssh_control_dir),

--- a/src/remo_cli/web/config.py
+++ b/src/remo_cli/web/config.py
@@ -121,10 +121,30 @@ class WebSettings:
     # Directory the built frontend SPA is served from (same-origin, FR-038).
     frontend_dist_dir: Path = field(default_factory=_default_frontend_dist_dir)
 
-    # Setup API bearer token (011-web-adopt, FR-020/FR-021). Unset or empty
-    # means "not configured": the entire /api/v1/setup surface is disabled
-    # (404 on every setup route -- fail closed, see web/api/setup.py).
-    api_token: str = field(default_factory=lambda: _env_str("API_TOKEN", "").strip())
+    # -- Ephemeral device pairing (012-web-adopt-pairing) -------------------
+    #
+    # The static REMO_WEB_API_TOKEN gate of 011 is removed (FR-021). The
+    # /api/v1/setup surface is now dormant (404) unless a live pairing session
+    # exists; a session is minted from the adopt page and gated by operator
+    # authentication (see web/pairing.py + web/operator_auth.py).
+
+    # Sliding idle TTL for a pairing session, seconds (FR-002, default 15 min).
+    pairing_ttl_s: float = field(default_factory=lambda: _env_float("PAIRING_TTL_S", 900.0))
+
+    # Operator-authentication mode gating the browser mint endpoint (FR-009):
+    #   "forward" -> require a trusted proxy-injected identity header
+    #                (forward_auth_header MUST be set; fail-fast otherwise).
+    #   "none"    -> network-restricted posture: mint without a credential
+    #                (loud, explicit opt-in for loopback/dev, FR-013).
+    #   ""        -> unset: minting is disabled (mint returns 403; fail closed).
+    operator_auth: str = field(default_factory=lambda: _env_str("OPERATOR_AUTH", "").strip())
+
+    # Trusted forward-auth identity header name (FR-009). No baked-in default:
+    # it varies by proxy (X-Forwarded-User, Remote-User, ...) and enabling
+    # forward auth without naming it is a fail-fast config error.
+    forward_auth_header: str = field(
+        default_factory=lambda: _env_str("FORWARD_AUTH_HEADER", "").strip()
+    )
 
     # Service identity state directory (011-web-adopt, research R1).
     # Everything the adopted service owns lives under

--- a/src/remo_cli/web/health.py
+++ b/src/remo_cli/web/health.py
@@ -75,6 +75,12 @@ async def ready(request: Request) -> JSONResponse:
         "ssh": ssh_status,
         "aws_cli": aws_cli_status,
         "ssm_plugin": ssm_plugin_status,
+        # Additive operator-auth posture (012-web-adopt-pairing, FR-013): a
+        # constant diagnostic that surfaces the weaker network-restricted mode.
+        # It is independent of pairing-session state (dormant/live/post-adoption)
+        # so readiness output stays byte-stable across those states (SC-008),
+        # and it never gates readiness (not read by required_ok below).
+        "operator_auth": _operator_auth_posture(settings),
     }
 
     # Unconfigured is a *healthy* 200 state (research R11): the container is
@@ -133,6 +139,23 @@ async def ready(request: Request) -> JSONResponse:
             "detail": detail,
         },
     )
+
+
+def _operator_auth_posture(settings: WebSettings) -> str:
+    """Label the operator-auth posture for readiness diagnostics (FR-013).
+
+    Derived directly from config (never raises) so readiness is robust: the
+    fail-fast for forward-auth-without-a-header lives in app startup, so a
+    running service is always in a valid posture.
+    """
+    mode = settings.operator_auth.strip().lower()
+    if mode == "forward":
+        return "forward"
+    if mode == "none":
+        return "network-restricted"
+    if mode == "":
+        return "unconfigured"
+    return "unknown"
 
 
 def _check_registry() -> str:

--- a/src/remo_cli/web/logging_config.py
+++ b/src/remo_cli/web/logging_config.py
@@ -57,6 +57,13 @@ _AUTHORIZATION_HEADER_RE = re.compile(
 #: length keeps prose like "bearer of" from being mangled.
 _BEARER_TOKEN_RE = re.compile(r"(?i)\b(bearer)\s+[A-Za-z0-9._~+/=-]{8,}")
 
+#: Pairing-code values (012-web-adopt-pairing, FR-016) appearing in a `code`
+#: key/assignment context, e.g. a naively logged mint response
+#: (`{"code": "xY9...">`, `code=xY9...`). The 16-char minimum keeps ordinary
+#: prose containing the word "code" from being mangled; a real pairing code is
+#: `secrets.token_urlsafe(24)` (~32 url-safe chars).
+_PAIRING_CODE_RE = re.compile(r"(?i)\b(code)\b[\"']?\s*[=:]\s*[\"']?[A-Za-z0-9_-]{16,}")
+
 #: PEM-encoded private key material, any key type, whole block.
 _PRIVATE_KEY_RE = re.compile(
     r"-----BEGIN [A-Z0-9 ]*PRIVATE KEY-----[\s\S]*?-----END [A-Z0-9 ]*PRIVATE KEY-----"
@@ -85,6 +92,7 @@ class RedactingFilter(logging.Filter):
         redacted = _PROXY_COMMAND_RE.sub(lambda m: f"{m.group(1)}={_REDACTED}", redacted)
         redacted = _AUTHORIZATION_HEADER_RE.sub(lambda m: f"{m.group(1)}={_REDACTED}", redacted)
         redacted = _BEARER_TOKEN_RE.sub(lambda m: f"{m.group(1)} {_REDACTED}", redacted)
+        redacted = _PAIRING_CODE_RE.sub(lambda m: f"{m.group(1)}={_REDACTED}", redacted)
         redacted = _PRIVATE_KEY_RE.sub(_REDACTED, redacted)
 
         if redacted != message:

--- a/src/remo_cli/web/operator_auth.py
+++ b/src/remo_cli/web/operator_auth.py
@@ -1,0 +1,109 @@
+"""Operator-authentication provider seam (012-web-adopt-pairing).
+
+Minting a pairing code is gated by operator authentication (FR-009): the
+service only mints for a request that carries proof the operator is logged in.
+v1 ships **forward auth** — the app platform terminates SSO and injects a
+trusted identity header, and remo-web reads that header. The gate is a small
+pluggable seam so a future in-app **OIDC** verifier (JWKS + iss/aud/exp) can be
+added without touching the pairing core (FR-010); OIDC is deferred (Out of
+Scope).
+
+Configuration (WebSettings / `REMO_WEB_*`):
+
+    OPERATOR_AUTH=forward + FORWARD_AUTH_HEADER=<name>  -> ForwardAuthProvider
+    OPERATOR_AUTH=none                                  -> NetworkRestrictedProvider
+    OPERATOR_AUTH=""  (unset)                           -> None (minting disabled)
+
+`build_operator_auth_provider` fail-fasts (FR-009) if forward auth is enabled
+without a header name, so the service never trusts a header the proxy does not
+set and strip.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Protocol, runtime_checkable
+
+if TYPE_CHECKING:
+    from fastapi import Request
+
+    from remo_cli.web.config import WebSettings
+
+
+class OperatorAuthConfigError(Exception):
+    """Fail-fast configuration error (e.g. forward auth without a header name)."""
+
+
+@dataclass(frozen=True)
+class OperatorIdentity:
+    """The authenticated operator that minted a pairing session (FR-012)."""
+
+    subject: str
+    provider: str
+
+
+@runtime_checkable
+class OperatorAuthProvider(Protocol):
+    """Authenticates a mint request. Returns an identity, or None to refuse."""
+
+    #: Human-readable posture name surfaced in readiness/diagnostics (FR-013).
+    posture: str
+
+    def authenticate(self, request: "Request") -> OperatorIdentity | None: ...
+
+
+class ForwardAuthProvider:
+    """Trusts a proxy-injected identity header (FR-009/FR-014).
+
+    The header is trusted only under the documented forward-auth boundary: a
+    proxy in front sets/strips it and prevents direct client access to the app.
+    """
+
+    posture = "forward"
+
+    def __init__(self, header_name: str) -> None:
+        if not header_name.strip():
+            raise OperatorAuthConfigError(
+                "forward auth requires REMO_WEB_FORWARD_AUTH_HEADER to name the "
+                "trusted, proxy-injected identity header (e.g. X-Forwarded-User)."
+            )
+        self.header_name = header_name.strip()
+
+    def authenticate(self, request: "Request") -> OperatorIdentity | None:
+        value = request.headers.get(self.header_name, "").strip()
+        if not value:
+            return None
+        return OperatorIdentity(subject=value, provider="forward")
+
+
+class NetworkRestrictedProvider:
+    """No operator-auth provider — mint proceeds without a credential (FR-013).
+
+    An explicit, loudly-logged opt-in for loopback/private/dev deployments; the
+    minting request is treated as an anonymous operator.
+    """
+
+    posture = "network-restricted"
+
+    def authenticate(self, request: "Request") -> OperatorIdentity | None:
+        return OperatorIdentity(subject="network-restricted", provider="network-restricted")
+
+
+def build_operator_auth_provider(settings: "WebSettings") -> OperatorAuthProvider | None:
+    """Construct the configured provider, or None when minting is disabled.
+
+    Fail-fasts (raises ``OperatorAuthConfigError``) when forward auth is enabled
+    without a header name (FR-009). ``None`` means no provider is configured:
+    the mint endpoint refuses with a "not configured" 403 (fail closed, R5).
+    """
+    mode = settings.operator_auth.strip().lower()
+    if mode == "forward":
+        return ForwardAuthProvider(settings.forward_auth_header)
+    if mode == "none":
+        return NetworkRestrictedProvider()
+    if mode == "":
+        return None
+    raise OperatorAuthConfigError(
+        f"REMO_WEB_OPERATOR_AUTH={settings.operator_auth!r} is not recognized "
+        "(expected 'forward', 'none', or unset)."
+    )

--- a/src/remo_cli/web/pairing.py
+++ b/src/remo_cli/web/pairing.py
@@ -1,0 +1,142 @@
+"""In-memory ephemeral pairing sessions (012-web-adopt-pairing).
+
+Replaces 011's static `REMO_WEB_API_TOKEN` gate on `/api/v1/setup/*` with a
+short-lived, page-minted **pairing code**. At most one pairing session is live
+at a time (most-recent-wins rotation, FR-003); a session exists only in process
+memory and is dropped on restart (FR-008).
+
+Lifecycle (data-model.md):
+
+    (none) --mint()--> LIVE
+    LIVE   --authenticate() success (touch)--> LIVE   (sliding idle TTL reset)
+    LIVE   --mint() again--> LIVE   (fresh code; prior code invalid)   [FR-003]
+    LIVE   --idle > ttl_s--> (none) (lazy expiry)                      [FR-002]
+    LIVE   --end()--> (none)  (adoption apply / page-hide beacon)      [FR-004/7]
+
+Time is measured against a monotonic clock so a wall-clock change can neither
+extend nor prematurely expire a session (spec Edge Cases). The clock is
+injectable (`now=`) so TTL branches are deterministic in tests — no `sleep`.
+
+Thread safety: FastAPI runs the sync setup/mint routes in a threadpool, so
+every mutation is guarded by a `threading.Lock`.
+"""
+
+from __future__ import annotations
+
+import hmac
+import secrets
+import threading
+import time
+from collections.abc import Callable
+from dataclasses import dataclass
+from typing import Literal
+
+from remo_cli.web.operator_auth import OperatorIdentity
+
+#: Bytes of entropy for a pairing code (research R6). `token_urlsafe(24)` yields
+#: ~192 bits, ~32 url-safe chars — clipboard-delivered, never hand-typed, so we
+#: favor generous entropy over brevity.
+_CODE_ENTROPY_BYTES = 24
+
+PairingOrigin = Literal["adopt", "resync"]
+
+
+@dataclass
+class PairingSession:
+    """One live adoption/push handoff. In-memory only (never persisted)."""
+
+    code: str
+    identity: OperatorIdentity | None
+    origin: PairingOrigin
+    last_activity: float
+    ttl_s: float
+
+    def is_expired(self, now: float) -> bool:
+        return (now - self.last_activity) > self.ttl_s
+
+
+class PairingSessionManager:
+    """Holds at most one live pairing session (most-recent-wins).
+
+    All methods are lock-guarded and use the injected monotonic clock.
+    """
+
+    def __init__(
+        self,
+        *,
+        ttl_s: float = 900.0,
+        now: Callable[[], float] = time.monotonic,
+    ) -> None:
+        self._ttl_s = ttl_s
+        self._now = now
+        self._lock = threading.Lock()
+        self._session: PairingSession | None = None
+
+    def mint(
+        self, identity: OperatorIdentity | None, origin: PairingOrigin = "adopt"
+    ) -> tuple[str, float]:
+        """Create a fresh code, evicting any prior session (rotation, FR-003).
+
+        Returns ``(code, ttl_s)``. The raw code is returned exactly once; it is
+        never stored anywhere but in the live session.
+        """
+        code = secrets.token_urlsafe(_CODE_ENTROPY_BYTES)
+        with self._lock:
+            self._session = PairingSession(
+                code=code,
+                identity=identity,
+                origin=origin,
+                last_activity=self._now(),
+                ttl_s=self._ttl_s,
+            )
+        return code, self._ttl_s
+
+    def authenticate(self, presented: str) -> PairingSession | None:
+        """Constant-time match against the live, non-expired session.
+
+        On success the session is touched (sliding TTL reset) and returned; an
+        absent/expired/wrong code yields ``None`` — indistinguishable to the
+        caller, which turns all of them into the dormant 404 (FR-005/FR-006).
+        """
+        with self._lock:
+            session = self._live_locked()
+            if session is None or not presented:
+                return None
+            # Compare as bytes, never as str: hmac.compare_digest raises
+            # TypeError on a non-ASCII str, and `presented` is attacker-
+            # controlled (a raw Authorization header byte 0x80-0xFF decodes to a
+            # non-ASCII str). Encoding to UTF-8 keeps the comparison constant-
+            # time and total, so a crafted bearer yields a clean mismatch (the
+            # dormant 404) instead of a 500 that would reveal a live session.
+            if not hmac.compare_digest(presented.encode("utf-8"), session.code.encode("utf-8")):
+                return None
+            session.last_activity = self._now()
+            return session
+
+    def current_identity(self) -> OperatorIdentity | None:
+        """Identity of the live session (for audit logging), or None."""
+        with self._lock:
+            session = self._live_locked()
+            return session.identity if session else None
+
+    def is_live(self) -> bool:
+        """True when a non-expired session exists (drives dormancy)."""
+        with self._lock:
+            return self._live_locked() is not None
+
+    def end(self) -> None:
+        """Drop the live session. Idempotent (completion / beacon / rotation)."""
+        with self._lock:
+            self._session = None
+
+    # -- internals ---------------------------------------------------------
+
+    def _live_locked(self) -> PairingSession | None:
+        """Return the live session, lazily dropping it if expired. Caller holds the lock."""
+        session = self._session
+        if session is None:
+            return None
+        if session.is_expired(self._now()):
+            self._session = None
+            return None
+        return session

--- a/tests/image/test_docker_image.py
+++ b/tests/image/test_docker_image.py
@@ -42,9 +42,9 @@ tests (skip honestly rather than fail when infra isn't available):
 the container's REMO_HOME and no registry/SSH mounts at all, then assert the
 service reaches its "awaiting adoption" state (ready 200 `unconfigured`)
 within 30s, generates a persistent service identity (same fingerprint across
-a container restart, FR-002), and token-gates the setup API (404 when
-`REMO_WEB_API_TOKEN` is unset, FR-021). The pre-existing RO-mount tests
-above are intentionally untouched — them still passing IS SC-005.
+a container restart, FR-002), and pairing-gates the setup API (012: dormant
+404 with no live session; reachable behind a minted code). The pre-existing
+RO-mount tests above are intentionally untouched — them still passing IS SC-005.
 
 A fourth group covers the self-healing permissions model: the image starts
 as root and its entrypoint chowns a ROOT-OWNED (bind-mounted) config dir and
@@ -748,7 +748,6 @@ def test_build_and_run_arm64(tmp_path):
 
 _CONTAINER_REMO_HOME = "/home/remo/.config/remo"
 _IDENTITY_DIR = f"{_CONTAINER_REMO_HOME}/web-identity"
-_SETUP_TOKEN = "image-test-token-123"
 _SETUP_STATUS_URL = "http://127.0.0.1:8080/api/v1/setup/status"
 
 
@@ -791,7 +790,7 @@ def empty_state_dir(tmp_path, amd64_image):
 
 
 def _run_unconfigured_container(
-    image: str, name: str, state_dir: Path, *, token: str | None
+    image: str, name: str, state_dir: Path, *, operator_auth: str | None = None
 ) -> None:
     """`docker run` with compose.example.yml's hardening flags, an empty
     writable state volume at REMO_HOME, and NO registry/SSH mounts.
@@ -802,6 +801,9 @@ def _run_unconfigured_container(
     make the runtime-dir check fail on the second boot of the FR-002
     restart test below. `rw,mode=1777` pins Docker's own first-boot default
     so every (re)mount is identical.
+
+    ``operator_auth`` sets ``REMO_WEB_OPERATOR_AUTH`` (012): pass ``"none"``
+    (network-restricted) so the container can mint a pairing code over HTTP.
     """
     cmd = [
         "docker",
@@ -817,11 +819,31 @@ def _run_unconfigured_container(
         "-v",
         f"{state_dir}:{_CONTAINER_REMO_HOME}",
     ]
-    if token is not None:
-        cmd += ["-e", f"REMO_WEB_API_TOKEN={token}"]
+    if operator_auth is not None:
+        cmd += ["-e", f"REMO_WEB_OPERATOR_AUTH={operator_auth}"]
     cmd.append(image)
     run = subprocess.run(cmd, capture_output=True, text=True, timeout=30)
     assert run.returncode == 0, run.stderr
+
+
+def _mint_code_in_container(name: str) -> str:
+    """Mint a pairing code via `POST /pairing/mint` inside the container.
+
+    Requires the network-restricted posture (REMO_WEB_OPERATOR_AUTH=none). The
+    Origin header must be an allowed origin (127.0.0.1:8080 is a default).
+    """
+    result = subprocess.run(
+        [
+            "docker", "exec", name, "curl", "-s",
+            "-H", "Origin: http://127.0.0.1:8080",
+            "-X", "POST", "http://127.0.0.1:8080/api/v1/pairing/mint",
+        ],
+        capture_output=True,
+        text=True,
+        timeout=15,
+    )
+    assert result.returncode == 0, result.stdout + result.stderr
+    return json.loads(result.stdout)["code"]
 
 
 def _wait_for_ready_payload(name: str, timeout_s: float = 30.0) -> dict:
@@ -891,7 +913,7 @@ def test_amd64_unconfigured_boot_reports_unconfigured_and_generates_identity(
     must have generated the service identity into the state volume."""
     name = f"remo-web-test-unconf-{uuid.uuid4().hex[:8]}"
     try:
-        _run_unconfigured_container(amd64_image, name, empty_state_dir, token=_SETUP_TOKEN)
+        _run_unconfigured_container(amd64_image, name, empty_state_dir)
         payload = _wait_for_ready_payload(name)
         assert payload["status"] == "unconfigured"
 
@@ -931,7 +953,7 @@ def test_amd64_service_identity_survives_container_restart(amd64_image, empty_st
     key files exist — a restart must come back with the same fingerprint."""
     name = f"remo-web-test-restart-{uuid.uuid4().hex[:8]}"
     try:
-        _run_unconfigured_container(amd64_image, name, empty_state_dir, token=_SETUP_TOKEN)
+        _run_unconfigured_container(amd64_image, name, empty_state_dir)
         assert _wait_for_ready_payload(name)["status"] == "unconfigured"
         fingerprint_before = _service_key_fingerprint(name)
 
@@ -947,41 +969,46 @@ def test_amd64_service_identity_survives_container_restart(amd64_image, empty_st
 
 
 @requires_image_build
-def test_amd64_setup_status_token_gated(amd64_image, empty_state_dir):
-    """With REMO_WEB_API_TOKEN set: the right bearer token sees the setup
-    surface (state `unconfigured`); a wrong token gets 401 (SC-004)."""
+def test_amd64_setup_status_pairing_gated(amd64_image, empty_state_dir):
+    """012: with a minted pairing code the setup surface is reachable (state
+    `unconfigured`); a wrong code gets the dormant 404, never a 401 (SC-004)."""
     name = f"remo-web-test-setup-{uuid.uuid4().hex[:8]}"
     try:
-        _run_unconfigured_container(amd64_image, name, empty_state_dir, token=_SETUP_TOKEN)
+        # Network-restricted posture so the container can mint over HTTP.
+        _run_unconfigured_container(amd64_image, name, empty_state_dir, operator_auth="none")
         _wait_for_ready_payload(name)
 
+        code = _mint_code_in_container(name)
         status, payload = _curl_status_and_json(
-            name, _SETUP_STATUS_URL, headers=(f"Authorization: Bearer {_SETUP_TOKEN}",)
+            name, _SETUP_STATUS_URL, headers=(f"Authorization: Bearer {code}",)
         )
         assert status == "200", payload
         assert payload["state"] == "unconfigured"
         assert payload["public_key_available"] is True
         assert payload["registry_instances"] == 0
 
-        status, payload = _curl_status_and_json(
-            name, _SETUP_STATUS_URL, headers=("Authorization: Bearer wrong-token",)
+        # A wrong code is the dormant 404 (FR-006), never a distinguishable 401.
+        status, body = _curl_status_and_json(
+            name, _SETUP_STATUS_URL, headers=("Authorization: Bearer wrong-code",)
         )
-        assert status == "401", payload
+        assert status == "404", body
+        assert body == {"detail": "Not Found"}
     finally:
         _docker_rm(name)
 
 
 @requires_image_build
-def test_amd64_setup_routes_hidden_without_token_env(amd64_image, empty_state_dir):
-    """With REMO_WEB_API_TOKEN entirely unset the setup surface must not
-    exist (404, indistinguishable from an unknown route — FR-021) while the
-    service still boots and reports `unconfigured` on ready."""
-    name = f"remo-web-test-notoken-{uuid.uuid4().hex[:8]}"
+def test_amd64_setup_routes_dormant_without_session(amd64_image, empty_state_dir):
+    """012: with no live pairing session the setup surface must not exist
+    (404, indistinguishable from an unknown route — FR-005) while the service
+    still boots and reports `unconfigured` on ready."""
+    name = f"remo-web-test-dormant-{uuid.uuid4().hex[:8]}"
     try:
-        _run_unconfigured_container(amd64_image, name, empty_state_dir, token=None)
+        _run_unconfigured_container(amd64_image, name, empty_state_dir, operator_auth="none")
         payload = _wait_for_ready_payload(name)
         assert payload["status"] == "unconfigured"
 
+        # No mint -> dormant.
         status, body = _curl_status_and_json(name, _SETUP_STATUS_URL)
         assert status == "404", body
         assert body == {"detail": "Not Found"}
@@ -1070,7 +1097,6 @@ def test_amd64_root_owned_bind_dir_self_heals_and_app_runs_non_root(
         cmd += _HEAL_RUN_FLAGS
         cmd += [
             "-v", f"{root_owned_state_dir}:{_CONTAINER_REMO_HOME}",
-            "-e", f"REMO_WEB_API_TOKEN={_SETUP_TOKEN}",
             amd64_image,
         ]
         run = subprocess.run(cmd, capture_output=True, text=True, timeout=30)
@@ -1108,7 +1134,6 @@ def test_amd64_bare_tmpfs_survives_restart_via_reheal(amd64_image, root_owned_st
         cmd += _HEAL_RUN_FLAGS
         cmd += [
             "-v", f"{root_owned_state_dir}:{_CONTAINER_REMO_HOME}",
-            "-e", f"REMO_WEB_API_TOKEN={_SETUP_TOKEN}",
             amd64_image,
         ]
         run = subprocess.run(cmd, capture_output=True, text=True, timeout=30)
@@ -1152,7 +1177,6 @@ def test_amd64_explicit_non_root_user_still_boots(amd64_image, empty_state_dir):
         cmd += _HEAL_RUN_FLAGS
         cmd += [
             "-v", f"{empty_state_dir}:{_CONTAINER_REMO_HOME}",
-            "-e", f"REMO_WEB_API_TOKEN={_SETUP_TOKEN}",
             amd64_image,
         ]
         run = subprocess.run(cmd, capture_output=True, text=True, timeout=30)

--- a/tests/integration/test_web_adopt_e2e.py
+++ b/tests/integration/test_web_adopt_e2e.py
@@ -1,14 +1,20 @@
-"""End-to-end integration test for CLI-to-Web adoption (011-web-adopt, T026/T043).
+"""End-to-end integration test for CLI-to-Web adoption (012-web-adopt-pairing).
 
-Proves quickstart.md scenarios C (first-time adoption, SC-001/SC-002), D
-(idempotence, FR-015/SC-003), and E (`remo web push` after adoption,
-FR-025/FR-026/FR-027) against a LIVE local service: a real uvicorn
-subprocess serving `create_app()` on an ephemeral 127.0.0.1 port, with
-`REMO_WEB_API_TOKEN` set and its own writable service-side `REMO_HOME`
-(distinct from the workstation-side temp `REMO_HOME`/`$HOME` the adopt flow
-runs under in the test process). The service subprocess and the test process
+Proves quickstart.md scenarios B (first-time adoption via a page-minted pairing
+code), idempotent re-run, and E (`remo web push` after adoption) against a LIVE
+local service: a real uvicorn subprocess serving `create_app()` on an ephemeral
+127.0.0.1 port, in the **network-restricted** operator-auth posture
+(`REMO_WEB_OPERATOR_AUTH=none`) so the test can mint a pairing code over HTTP
+without a forward-auth proxy, with its own writable service-side `REMO_HOME`
+(distinct from the workstation-side temp `REMO_HOME`/`$HOME` the adopt flow runs
+under in the test process). The service subprocess and the test process
 therefore see genuinely different registries/homes, exactly like a real
 workstation adopting a real container.
+
+Each adopt/push obtains a FRESH pairing code (minted via
+`POST /api/v1/pairing/mint`); the code authenticates the whole flow and the
+service ends the session on the terminal `POST /setup/verify` (FR-007), so a
+subsequent probe re-mints.
 
 No real SSH instances exist here, so the workstation-side per-instance SSH
 work is selectively substituted (see `adoption_ssh_mocks`):
@@ -21,9 +27,10 @@ work is selectively substituted (see `adoption_ssh_mocks`):
 * the SSM entry never reaches SSH at all (`skipped_by_design`, FR-012).
 
 The origin-allowlist middleware exempts Origin-less requests to
-/api/v1/setup/* (bearer-token-only surface, no ambient credentials -- see
+/api/v1/setup/* (code-authenticated surface, no ambient credentials -- see
 web/app.py), which is what lets the Origin-less `SetupApiClient` used here
-talk to the live service exactly like the real CLI does.
+talk to the live service exactly like the real CLI does. The browser-facing
+`POST /pairing/mint` DOES require an allowed Origin, which the mint helper sets.
 """
 
 from __future__ import annotations
@@ -67,8 +74,6 @@ requires_live_web = pytest.mark.skipif(
 # ---------------------------------------------------------------------------
 # Registry fixture data
 # ---------------------------------------------------------------------------
-
-_TOKEN = "e2e-test-token-123"
 
 #: RFC 5737 TEST-NET-1 -- guaranteed non-routable, so the service-side verify
 #: round-trip to this "instance" fails within its own bounded 5s timeout.
@@ -143,7 +148,6 @@ uvicorn.run(
 class LiveService:
     url: str
     port: int
-    token: str
     remo_home: Path  # service-side state dir (the container's ~/.config/remo)
 
     @property
@@ -153,6 +157,20 @@ class LiveService:
     @property
     def registry_path(self) -> Path:
         return self.remo_home / "known_hosts"
+
+    def mint(self) -> str:
+        """Mint a fresh pairing code over HTTP (network-restricted posture)."""
+        status, body = _http_json(
+            "POST", f"{self.url}/api/v1/pairing/mint", headers={"Origin": self.url}
+        )
+        assert status == 200, (status, body)
+        return str(body["code"])
+
+    def setup_status(self) -> tuple[int, dict]:
+        """GET /setup/status behind a freshly minted code (probe helper)."""
+        return _http_json(
+            "GET", f"{self.url}/api/v1/setup/status", token=self.mint()
+        )
 
 
 def _free_port() -> int:
@@ -210,9 +228,11 @@ def service(tmp_path: Path) -> LiveService:
         {
             "HOME": str(fake_home),
             "REMO_HOME": str(remo_home),
-            "REMO_WEB_API_TOKEN": _TOKEN,
+            # Network-restricted posture: mint a pairing code over HTTP without a
+            # forward-auth proxy (loud-opt-in, FR-013).
+            "REMO_WEB_OPERATOR_AUTH": "none",
             "REMO_WEB_SSH_CONTROL_DIR": str(control_dir),
-            # The Origin value the workaround fixture injects must be allowed.
+            # The Origin the mint helper sets must be allowed.
             "REMO_WEB_ALLOWED_ORIGINS": url,
         }
     )
@@ -244,7 +264,7 @@ def service(tmp_path: Path) -> LiveService:
                 )
             time.sleep(0.2)
 
-        yield LiveService(url=url, port=port, token=_TOKEN, remo_home=remo_home)
+        yield LiveService(url=url, port=port, remo_home=remo_home)
     finally:
         proc.terminate()
         try:
@@ -336,9 +356,7 @@ def test_fresh_boot_is_unconfigured_with_generated_identity(service: LiveService
     public_key = (service.identity_dir / "id_ed25519.pub").read_text().strip()
     assert public_key.endswith(f"remo-web@{state['deployment_id']}")
 
-    status, setup = _http_json(
-        "GET", f"{service.url}/api/v1/setup/status", token=service.token
-    )
+    status, setup = service.setup_status()
     assert status == 200
     assert setup == {
         "state": "unconfigured",
@@ -364,8 +382,8 @@ def test_full_adopt_then_idempotent_rerun(
     status, ready = _http_json("GET", f"{service.url}/api/v1/ready")
     assert (status, ready["status"]) == (200, "unconfigured")
 
-    # ---- First adoption (scenario C) ------------------------------------
-    result = web_adopt.run_adopt(service.url, service.token, interactive=False)
+    # ---- First adoption (scenario B) ------------------------------------
+    result = web_adopt.run_adopt(service.url, service.mint(), interactive=False)
 
     outcomes = {o.host.name: o.outcome for o in result.outcomes}
     assert outcomes == {
@@ -413,20 +431,18 @@ def test_full_adopt_then_idempotent_rerun(
     # Readiness flips off "unconfigured"; setup state is now "adopted".
     status, ready = _http_json("GET", f"{service.url}/api/v1/ready")
     assert (status, ready["status"]) == (200, "ready")
-    status, setup = _http_json(
-        "GET", f"{service.url}/api/v1/setup/status", token=service.token
-    )
+    status, setup = service.setup_status()
     assert status == 200
     assert setup["state"] == "adopted"
     assert setup["registry_instances"] == 3
     assert setup["deployment_id"] == result.deployment_id
 
-    # ---- Second, identical run (scenario D / FR-015) ---------------------
+    # ---- Second, identical run (idempotence / FR-015) -------------------
     registry_bytes = service.registry_path.read_bytes()
     known_hosts_bytes = service_known_hosts.read_bytes()
     state_bytes = (service.identity_dir / "state.json").read_bytes()
 
-    rerun = web_adopt.run_adopt(service.url, service.token, interactive=False)
+    rerun = web_adopt.run_adopt(service.url, service.mint(), interactive=False)
 
     assert {o.host.name: o.outcome for o in rerun.outcomes} == outcomes
     assert rerun.applied == result.applied
@@ -468,7 +484,10 @@ def test_registry_put_preserves_established_sessions(
     the service-side registry (standing in for an established session's held
     resources) and a live keep-alive HTTP connection spanning the PUT.
     """
-    client = web_adopt.SetupApiClient(service.url, service.token)
+    # One minted code drives every call here: the flow never calls /verify, so
+    # the session stays live across both PUTs (it would end only on verify).
+    code = service.mint()
+    client = web_adopt.SetupApiClient(service.url, code)
 
     # Adopt the service (fast path: direct PUT of the same mirror payload the
     # adopt flow builds; no per-instance SSH or verify round-trips needed).
@@ -478,7 +497,7 @@ def test_registry_put_preserves_established_sessions(
     applied = client.put_registry(payload)
     assert applied["applied"] is True
     status, setup = _http_json(
-        "GET", f"{service.url}/api/v1/setup/status", token=service.token
+        "GET", f"{service.url}/api/v1/setup/status", token=code
     )
     assert (status, setup["state"]) == (200, "adopted")
 
@@ -526,53 +545,8 @@ def test_registry_put_preserves_established_sessions(
 
 
 # ---------------------------------------------------------------------------
-# 5-7. T043: push after adoption (US4; quickstart scenario E;
-# FR-025/FR-026/FR-027) against the live service
+# 5. Push after adoption (US4; quickstart scenario E) against the live service
 # ---------------------------------------------------------------------------
-
-
-def _fast_adopt_and_save(service: LiveService) -> web_adopt.SavedCredentials:
-    """Establish the adopted + credentials-saved state on the cheap.
-
-    Direct PUT of the same mirror payload the adopt flow builds (as in the
-    session-continuity test: no per-instance SSH, no verify round-trips)
-    plus `save_credentials()` with the service's REAL identity and the same
-    seeded push cache `run_adopt(save=True)` leaves behind. Used by the
-    failure-path push tests, where re-running the whole adopt flow would
-    only add runtime.
-    """
-    client = web_adopt.SetupApiClient(service.url, service.token)
-    identity = client.get_identity()
-    applied = client.put_registry(
-        web_adopt.build_adoption_payload(
-            _HOSTS, {_DIRECT.name: list(_CANNED_HOST_KEY_LINES)}
-        )
-    )
-    assert applied["applied"] is True
-
-    credentials = web_adopt.SavedCredentials(
-        url=service.url,
-        token=service.token,
-        deployment_id=str(identity["deployment_id"]),
-        push_cache={
-            _DIRECT.name: web_adopt.CachedInstance(
-                fingerprint=web_adopt.instance_fingerprint(_DIRECT),
-                host_keys=list(_CANNED_HOST_KEY_LINES),
-            )
-        },
-    )
-    web_adopt.save_credentials(credentials)
-    return credentials
-
-
-def _corrupt_saved_credentials(ws_remo: Path, **overrides: str) -> Path:
-    """Rewrite fields of the saved web-service.json in place (simulating a
-    service-side token rotation / state-volume reset without a restart)."""
-    path = ws_remo / "web-service.json"
-    data = json.loads(path.read_text())
-    data.update(overrides)
-    path.write_text(json.dumps(data))
-    return path
 
 
 @requires_live_web
@@ -581,28 +555,29 @@ def test_push_after_adopt_processes_only_the_new_instance(
     workstation: Path,
     adoption_ssh_mocks: dict,
 ):
-    """Scenario E happy path: adopt + save, register a new direct-access
-    instance workstation-side, `run_push()` -- only the new instance gets
-    keyscan+authorize; the original is `unchanged` from the delta cache but
-    still contributes its cached host-key lines to the full mirror PUT."""
-    # ---- Adopt with explicit credential save (FR-025) --------------------
-    result = web_adopt.run_adopt(
-        service.url, service.token, interactive=False, save=True
-    )
+    """Scenario E happy path: adopt (auto-seeds the non-secret push cache),
+    register a new direct-access instance workstation-side, `run_push()` with a
+    fresh code -- only the new instance gets keyscan+authorize; the original is
+    `unchanged` from the delta cache but still contributes its cached host-key
+    lines to the full mirror PUT."""
+    # ---- Adopt (auto-seeds the deployment-keyed push cache, no secret) ---
+    result = web_adopt.run_adopt(service.url, service.mint(), interactive=False)
     assert {o.host.name: o.outcome for o in result.outcomes} == {
         "webbox": web_adopt.OUTCOME_ADOPTED,
         "ssmbox": web_adopt.OUTCOME_SKIPPED_BY_DESIGN,
         "ghost": web_adopt.OUTCOME_SKIPPED_UNREACHABLE,
     }
 
-    creds_path = workstation / "web-service.json"
-    assert creds_path.stat().st_mode & 0o777 == 0o600
-    saved = json.loads(creds_path.read_text())
-    assert saved["url"] == service.url
-    assert saved["deployment_id"] == result.deployment_id
-    # Delta cache seeded with exactly the adopted instance + its pushed lines.
-    assert set(saved["push_cache"]) == {"webbox"}
-    assert saved["push_cache"]["webbox"]["host_keys"] == _CANNED_HOST_KEY_LINES
+    cache_path = workstation / "web-service.json"
+    assert cache_path.stat().st_mode & 0o777 == 0o600
+    saved = json.loads(cache_path.read_text())
+    # No secret is persisted (FR-019): no url, no token/code, no top-level id.
+    assert set(saved) == {"push_cache"}
+    dep = result.deployment_id
+    # Delta cache is deployment-keyed and seeded with the adopted instance.
+    assert set(saved["push_cache"]) == {dep}
+    assert set(saved["push_cache"][dep]) == {"webbox"}
+    assert saved["push_cache"][dep]["webbox"]["host_keys"] == _CANNED_HOST_KEY_LINES
 
     adoption_ssh_mocks["scanned"].clear()
     adoption_ssh_mocks["authorized"].clear()
@@ -611,8 +586,8 @@ def test_push_after_adopt_processes_only_the_new_instance(
     registry = workstation / "known_hosts"
     registry.write_text(registry.read_text() + _NEW_DIRECT.to_line() + "\n")
 
-    # ---- Zero-argument push (FR-026) -------------------------------------
-    push = web_adopt.run_push(interactive=False)
+    # ---- Push with a freshly minted code (FR-018/FR-019) -----------------
+    push = web_adopt.run_push(service.url, service.mint(), interactive=False)
 
     assert {o.host.name: o.outcome for o in push.outcomes} == {
         "webbox": web_adopt.OUTCOME_UNCHANGED,
@@ -653,84 +628,44 @@ def test_push_after_adopt_processes_only_the_new_instance(
         line + "\n" for line in _NEW_CANNED_HOST_KEY_LINES
     )
 
-    status, setup = _http_json(
-        "GET", f"{service.url}/api/v1/setup/status", token=service.token
-    )
+    status, setup = service.setup_status()
     assert status == 200
     assert setup["state"] == "adopted"
     assert setup["registry_instances"] == 4
 
     # The delta cache was rewritten after the successful PUT: both adopted
-    # instances now present, so the NEXT push would skip newbox too.
-    resaved = json.loads(creds_path.read_text())
-    assert set(resaved["push_cache"]) == {"webbox", "newbox"}
-    assert resaved["push_cache"]["newbox"]["host_keys"] == _NEW_CANNED_HOST_KEY_LINES
-    assert resaved["push_cache"]["webbox"] == saved["push_cache"]["webbox"]
+    # instances now present under the same deployment key, so the NEXT push
+    # would skip newbox too.
+    resaved = json.loads(cache_path.read_text())
+    assert set(resaved["push_cache"][dep]) == {"webbox", "newbox"}
+    assert resaved["push_cache"][dep]["newbox"]["host_keys"] == _NEW_CANNED_HOST_KEY_LINES
+    assert resaved["push_cache"][dep]["webbox"] == saved["push_cache"][dep]["webbox"]
 
 
 @requires_live_web
-def test_push_with_rotated_token_fails_with_reauth_guidance(
+def test_push_with_dormant_code_fails_with_reopen_guidance(
     service: LiveService,
     workstation: Path,
     adoption_ssh_mocks: dict,
 ):
-    """FR-027: a saved token the service no longer accepts (token rotation,
-    simulated by corrupting web-service.json) must fail with clear re-adopt
-    guidance -- before any per-instance work or registry PUT."""
-    _fast_adopt_and_save(service)
-    _corrupt_saved_credentials(workstation, token="rotated-away-token")
-
+    """A stale/dormant code (never minted, or already used) makes every setup
+    call return the dormant 404, which the CLI maps to reopen-the-page guidance
+    -- before any per-instance work or registry PUT."""
+    # Adopt once so there is a registry to (not) disturb.
+    web_adopt.run_adopt(service.url, service.mint(), interactive=False)
+    adoption_ssh_mocks["scanned"].clear()
+    adoption_ssh_mocks["authorized"].clear()
     registry_before = service.registry_path.read_bytes()
-    with pytest.raises(web_adopt.SetupAuthError) as excinfo:
-        web_adopt.run_push(interactive=False)
 
-    assert excinfo.value.status == 401
+    # A code that was never minted -> the surface is dormant for it.
+    with pytest.raises(web_adopt.SetupNotFoundError) as excinfo:
+        web_adopt.run_push(service.url, "never-minted-code", interactive=False)
+
     message = str(excinfo.value)
-    assert "rejected the saved API token" in message
-    assert "remo web adopt" in message  # the documented re-auth remediation
+    assert "dormant" in message
+    assert "fresh code" in message  # reopen-the-page remediation
 
-    # Failed at the identity precheck: no instance was touched, no PUT.
+    # Failed at the first setup call: no instance touched, no PUT.
     assert adoption_ssh_mocks["scanned"] == []
     assert adoption_ssh_mocks["authorized"] == []
     assert service.registry_path.read_bytes() == registry_before
-
-
-@requires_live_web
-def test_push_with_stale_deployment_id_fails_without_put(
-    service: LiveService,
-    workstation: Path,
-    adoption_ssh_mocks: dict,
-):
-    """A deployment_id mismatch (service state volume reset since the save)
-    must abort the push with re-adopt guidance BEFORE any PUT, leaving the
-    service registry, known_hosts, and workstation credentials untouched."""
-    _fast_adopt_and_save(service)
-    creds_path = _corrupt_saved_credentials(
-        workstation, deployment_id="00000000-stale-deployment-id"
-    )
-
-    registry_before = service.registry_path.read_bytes()
-    known_hosts_before = (service.identity_dir / "known_hosts").read_bytes()
-
-    with pytest.raises(web_adopt.AdoptError) as excinfo:
-        web_adopt.run_push(interactive=False)
-
-    message = str(excinfo.value)
-    assert "service identity changed" in message
-    assert "00000000-stale-deployment-id" in message
-    assert "re-adopt" in message  # remediation: run `remo web adopt` again
-    # A mismatch is a local trust decision, not an HTTP failure.
-    assert not isinstance(excinfo.value, web_adopt.SetupApiError)
-
-    # No PUT happened: service-side files are byte-identical, no instance
-    # was scanned or authorized, and the saved credentials (including the
-    # corrupted deployment_id) were not rewritten -- the cache rewrite only
-    # ever follows a successful PUT.
-    assert adoption_ssh_mocks["scanned"] == []
-    assert adoption_ssh_mocks["authorized"] == []
-    assert service.registry_path.read_bytes() == registry_before
-    assert (service.identity_dir / "known_hosts").read_bytes() == known_hosts_before
-    assert (
-        json.loads(creds_path.read_text())["deployment_id"]
-        == "00000000-stale-deployment-id"
-    )

--- a/tests/unit/cli/test_web_adopt_cmd.py
+++ b/tests/unit/cli/test_web_adopt_cmd.py
@@ -32,7 +32,7 @@ from remo_cli.core.web_adopt import (
     EmptyRegistryError,
     InstanceOutcome,
     MountConfiguredError,
-    SetupAuthError,
+    SetupNotFoundError,
     TunnelError,
 )
 from remo_cli.models.host import KnownHost
@@ -115,7 +115,7 @@ class TestUrlResolutionOrder:
 
 
 class TestTokenResolutionOrder:
-    """API token: --token -> REMO_API_TOKEN -> hidden prompt."""
+    """Pairing code: --token -> REMO_API_TOKEN -> hidden prompt."""
 
     def test_token_option_beats_env(self, runner, mock_run_adopt):
         result = runner.invoke(
@@ -136,21 +136,21 @@ class TestTokenResolutionOrder:
 
         assert result.exit_code == 0
         assert mock_run_adopt.call_args[0][1] == "from-env"
-        assert "API token" not in result.output
+        assert "Pairing code" not in result.output
 
     def test_hidden_prompt_when_no_option_and_no_env(self, runner, mock_run_adopt):
         result = runner.invoke(
             adopt,
             ["http://svc:8080"],
             env=_CLEAN_ENV,
-            input="sekrit-token\n",
+            input="sekrit-code\n",
         )
 
         assert result.exit_code == 0
-        assert "API token" in result.output
-        assert mock_run_adopt.call_args[0][1] == "sekrit-token"
-        # hide_input=True: the typed token must never be echoed back.
-        assert "sekrit-token" not in result.output
+        assert "Pairing code" in result.output
+        assert mock_run_adopt.call_args[0][1] == "sekrit-code"
+        # hide_input=True: the typed code must never be echoed back.
+        assert "sekrit-code" not in result.output
 
 
 class TestExitCodes:
@@ -181,19 +181,21 @@ class TestExitCodes:
         assert "read-only mounts" in result.output
         assert "adoption does not apply" in result.output
 
-    def test_auth_failure_exits_one_with_token_message(self, runner, mock_run_adopt):
-        mock_run_adopt.side_effect = SetupAuthError(
-            "the service rejected the API token (HTTP 401). Check the token "
-            "against the service's REMO_WEB_API_TOKEN and try again.",
-            status=401,
+    def test_dormant_surface_exits_one_with_reopen_message(self, runner, mock_run_adopt):
+        mock_run_adopt.side_effect = SetupNotFoundError(
+            "the pairing code is no longer valid — the setup surface at "
+            "http://svc:8080 is dormant (HTTP 404). Reopen the adopt page to mint "
+            "a fresh code, then retry.",
+            status=404,
         )
 
         result = runner.invoke(
-            adopt, ["http://svc:8080", "--token", "bad-token"], env=_CLEAN_ENV
+            adopt, ["http://svc:8080", "--token", "stale-code"], env=_CLEAN_ENV
         )
 
         assert result.exit_code == 1
-        assert "rejected the API token" in result.output
+        assert "dormant" in result.output
+        assert "fresh code" in result.output
 
     def test_empty_registry_exits_one_and_names_allow_empty(
         self, runner, mock_run_adopt
@@ -236,7 +238,7 @@ class TestExitCodes:
 
 
 class TestFlagPassThrough:
-    """--via/--allow-empty/--yes/--save must reach run_adopt unchanged."""
+    """--via/--allow-empty/--yes must reach run_adopt unchanged (no more --save)."""
 
     def test_all_flags_forwarded(self, runner, mock_run_adopt):
         result = runner.invoke(
@@ -249,7 +251,6 @@ class TestFlagPassThrough:
                 "jumphost",
                 "--allow-empty",
                 "--yes",
-                "--save",
             ],
             env=_CLEAN_ENV,
         )
@@ -261,7 +262,6 @@ class TestFlagPassThrough:
             "via": "jumphost",
             "allow_empty": True,
             "assume_yes": True,
-            "save": True,
         }
 
     def test_defaults_forwarded_when_flags_omitted(self, runner, mock_run_adopt):
@@ -275,7 +275,6 @@ class TestFlagPassThrough:
             "via": None,
             "allow_empty": False,
             "assume_yes": False,
-            "save": False,
         }
 
 

--- a/tests/unit/core/test_web_adopt_code.py
+++ b/tests/unit/core/test_web_adopt_code.py
@@ -1,0 +1,56 @@
+"""Adopt pairing-code plumbing (012-web-adopt-pairing, T010).
+
+The CLI sends the pasted pairing code as `Authorization: Bearer <code>` on every
+setup call, and a dormant `404` maps to an actionable "reopen the page for a
+fresh code" message (FR-018/FR-020).
+"""
+
+from __future__ import annotations
+
+import urllib.error
+import urllib.request
+
+import pytest
+
+from remo_cli.core.web_adopt import SetupApiClient, SetupNotFoundError
+
+
+def test_bearer_header_carries_the_pairing_code(mocker):
+    client = SetupApiClient("http://svc:8080", "the-pairing-code")
+
+    captured = {}
+
+    class _Resp:
+        def read(self):
+            return b"{}"
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *a):
+            return False
+
+    def fake_urlopen(request, timeout=None):
+        captured["auth"] = request.get_header("Authorization")
+        return _Resp()
+
+    mocker.patch.object(urllib.request, "urlopen", side_effect=fake_urlopen)
+    client.get_status()
+    assert captured["auth"] == "Bearer the-pairing-code"
+
+
+def test_dormant_404_maps_to_reopen_message(mocker):
+    client = SetupApiClient("http://svc:8080", "stale-code")
+
+    def raise_404(request, timeout=None):
+        raise urllib.error.HTTPError(
+            "http://svc:8080/api/v1/setup/status", 404, "Not Found", {}, None
+        )
+
+    mocker.patch.object(urllib.request, "urlopen", side_effect=raise_404)
+    with pytest.raises(SetupNotFoundError) as excinfo:
+        client.get_status()
+    message = str(excinfo.value)
+    assert "dormant" in message
+    assert "fresh code" in message
+    assert "reopen the adopt page" in message.lower()

--- a/tests/unit/core/test_web_push.py
+++ b/tests/unit/core/test_web_push.py
@@ -1,60 +1,49 @@
-"""Unit tests for `remo web push` (011-web-adopt US4, T042).
+"""Unit tests for `remo web push` (012-web-adopt-pairing, T030).
 
-Covers:
+Covers the non-secret, deployment-keyed push cache and the delta logic now that
+`run_push(url, code, ...)` resolves URL + pairing code every time and nothing
+durable (url/token) is persisted (FR-018/FR-019):
 
-* Saved-credentials lifecycle (FR-025): atomic 0600 writes (including
-  tightening a pre-existing 0644 file), full round-trip of
-  url/token/deployment_id/push_cache, absent/corrupt files -> None from
-  ``load_saved_credentials``, lenient ``_parse_push_cache`` junk handling,
-  and backward compatibility with files written before the delta cache.
-* Consent semantics (FR-025): ``--yes`` alone never saves; ``--save`` or an
-  interactive yes does (exercised at the ``_adopt_flow`` level with mocks).
-* Fingerprint + delta logic (FR-026): fingerprint stability, unchanged
-  instances skipping keyscan/authorize while reusing cached host-key lines
-  in the PUT payload, full treatment for new/changed instances, removed
-  instances propagating out of the mirror with a manual-revoke note
-  (clarification Q1), and cache rebuild only after a successful PUT.
-* Error handling (FR-027): deployment_id mismatch, rejected saved token
-  (401), missing credentials, and the empty-registry guard (FR-016).
+* Push cache lifecycle: atomic 0600 writes, deployment-keyed round-trip, junk
+  entries dropped, absent/corrupt -> {}, and the 011 credential file format
+  (url/token + name-keyed cache) ignored (parsed to {}).
+* Fingerprint stability (unchanged from 011): any field change re-fingerprints.
+* Delta logic via run_push: unchanged instances skip keyscan/authorize and reuse
+  cached lines, new/changed get full treatment, removed instances drop out with a
+  manual-revoke note, cache rebuilt only after a successful PUT.
+* Errors: mount_configured, missing public key, empty-registry guard, dormant
+  404 mapping.
 """
 
 from __future__ import annotations
 
 import json
-import os
 import stat
 
 import pytest
 
 from remo_cli.core.web_adopt import (
     OUTCOME_ADOPTED,
-    OUTCOME_SKIPPED_BY_DESIGN,
     OUTCOME_SKIPPED_UNREACHABLE,
     OUTCOME_UNCHANGED,
     AdoptError,
     CachedInstance,
     EmptyRegistryError,
     InstanceOutcome,
-    MissingCredentialsError,
-    SavedCredentials,
+    MountConfiguredError,
     SetupApiError,
-    SetupAuthError,
+    SetupNotFoundError,
     _adopt_flow,
-    _parse_push_cache,
-    credentials_path,
     instance_fingerprint,
-    load_saved_credentials,
+    load_push_cache,
+    push_cache_path,
     run_push,
-    save_credentials,
+    save_push_cache,
 )
 from remo_cli.models.host import KnownHost
 
-# ---------------------------------------------------------------------------
-# Shared fixtures / helpers
-# ---------------------------------------------------------------------------
-
 URL = "http://web.example:8080"
-TOKEN = "s3cret-api-token"
+CODE = "ephemeral-pairing-code"
 DEPLOYMENT_ID = "dep-1234abcd"
 PUBLIC_KEY = (
     "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIKk4mCBB2AVDBWvIRtRZlc2VydmljZWtleQ "
@@ -80,30 +69,17 @@ def _ssm_host() -> KnownHost:
     )
 
 
-def _credentials(push_cache=None) -> SavedCredentials:
-    return SavedCredentials(
-        url=URL,
-        token=TOKEN,
-        deployment_id=DEPLOYMENT_ID,
-        push_cache=push_cache or {},
-    )
-
-
 def _mode(path) -> int:
     return stat.S_IMODE(path.stat().st_mode)
 
 
 @pytest.fixture
 def api_client(mocker):
-    """A mocked SetupApiClient wired into the web_adopt module namespace."""
     client = mocker.MagicMock()
     client.base_url = URL
-    client.token = TOKEN
+    client.token = CODE
     client.get_status.return_value = {"state": "adopted", "registry_instances": 2}
-    client.get_identity.return_value = {
-        "deployment_id": DEPLOYMENT_ID,
-        "public_key": PUBLIC_KEY,
-    }
+    client.get_identity.return_value = {"deployment_id": DEPLOYMENT_ID, "public_key": PUBLIC_KEY}
     client.put_registry.return_value = {"registry_instances": 2, "host_key_instances": 1}
     client.post_verify.return_value = {"all_passed": True, "results": []}
     mocker.patch("remo_cli.core.web_adopt.SetupApiClient", return_value=client)
@@ -112,13 +88,10 @@ def api_client(mocker):
 
 @pytest.fixture
 def registry(mocker):
-    """Patch get_known_hosts; tests assign .return_value with their hosts."""
     return mocker.patch("remo_cli.core.web_adopt.get_known_hosts", return_value=[])
 
 
 def _fake_process_instance(mocker, outcome=OUTCOME_ADOPTED):
-    """Patch _process_instance to succeed and record the scanned key line."""
-
     def fake(host, public_key, *, interactive, host_keys, known_hosts_file=None):
         if outcome == OUTCOME_ADOPTED:
             host_keys[host.name] = [f"{host.host} ssh-ed25519 AAAAfake{host.name}"]
@@ -128,214 +101,83 @@ def _fake_process_instance(mocker, outcome=OUTCOME_ADOPTED):
 
 
 # ---------------------------------------------------------------------------
-# Saved-credentials lifecycle (FR-025, research R10)
+# Push cache lifecycle (012 R10)
 # ---------------------------------------------------------------------------
 
 
-class TestCredentialsPath:
-    def test_lives_under_remo_home(self, tmp_config_dir):
-        assert credentials_path() == tmp_config_dir / "web-service.json"
+class TestPushCacheLifecycle:
+    def test_path_under_remo_home(self, tmp_config_dir):
+        assert push_cache_path() == tmp_config_dir / "web-service.json"
 
-
-class TestSaveCredentials:
-    def test_writes_file_with_0600_perms(self, tmp_config_dir):
-        path = save_credentials(_credentials())
-        assert path == credentials_path()
-        assert path.exists()
+    def test_writes_0600(self, tmp_config_dir):
+        path = save_push_cache({DEPLOYMENT_ID: {}})
         assert _mode(path) == 0o600
 
-    def test_overwrite_tightens_preexisting_0644_file(self, tmp_config_dir):
-        path = credentials_path()
-        path.write_text("{}")
-        path.chmod(0o644)
-        save_credentials(_credentials())
-        assert _mode(path) == 0o600
-        # ...and the content was actually replaced.
-        assert json.loads(path.read_text())["url"] == URL
-
-    def test_leaves_no_temp_files_behind(self, tmp_config_dir):
-        save_credentials(_credentials())
-        assert [p.name for p in tmp_config_dir.iterdir()] == ["web-service.json"]
-
-    def test_creates_missing_parent_directory(self, tmp_config_dir):
-        nested = tmp_config_dir / "does-not-exist-yet"
-        os.environ["REMO_HOME"] = str(nested)
-        path = save_credentials(_credentials())
-        assert path.exists()
-        assert _mode(path) == 0o600
-
-    def test_round_trip_all_fields(self, tmp_config_dir):
-        cache = {
-            "node1/dev": CachedInstance(fingerprint="a" * 64, host_keys=[KEY_LINE_NODE1]),
-            "web1": CachedInstance(fingerprint="b" * 64, host_keys=[KEY_LINE_WEB1]),
-        }
-        save_credentials(_credentials(push_cache=cache))
-        loaded = load_saved_credentials()
-        assert loaded is not None
-        assert loaded.url == URL
-        assert loaded.token == TOKEN
-        assert loaded.deployment_id == DEPLOYMENT_ID
-        assert loaded.push_cache == cache
-
-    def test_round_trip_empty_cache(self, tmp_config_dir):
-        save_credentials(_credentials())
-        loaded = load_saved_credentials()
-        assert loaded is not None
-        assert loaded.push_cache == {}
-
-
-class TestLoadSavedCredentials:
-    def test_absent_file_returns_none(self, tmp_config_dir):
-        assert load_saved_credentials() is None
-
-    def test_corrupt_json_returns_none(self, tmp_config_dir):
-        credentials_path().write_text("{not json at all")
-        assert load_saved_credentials() is None
-
-    def test_non_object_json_returns_none(self, tmp_config_dir):
-        credentials_path().write_text('["a", "list"]')
-        assert load_saved_credentials() is None
-
-    @pytest.mark.parametrize("missing", ["url", "token", "deployment_id"])
-    def test_missing_required_field_returns_none(self, tmp_config_dir, missing):
-        data = {"url": URL, "token": TOKEN, "deployment_id": DEPLOYMENT_ID}
-        del data[missing]
-        credentials_path().write_text(json.dumps(data))
-        assert load_saved_credentials() is None
-
-    @pytest.mark.parametrize("bad", [None, 42, ["x"]])
-    def test_non_string_required_field_returns_none(self, tmp_config_dir, bad):
-        data = {"url": URL, "token": bad, "deployment_id": DEPLOYMENT_ID}
-        credentials_path().write_text(json.dumps(data))
-        assert load_saved_credentials() is None
-
-    def test_backward_compat_file_without_push_cache(self, tmp_config_dir):
-        """Files from before the delta cache load fine with an empty cache."""
-        credentials_path().write_text(
-            json.dumps({"url": URL, "token": TOKEN, "deployment_id": DEPLOYMENT_ID})
+    def test_no_url_or_token_persisted(self, tmp_config_dir):
+        save_push_cache(
+            {DEPLOYMENT_ID: {"n": CachedInstance("f" * 64, [KEY_LINE_NODE1])}}
         )
-        loaded = load_saved_credentials()
-        assert loaded is not None
-        assert loaded.url == URL
-        assert loaded.push_cache == {}
+        text = push_cache_path().read_text()
+        assert "token" not in text
+        assert "http" not in text  # no url
 
-    def test_junk_push_cache_entries_are_dropped_not_fatal(self, tmp_config_dir):
-        credentials_path().write_text(
+    def test_round_trip_deployment_keyed(self, tmp_config_dir):
+        cache = {
+            DEPLOYMENT_ID: {
+                "node1/dev": CachedInstance("a" * 64, [KEY_LINE_NODE1]),
+                "web1": CachedInstance("b" * 64, [KEY_LINE_WEB1]),
+            },
+            "other-dep": {"x": CachedInstance("c" * 64, [])},
+        }
+        save_push_cache(cache)
+        assert load_push_cache() == cache
+
+    def test_absent_returns_empty(self, tmp_config_dir):
+        assert load_push_cache() == {}
+
+    def test_corrupt_returns_empty(self, tmp_config_dir):
+        push_cache_path().write_text("{not json")
+        assert load_push_cache() == {}
+
+    def test_old_011_credential_format_ignored(self, tmp_config_dir):
+        # 011 file: top-level url/token + name-keyed push_cache (values are the
+        # entry dicts directly). The deployment-keyed loader must ignore it.
+        push_cache_path().write_text(
             json.dumps(
                 {
                     "url": URL,
-                    "token": TOKEN,
+                    "token": "old-secret",
                     "deployment_id": DEPLOYMENT_ID,
                     "push_cache": {
-                        "good": {"fingerprint": "f" * 64, "host_keys": [KEY_LINE_NODE1]},
-                        "junk": "not-a-dict",
+                        "node1/dev": {"fingerprint": "f" * 64, "host_keys": [KEY_LINE_NODE1]}
                     },
                 }
             )
         )
-        loaded = load_saved_credentials()
-        assert loaded is not None
-        assert set(loaded.push_cache) == {"good"}
+        assert load_push_cache() == {}
 
-
-class TestParsePushCache:
-    def test_non_dict_input_yields_empty_cache(self):
-        for raw in (None, "text", 7, ["list"], True):
-            assert _parse_push_cache(raw) == {}
-
-    def test_valid_entry_parsed(self):
-        cache = _parse_push_cache(
-            {"web1": {"fingerprint": "f" * 64, "host_keys": [KEY_LINE_WEB1]}}
+    def test_junk_entries_dropped(self, tmp_config_dir):
+        push_cache_path().write_text(
+            json.dumps(
+                {
+                    "push_cache": {
+                        DEPLOYMENT_ID: {
+                            "good": {"fingerprint": "f" * 64, "host_keys": [KEY_LINE_NODE1]},
+                            "bad": "not-a-dict",
+                        },
+                        "all-junk-dep": {"y": "not-a-dict", "z": ["list"]},
+                        "empty-dep": {},
+                    }
+                }
+            )
         )
-        assert cache == {"web1": CachedInstance(fingerprint="f" * 64, host_keys=[KEY_LINE_WEB1])}
-
-    def test_non_dict_entry_dropped(self):
-        assert _parse_push_cache({"web1": "junk"}) == {}
-        assert _parse_push_cache({"web1": ["junk"]}) == {}
-
-    @pytest.mark.parametrize("fingerprint", [None, "", 42, ["x"], {"a": 1}])
-    def test_missing_or_invalid_fingerprint_drops_entry(self, fingerprint):
-        entry = {"host_keys": [KEY_LINE_WEB1]}
-        if fingerprint is not None:
-            entry["fingerprint"] = fingerprint
-        assert _parse_push_cache({"web1": entry}) == {}
-
-    @pytest.mark.parametrize("host_keys", ["junk", 42, {"a": 1}, [1, 2], ["ok", 3]])
-    def test_invalid_host_keys_coerced_to_empty_list(self, host_keys):
-        cache = _parse_push_cache({"web1": {"fingerprint": "f" * 64, "host_keys": host_keys}})
-        assert cache == {"web1": CachedInstance(fingerprint="f" * 64, host_keys=[])}
-
-    def test_good_entries_survive_next_to_junk(self):
-        cache = _parse_push_cache(
-            {
-                "good": {"fingerprint": "a" * 64, "host_keys": [KEY_LINE_NODE1]},
-                "bad-fp": {"fingerprint": "", "host_keys": []},
-                "bad-shape": [],
-                42: {"fingerprint": "b" * 64, "host_keys": []},
-            }
-        )
-        assert set(cache) == {"good"}
+        loaded = load_push_cache()
+        assert set(loaded) == {DEPLOYMENT_ID}
+        assert set(loaded[DEPLOYMENT_ID]) == {"good"}
 
 
 # ---------------------------------------------------------------------------
-# Consent semantics (FR-025) — exercised through _adopt_flow with mocks
-# ---------------------------------------------------------------------------
-
-
-class TestAdoptSaveConsent:
-    def _run(self, api_client, *, interactive, save):
-        return _adopt_flow(
-            api_client,
-            original_url=URL,
-            allow_empty=False,
-            interactive=interactive,
-            save=save,
-        )
-
-    @pytest.fixture(autouse=True)
-    def _setup(self, tmp_config_dir, api_client, registry, mocker):
-        registry.return_value = [_make_host()]
-        _fake_process_instance(mocker)
-        self.confirm = mocker.patch("remo_cli.core.web_adopt.confirm", return_value=True)
-
-    def test_yes_alone_never_saves(self, api_client):
-        """--yes implies non-interactive; without --save nothing is written."""
-        self._run(api_client, interactive=False, save=False)
-        assert not credentials_path().exists()
-        self.confirm.assert_not_called()
-
-    def test_save_flag_is_explicit_consent(self, api_client):
-        self._run(api_client, interactive=False, save=True)
-        assert credentials_path().exists()
-        assert _mode(credentials_path()) == 0o600
-        self.confirm.assert_not_called()
-
-    def test_interactive_yes_saves(self, api_client):
-        self.confirm.return_value = True
-        self._run(api_client, interactive=True, save=False)
-        assert credentials_path().exists()
-        self.confirm.assert_called_once()
-
-    def test_interactive_decline_does_not_save(self, api_client):
-        self.confirm.return_value = False
-        self._run(api_client, interactive=True, save=False)
-        assert not credentials_path().exists()
-
-    def test_saved_file_records_service_identity_and_seeded_cache(self, api_client):
-        self._run(api_client, interactive=False, save=True)
-        loaded = load_saved_credentials()
-        assert loaded is not None
-        assert loaded.url == URL
-        assert loaded.token == TOKEN
-        assert loaded.deployment_id == DEPLOYMENT_ID
-        # FR-026: the adopt run seeds the delta cache for the adopted host.
-        assert set(loaded.push_cache) == {"node1/dev"}
-        assert loaded.push_cache["node1/dev"].fingerprint == instance_fingerprint(_make_host())
-        assert loaded.push_cache["node1/dev"].host_keys
-
-
-# ---------------------------------------------------------------------------
-# Fingerprint stability (FR-026)
+# Fingerprint stability (unchanged from 011)
 # ---------------------------------------------------------------------------
 
 
@@ -346,7 +188,7 @@ class TestInstanceFingerprint:
     def test_is_sha256_hex(self):
         fp = instance_fingerprint(_make_host())
         assert len(fp) == 64
-        int(fp, 16)  # raises if not hex
+        int(fp, 16)
 
     @pytest.mark.parametrize(
         "change",
@@ -365,7 +207,23 @@ class TestInstanceFingerprint:
 
 
 # ---------------------------------------------------------------------------
-# Delta logic via run_push (FR-026, clarification Q1)
+# Adopt seeds the push cache (no consent, no url/token)
+# ---------------------------------------------------------------------------
+
+
+class TestAdoptSeedsCache:
+    def test_adopt_seeds_deployment_keyed_cache(self, tmp_config_dir, api_client, registry, mocker):
+        registry.return_value = [_make_host()]
+        _fake_process_instance(mocker)
+        _adopt_flow(api_client, allow_empty=False, interactive=False)
+        loaded = load_push_cache()
+        assert set(loaded) == {DEPLOYMENT_ID}
+        assert set(loaded[DEPLOYMENT_ID]) == {"node1/dev"}
+        assert loaded[DEPLOYMENT_ID]["node1/dev"].fingerprint == instance_fingerprint(_make_host())
+
+
+# ---------------------------------------------------------------------------
+# Delta logic via run_push
 # ---------------------------------------------------------------------------
 
 
@@ -375,8 +233,8 @@ class TestPushDelta:
         self.client = api_client
         self.registry = registry
 
-    def _seed(self, push_cache=None):
-        save_credentials(_credentials(push_cache=push_cache))
+    def _seed(self, instances):
+        save_push_cache({DEPLOYMENT_ID: instances})
 
     def _put_payload(self):
         self.client.put_registry.assert_called_once()
@@ -385,46 +243,37 @@ class TestPushDelta:
     def test_unchanged_instance_skips_keyscan_and_authorize(self, mocker):
         host = _make_host()
         self.registry.return_value = [host]
-        self._seed(
-            {host.name: CachedInstance(instance_fingerprint(host), [KEY_LINE_NODE1])}
-        )
+        self._seed({host.name: CachedInstance(instance_fingerprint(host), [KEY_LINE_NODE1])})
         scan = mocker.patch("remo_cli.core.web_adopt.scan_and_verify_host_key")
         authorize = mocker.patch("remo_cli.core.web_adopt.authorize_service_key")
 
-        result = run_push(interactive=False)
+        result = run_push(URL, CODE, interactive=False)
 
         assert [o.outcome for o in result.outcomes] == [OUTCOME_UNCHANGED]
         scan.assert_not_called()
         authorize.assert_not_called()
 
-    def test_unchanged_instance_reuses_cached_lines_in_payload(self, mocker):
-        """PUT replaces known_hosts wholesale, so cached lines must be re-sent."""
+    def test_unchanged_instance_reuses_cached_lines(self, mocker):
         host = _make_host()
         self.registry.return_value = [host]
-        self._seed(
-            {host.name: CachedInstance(instance_fingerprint(host), [KEY_LINE_NODE1])}
-        )
-        _fake_process_instance(mocker)  # would produce different lines if hit
+        self._seed({host.name: CachedInstance(instance_fingerprint(host), [KEY_LINE_NODE1])})
+        _fake_process_instance(mocker)
 
-        run_push(interactive=False)
+        run_push(URL, CODE, interactive=False)
 
         payload = self._put_payload()
         assert payload["host_keys"] == {host.name: [KEY_LINE_NODE1]}
-        assert [e["name"] for e in payload["registry"]] == [host.name]
 
     def test_changed_fingerprint_gets_full_treatment(self, mocker):
-        host = _make_host(host="10.0.0.99")  # host field changed since last push
+        host = _make_host(host="10.0.0.99")
         self.registry.return_value = [host]
-        stale_fp = instance_fingerprint(_make_host())  # fingerprint of the OLD entry
-        assert stale_fp != instance_fingerprint(host)
+        stale_fp = instance_fingerprint(_make_host())
         self._seed({host.name: CachedInstance(stale_fp, [KEY_LINE_NODE1])})
-        process = _fake_process_instance(mocker)
+        _fake_process_instance(mocker)
 
-        result = run_push(interactive=False)
+        result = run_push(URL, CODE, interactive=False)
 
-        assert process.call_count == 1
         assert [o.outcome for o in result.outcomes] == [OUTCOME_ADOPTED]
-        # Fresh lines from the re-scan, not the stale cached ones.
         assert self._put_payload()["host_keys"][host.name] != [KEY_LINE_NODE1]
 
     def test_new_instance_gets_full_treatment(self, mocker):
@@ -434,73 +283,39 @@ class TestPushDelta:
         self._seed({old.name: CachedInstance(instance_fingerprint(old), [KEY_LINE_NODE1])})
         process = _fake_process_instance(mocker)
 
-        result = run_push(interactive=False)
+        result = run_push(URL, CODE, interactive=False)
 
         assert {o.host.name: o.outcome for o in result.outcomes} == {
             old.name: OUTCOME_UNCHANGED,
             new.name: OUTCOME_ADOPTED,
         }
         assert process.call_count == 1
-        assert process.call_args.args[0] is new
 
-    def test_cached_entry_with_no_host_keys_is_retried_in_full(self, mocker):
-        host = _make_host()
-        self.registry.return_value = [host]
-        self._seed({host.name: CachedInstance(instance_fingerprint(host), [])})
-        process = _fake_process_instance(mocker)
-
-        result = run_push(interactive=False)
-
-        assert process.call_count == 1
-        assert [o.outcome for o in result.outcomes] == [OUTCOME_ADOPTED]
-
-    def test_ssm_instance_never_marked_unchanged(self, mocker):
-        ssm = _ssm_host()
-        self.registry.return_value = [ssm]
-        self._seed({ssm.name: CachedInstance(instance_fingerprint(ssm), [KEY_LINE_NODE1])})
-        process = _fake_process_instance(mocker, outcome=OUTCOME_SKIPPED_BY_DESIGN)
-
-        result = run_push(interactive=False)
-
-        assert process.call_count == 1
-        assert [o.outcome for o in result.outcomes] == [OUTCOME_SKIPPED_BY_DESIGN]
-        assert self._put_payload()["host_keys"] == {}
-
-    def test_removed_instance_dropped_from_mirror_with_revoke_note(self, capsys):
+    def test_removed_instance_dropped_with_revoke_note(self, capsys):
         remaining = _make_host()
         self.registry.return_value = [remaining]
         self._seed(
             {
-                remaining.name: CachedInstance(
-                    instance_fingerprint(remaining), [KEY_LINE_NODE1]
-                ),
+                remaining.name: CachedInstance(instance_fingerprint(remaining), [KEY_LINE_NODE1]),
                 "gone-host": CachedInstance("c" * 64, [KEY_LINE_WEB1]),
             }
         )
 
-        run_push(interactive=False)
+        run_push(URL, CODE, interactive=False)
 
         payload = self._put_payload()
         assert [e["name"] for e in payload["registry"]] == [remaining.name]
-        assert "gone-host" not in payload["host_keys"]
-        # Clarification Q1: removal propagates, revocation stays manual.
         out = capsys.readouterr().out
-        assert "gone-host" in out
-        assert "revoke it manually" in out
-        assert "authorized_keys" in out
-        # The removed instance is dropped from the rewritten cache.
-        loaded = load_saved_credentials()
-        assert loaded is not None
-        assert set(loaded.push_cache) == {remaining.name}
+        assert "gone-host" in out and "revoke it manually" in out
+        loaded = load_push_cache()
+        assert set(loaded[DEPLOYMENT_ID]) == {remaining.name}
 
     def test_cache_rebuilt_after_successful_put(self, mocker):
         unchanged = _make_host()
         fresh = _make_host(type_="hetzner", name="web1", host="5.6.7.8")
         flaky = _make_host(type_="hetzner", name="down1", host="5.6.7.9")
         self.registry.return_value = [unchanged, fresh, flaky]
-        self._seed(
-            {unchanged.name: CachedInstance(instance_fingerprint(unchanged), [KEY_LINE_NODE1])}
-        )
+        self._seed({unchanged.name: CachedInstance(instance_fingerprint(unchanged), [KEY_LINE_NODE1])})
 
         def fake(host, public_key, *, interactive, host_keys, known_hosts_file=None):
             if host.name == flaky.name:
@@ -510,121 +325,62 @@ class TestPushDelta:
 
         mocker.patch("remo_cli.core.web_adopt._process_instance", side_effect=fake)
 
-        run_push(interactive=False)
+        run_push(URL, CODE, interactive=False)
 
-        loaded = load_saved_credentials()
-        assert loaded is not None
-        # unchanged + newly adopted are cached; the skipped one is NOT, so the
-        # next push retries it in full.
-        assert set(loaded.push_cache) == {unchanged.name, fresh.name}
-        assert loaded.push_cache[unchanged.name].host_keys == [KEY_LINE_NODE1]
-        assert loaded.push_cache[fresh.name].fingerprint == instance_fingerprint(fresh)
+        loaded = load_push_cache()
+        assert set(loaded[DEPLOYMENT_ID]) == {unchanged.name, fresh.name}
 
     def test_failed_put_leaves_cache_untouched(self, mocker):
         host = _make_host()
         changed = _make_host(host="10.9.9.9")
         self.registry.return_value = [changed]
-        original_cache = {host.name: CachedInstance(instance_fingerprint(host), [KEY_LINE_NODE1])}
-        self._seed(original_cache)
+        original = {host.name: CachedInstance(instance_fingerprint(host), [KEY_LINE_NODE1])}
+        self._seed(original)
         _fake_process_instance(mocker)
         self.client.put_registry.side_effect = SetupApiError("boom", status=500)
 
         with pytest.raises(SetupApiError):
-            run_push(interactive=False)
+            run_push(URL, CODE, interactive=False)
 
-        loaded = load_saved_credentials()
-        assert loaded is not None
-        assert loaded.push_cache == original_cache
-
-    def test_full_mirror_always_put_even_when_everything_unchanged(self, mocker):
-        direct = _make_host()
-        ssm = _ssm_host()
-        self.registry.return_value = [direct, ssm]
-        self._seed(
-            {direct.name: CachedInstance(instance_fingerprint(direct), [KEY_LINE_NODE1])}
-        )
-        _fake_process_instance(mocker, outcome=OUTCOME_SKIPPED_BY_DESIGN)
-
-        run_push(interactive=False)
-
-        payload = self._put_payload()
-        assert {e["name"] for e in payload["registry"]} == {direct.name, ssm.name}
-        assert payload["host_keys"] == {direct.name: [KEY_LINE_NODE1]}
+        assert load_push_cache() == {DEPLOYMENT_ID: original}
 
 
 # ---------------------------------------------------------------------------
-# Hard failures (FR-027, FR-016) via run_push
+# Hard failures via run_push
 # ---------------------------------------------------------------------------
 
 
 class TestPushErrors:
-    def test_missing_credentials_raises(self, tmp_config_dir):
-        with pytest.raises(MissingCredentialsError, match="no saved service credentials"):
-            run_push(interactive=False)
-
-    def test_unreadable_credentials_file_raises_missing(self, tmp_config_dir):
-        credentials_path().write_text("{corrupt")
-        with pytest.raises(MissingCredentialsError):
-            run_push(interactive=False)
-
-    def test_client_built_from_saved_credentials(self, tmp_config_dir, api_client, registry, mocker):
+    def test_client_built_from_supplied_url_and_code(self, tmp_config_dir, api_client, registry, mocker):
         registry.return_value = [_make_host()]
         _fake_process_instance(mocker)
-        save_credentials(_credentials())
         from remo_cli.core import web_adopt
 
-        run_push(interactive=False)
-        web_adopt.SetupApiClient.assert_called_once_with(URL, TOKEN)
+        run_push(URL, CODE, interactive=False)
+        web_adopt.SetupApiClient.assert_called_once_with(URL, CODE)
 
-    def test_deployment_id_mismatch_aborts_with_readopt_guidance(
-        self, tmp_config_dir, api_client, registry
-    ):
-        save_credentials(_credentials())
-        api_client.get_identity.return_value = {
-            "deployment_id": "dep-NEW00000",
-            "public_key": PUBLIC_KEY,
-        }
-        with pytest.raises(AdoptError, match="remo web adopt"):
-            run_push(interactive=False)
-        api_client.put_registry.assert_not_called()
-        # The stale cache/file is not rewritten by an aborted push.
-        loaded = load_saved_credentials()
-        assert loaded is not None
-        assert loaded.deployment_id == DEPLOYMENT_ID
-
-    def test_rejected_token_raises_auth_error_with_readopt_guidance(
-        self, tmp_config_dir, api_client, registry
-    ):
-        save_credentials(_credentials())
-        api_client.get_identity.side_effect = SetupAuthError("nope", status=401)
-        with pytest.raises(SetupAuthError, match="remo web adopt") as excinfo:
-            run_push(interactive=False)
-        assert excinfo.value.status == 401
+    def test_mount_configured_aborts(self, tmp_config_dir, api_client, registry):
+        api_client.get_status.return_value = {"state": "mount_configured"}
+        with pytest.raises(MountConfiguredError):
+            run_push(URL, CODE, interactive=False)
         api_client.put_registry.assert_not_called()
 
     def test_missing_public_key_aborts(self, tmp_config_dir, api_client, registry):
-        save_credentials(_credentials())
-        api_client.get_identity.return_value = {
-            "deployment_id": DEPLOYMENT_ID,
-            "public_key": "",
-        }
+        api_client.get_identity.return_value = {"deployment_id": DEPLOYMENT_ID, "public_key": ""}
         with pytest.raises(AdoptError, match="no public key"):
-            run_push(interactive=False)
+            run_push(URL, CODE, interactive=False)
         api_client.put_registry.assert_not_called()
 
     def test_empty_registry_guard(self, tmp_config_dir, api_client, registry):
-        save_credentials(_credentials())
         registry.return_value = []
         with pytest.raises(EmptyRegistryError, match="--allow-empty"):
-            run_push(interactive=False)
+            run_push(URL, CODE, interactive=False)
         api_client.put_registry.assert_not_called()
 
-    def test_allow_empty_bypasses_guard(self, tmp_config_dir, api_client, registry):
-        save_credentials(_credentials())
-        registry.return_value = []
-        result = run_push(interactive=False, allow_empty=True)
-        assert result.outcomes == []
-        payload = api_client.put_registry.call_args.args[0]
-        assert payload["registry"] == []
-        # allow_empty must be forwarded so the SERVICE-side guard is bypassed too.
-        assert api_client.put_registry.call_args.kwargs["allow_empty"] is True
+    def test_dormant_404_maps_to_reopen_message(self, tmp_config_dir, api_client, registry):
+        registry.return_value = [_make_host()]
+        api_client.get_identity.side_effect = SetupNotFoundError(
+            "dormant", status=404
+        )
+        with pytest.raises(SetupNotFoundError):
+            run_push(URL, CODE, interactive=False)

--- a/tests/unit/web/_pairing_support.py
+++ b/tests/unit/web/_pairing_support.py
@@ -1,0 +1,53 @@
+"""Shared helpers for the 012 pairing app-level tests (dormancy/mint/origin).
+
+Builds a TestClient over the real FastAPI app with a no-op discovery service
+(so the lifespan never opens SSH) and a controllable operator-auth posture, plus
+a `mint` helper that drives the real `/pairing/mint` endpoint.
+"""
+
+from __future__ import annotations
+
+from fastapi.testclient import TestClient
+
+from remo_cli.web import app as app_module
+
+ORIGIN = "http://127.0.0.1:8080"
+
+
+class _NoopDiscovery:
+    async def refresh(self, instance_id: str | None = None, *, force: bool = True) -> None:
+        return None
+
+
+def make_client(
+    state_dir,
+    *,
+    operator_auth: str = "none",
+    forward_auth_header: str = "",
+    **extra,
+) -> TestClient:
+    overrides = dict(
+        allowed_hosts=["127.0.0.1", "localhost", "testserver"],
+        allowed_origins=[ORIGIN],
+        operator_auth=operator_auth,
+        forward_auth_header=forward_auth_header,
+    )
+    overrides.update(extra)
+    settings = state_dir.settings(**overrides)
+    application = app_module.create_app(settings)
+    application.state.discovery_service = _NoopDiscovery()
+    return TestClient(application, base_url=ORIGIN)
+
+
+def mint(client: TestClient, *, headers: dict[str, str] | None = None, origin: str = "adopt") -> str:
+    """Mint a code through the real endpoint; return it. Raises on non-200."""
+    hdrs = {"Origin": ORIGIN}
+    if headers:
+        hdrs.update(headers)
+    resp = client.post(f"/api/v1/pairing/mint?origin={origin}", headers=hdrs)
+    assert resp.status_code == 200, (resp.status_code, resp.text)
+    return resp.json()["code"]
+
+
+def bearer(code: str) -> dict[str, str]:
+    return {"Authorization": f"Bearer {code}"}

--- a/tests/unit/web/test_csp.py
+++ b/tests/unit/web/test_csp.py
@@ -121,15 +121,16 @@ def test_originless_setup_request_bypasses_origin_check(tmp_path, monkeypatch):
     # the route: with a token configured and presented, the request reaches
     # domain validation (422 for a garbage body), never 403.
     settings = _settings()
-    settings.api_token = "csp-test-token"
+    settings.operator_auth = "none"
     settings.web_identity_dir = tmp_path / "web-identity"
     monkeypatch.setenv("REMO_HOME", str(tmp_path))
     application = app_module.create_app(settings)
     with TestClient(application, base_url=_ORIGIN) as client:
+        code, _ = application.state.pairing_manager.mint(None)
         resp = client.put(
             "/api/v1/setup/registry",
             json={},
-            headers={"Authorization": "Bearer csp-test-token"},
+            headers={"Authorization": f"Bearer {code}"},
         )
     assert resp.status_code == 422
 
@@ -138,14 +139,15 @@ def test_setup_request_with_disallowed_origin_still_rejected():
     # A present-but-disallowed Origin on a setup route is still a 403 — only
     # the Origin-less (non-browser) case is exempt.
     settings = _settings()
-    settings.api_token = "csp-test-token"
+    settings.operator_auth = "none"
     application = app_module.create_app(settings)
     with TestClient(application, base_url=_ORIGIN) as client:
+        code, _ = application.state.pairing_manager.mint(None)
         resp = client.put(
             "/api/v1/setup/registry",
             json={},
             headers={
-                "Authorization": "Bearer csp-test-token",
+                "Authorization": f"Bearer {code}",
                 "Origin": "http://evil.example",
             },
         )

--- a/tests/unit/web/test_mint_gating.py
+++ b/tests/unit/web/test_mint_gating.py
@@ -1,0 +1,57 @@
+"""Mint-endpoint gating tests (012-web-adopt-pairing, T024, US3).
+
+`POST /pairing/mint` is refused (403) without the trusted forward-auth header,
+succeeds with it, records the operator subject in logs and on the session, and
+never logs the code (FR-011/FR-012, SC-004).
+"""
+
+from __future__ import annotations
+
+import logging
+
+from ._pairing_support import ORIGIN, bearer, make_client
+
+
+def test_mint_refused_without_header(state_dir):
+    state_dir.adopted()
+    client = make_client(state_dir, operator_auth="forward", forward_auth_header="X-Forwarded-User")
+    resp = client.post("/api/v1/pairing/mint", headers={"Origin": ORIGIN})
+    assert resp.status_code == 403
+    assert resp.json() == {"detail": "operator authentication required"}
+    # No session created -> setup stays dormant.
+    assert client.get("/api/v1/setup/status", headers=bearer("x")).status_code == 404
+
+
+def test_mint_succeeds_with_header(state_dir):
+    state_dir.adopted()
+    client = make_client(state_dir, operator_auth="forward", forward_auth_header="X-Forwarded-User")
+    resp = client.post(
+        "/api/v1/pairing/mint",
+        headers={"Origin": ORIGIN, "X-Forwarded-User": "alice"},
+    )
+    assert resp.status_code == 200
+    assert resp.headers.get("cache-control") == "no-store"
+    code = resp.json()["code"]
+    assert client.get("/api/v1/setup/status", headers=bearer(code)).status_code == 200
+
+
+def test_mint_disabled_when_unconfigured(state_dir):
+    state_dir.adopted()
+    client = make_client(state_dir, operator_auth="")  # no provider
+    resp = client.post("/api/v1/pairing/mint", headers={"Origin": ORIGIN})
+    assert resp.status_code == 403
+    assert resp.json() == {"detail": "operator authentication not configured"}
+
+
+def test_mint_logs_subject_not_code(state_dir, caplog):
+    state_dir.adopted()
+    client = make_client(state_dir, operator_auth="forward", forward_auth_header="X-Forwarded-User")
+    with caplog.at_level(logging.INFO, logger="remo_cli.web.pairing"):
+        resp = client.post(
+            "/api/v1/pairing/mint",
+            headers={"Origin": ORIGIN, "X-Forwarded-User": "carol"},
+        )
+    code = resp.json()["code"]
+    text = "\n".join(r.getMessage() for r in caplog.records)
+    assert "carol" in text
+    assert code not in text

--- a/tests/unit/web/test_operator_auth.py
+++ b/tests/unit/web/test_operator_auth.py
@@ -1,0 +1,90 @@
+"""Operator-auth provider seam tests (012-web-adopt-pairing, T023).
+
+Covers ForwardAuthProvider header trust, NetworkRestrictedProvider anonymity,
+and build_operator_auth_provider's fail-fast + disabled-minting behavior
+(FR-009/FR-011/FR-013).
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from remo_cli.web.operator_auth import (
+    ForwardAuthProvider,
+    NetworkRestrictedProvider,
+    OperatorAuthConfigError,
+    build_operator_auth_provider,
+)
+
+
+class _FakeRequest:
+    def __init__(self, headers: dict[str, str]) -> None:
+        # Starlette headers are case-insensitive; emulate with a lookup helper.
+        self._headers = {k.lower(): v for k, v in headers.items()}
+
+    @property
+    def headers(self):  # noqa: ANN202
+        store = self._headers
+
+        class _H:
+            def get(self, name: str, default: str = "") -> str:
+                return store.get(name.lower(), default)
+
+        return _H()
+
+
+def test_forward_auth_requires_header_name():
+    with pytest.raises(OperatorAuthConfigError):
+        ForwardAuthProvider("")
+    with pytest.raises(OperatorAuthConfigError):
+        ForwardAuthProvider("   ")
+
+
+def test_forward_auth_authenticates_only_with_header():
+    provider = ForwardAuthProvider("X-Forwarded-User")
+    assert provider.authenticate(_FakeRequest({})) is None
+    assert provider.authenticate(_FakeRequest({"X-Forwarded-User": "  "})) is None
+    identity = provider.authenticate(_FakeRequest({"X-Forwarded-User": "alice"}))
+    assert identity is not None
+    assert identity.subject == "alice"
+    assert identity.provider == "forward"
+    assert provider.posture == "forward"
+
+
+def test_network_restricted_is_anonymous():
+    provider = NetworkRestrictedProvider()
+    identity = provider.authenticate(_FakeRequest({}))
+    assert identity is not None
+    assert identity.provider == "network-restricted"
+    assert provider.posture == "network-restricted"
+
+
+class _Settings:
+    def __init__(self, operator_auth: str, forward_auth_header: str = "") -> None:
+        self.operator_auth = operator_auth
+        self.forward_auth_header = forward_auth_header
+
+
+def test_build_forward_fail_fast_without_header():
+    with pytest.raises(OperatorAuthConfigError):
+        build_operator_auth_provider(_Settings("forward", ""))
+
+
+def test_build_forward_ok_with_header():
+    provider = build_operator_auth_provider(_Settings("forward", "Remote-User"))
+    assert isinstance(provider, ForwardAuthProvider)
+    assert provider.header_name == "Remote-User"
+
+
+def test_build_none_is_network_restricted():
+    provider = build_operator_auth_provider(_Settings("none"))
+    assert isinstance(provider, NetworkRestrictedProvider)
+
+
+def test_build_unset_disables_minting():
+    assert build_operator_auth_provider(_Settings("")) is None
+
+
+def test_build_unknown_mode_raises():
+    with pytest.raises(OperatorAuthConfigError):
+        build_operator_auth_provider(_Settings("bogus"))

--- a/tests/unit/web/test_pairing.py
+++ b/tests/unit/web/test_pairing.py
@@ -1,0 +1,116 @@
+"""Pairing session manager unit tests (012-web-adopt-pairing, T008).
+
+Exercises the in-memory `PairingSessionManager` with an injected fake monotonic
+clock so every TTL branch is deterministic (no `sleep`): mint returns a code,
+rotation invalidates the prior, authenticate touches the sliding window, idle
+expiry drops the session, and end() is idempotent (Constitution II).
+"""
+
+from __future__ import annotations
+
+from remo_cli.web.operator_auth import OperatorIdentity
+from remo_cli.web.pairing import PairingSessionManager
+
+
+class _Clock:
+    """A controllable monotonic clock."""
+
+    def __init__(self) -> None:
+        self.t = 1000.0
+
+    def __call__(self) -> float:
+        return self.t
+
+    def advance(self, seconds: float) -> None:
+        self.t += seconds
+
+
+def _manager(clock: _Clock, ttl_s: float = 900.0) -> PairingSessionManager:
+    return PairingSessionManager(ttl_s=ttl_s, now=clock)
+
+
+def test_mint_returns_code_and_ttl():
+    clock = _Clock()
+    mgr = _manager(clock)
+    code, ttl = mgr.mint(None)
+    assert code and isinstance(code, str)
+    assert ttl == 900.0
+    assert mgr.is_live()
+
+
+def test_mint_records_identity():
+    clock = _Clock()
+    mgr = _manager(clock)
+    identity = OperatorIdentity(subject="alice", provider="forward")
+    code, _ = mgr.mint(identity, "resync")
+    assert mgr.current_identity() == identity
+    session = mgr.authenticate(code)
+    assert session is not None
+    assert session.identity == identity
+    assert session.origin == "resync"
+
+
+def test_authenticate_success_and_wrong_code():
+    clock = _Clock()
+    mgr = _manager(clock)
+    code, _ = mgr.mint(None)
+    assert mgr.authenticate(code) is not None
+    assert mgr.authenticate("nope") is None
+    assert mgr.authenticate("") is None
+
+
+def test_authenticate_non_ascii_presented_is_a_clean_mismatch():
+    # A raw Authorization header byte 0x80-0xFF decodes to a non-ASCII str;
+    # comparing it must NOT raise (hmac.compare_digest rejects non-ASCII str) —
+    # it must return None (the dormant 404), never crash the gate with a 500.
+    clock = _Clock()
+    mgr = _manager(clock)
+    mgr.mint(None)
+    assert mgr.authenticate("café☕éé") is None
+
+
+def test_rotation_invalidates_prior_code():
+    clock = _Clock()
+    mgr = _manager(clock)
+    first, _ = mgr.mint(None)
+    second, _ = mgr.mint(None)
+    assert first != second
+    assert mgr.authenticate(first) is None
+    assert mgr.authenticate(second) is not None
+
+
+def test_sliding_ttl_touch_extends_window():
+    clock = _Clock()
+    mgr = _manager(clock, ttl_s=100.0)
+    code, _ = mgr.mint(None)
+    clock.advance(80)
+    # A successful authenticate touches the session, resetting the idle window.
+    assert mgr.authenticate(code) is not None
+    clock.advance(80)  # 80s since the touch < 100s ttl
+    assert mgr.authenticate(code) is not None
+
+
+def test_idle_expiry_drops_session():
+    clock = _Clock()
+    mgr = _manager(clock, ttl_s=100.0)
+    code, _ = mgr.mint(None)
+    clock.advance(101)
+    assert mgr.is_live() is False
+    assert mgr.authenticate(code) is None
+
+
+def test_end_is_idempotent():
+    clock = _Clock()
+    mgr = _manager(clock)
+    code, _ = mgr.mint(None)
+    mgr.end()
+    assert mgr.is_live() is False
+    mgr.end()  # no error on a second end
+    assert mgr.authenticate(code) is None
+
+
+def test_authenticate_when_dormant_returns_none():
+    clock = _Clock()
+    mgr = _manager(clock)
+    assert mgr.is_live() is False
+    assert mgr.authenticate("anything") is None

--- a/tests/unit/web/test_pairing_origin.py
+++ b/tests/unit/web/test_pairing_origin.py
@@ -1,0 +1,43 @@
+"""Origin-allowlist interaction tests (012-web-adopt-pairing, T022, R11).
+
+The browser-only `/pairing/*` routes remain subject to the Origin allowlist,
+while the CLI-facing `/api/v1/setup/*` origin-less exemption is intact.
+"""
+
+from __future__ import annotations
+
+from ._pairing_support import bearer, make_client, mint
+
+
+def test_mint_rejected_without_origin(state_dir):
+    state_dir.adopted()
+    client = make_client(state_dir)
+    # No Origin header on a state-changing POST -> blocked by the allowlist.
+    resp = client.post("/api/v1/pairing/mint")
+    assert resp.status_code == 403
+    assert resp.json()["error"]["code"] == "forbidden_origin"
+
+
+def test_mint_rejected_with_bad_origin(state_dir):
+    state_dir.adopted()
+    client = make_client(state_dir)
+    resp = client.post("/api/v1/pairing/mint", headers={"Origin": "http://evil.example"})
+    assert resp.status_code == 403
+    assert resp.json()["error"]["code"] == "forbidden_origin"
+
+
+def test_setup_routes_remain_originless_exempt(state_dir):
+    state_dir.adopted()
+    client = make_client(state_dir)
+    code = mint(client)
+    # The CLI calls setup with NO Origin header (it has none) — still allowed.
+    resp = client.put(
+        "/api/v1/setup/registry",
+        headers=bearer(code),  # deliberately no Origin
+        json={
+            "version": 1,
+            "registry": [{"type": "incus", "name": "dev", "host": "10.0.0.5", "user": "remo"}],
+            "host_keys": {},
+        },
+    )
+    assert resp.status_code == 200

--- a/tests/unit/web/test_setup_api.py
+++ b/tests/unit/web/test_setup_api.py
@@ -46,14 +46,32 @@ class _NoopDiscovery:
         return None
 
 
-def _client(state_dir, *, token: str = _TOKEN) -> TestClient:
+def _inject_session(application, code: str = _TOKEN) -> None:
+    """Directly install a live pairing session with a KNOWN code (012).
+
+    Reaches into the in-memory manager so the many ``_AUTH`` (Bearer _TOKEN)
+    call sites below keep working without minting a random code per test. The
+    huge ttl means it never idle-expires mid-test.
+    """
+    import time
+
+    from remo_cli.web.pairing import PairingSession
+
+    application.state.pairing_manager._session = PairingSession(
+        code=code, identity=None, origin="adopt", last_activity=time.monotonic(), ttl_s=1e9
+    )
+
+
+def _client(state_dir, *, live: bool = True) -> TestClient:
     settings = state_dir.settings(
         allowed_hosts=["testserver", "localhost", "127.0.0.1"],
         allowed_origins=[_ORIGIN],
-        api_token=token,
+        operator_auth="none",
     )
     application = app_module.create_app(settings)
     application.state.discovery_service = _NoopDiscovery()
+    if live:
+        _inject_session(application)
     return TestClient(application, base_url=_ORIGIN)
 
 
@@ -250,6 +268,7 @@ def test_put_registry_happy_path_applies_mirror_and_flips_to_adopted(state_dir):
         assert _service_known_hosts(state_dir).read_text() == _VALID_KEY_LINE + "\n"
         assert state_dir.registry_path.read_text() == _EXPECTED_REGISTRY_TEXT
 
+        # The PUT does not end the session (verify is the terminal step, FR-007).
         status = client.get("/api/v1/setup/status", headers=_AUTH).json()
     assert status["state"] == "adopted"
     assert status["registry_instances"] == 2
@@ -375,7 +394,9 @@ def test_put_registry_mid_apply_failure_is_safe_and_converges(state_dir, monkeyp
         assert not state_dir.registry_path.exists()
         assert _service_known_hosts(state_dir).read_text() == _VALID_KEY_LINE + "\n"
 
-        # A subsequent successful push converges to the full mirror.
+        # A subsequent successful push converges to the full mirror. (The
+        # first PUT failed inside _apply_payload, before end(), so the session
+        # is still live here.)
         fail_registry_write["active"] = False
         resp = client.put("/api/v1/setup/registry", json=_payload(), headers=_AUTH)
         assert resp.status_code == 200
@@ -452,7 +473,7 @@ def test_verify_all_passed_true_when_every_check_passes(state_dir, monkeypatch):
 
 
 # ---------------------------------------------------------------------------
-# Auth inheritance (dedicated exhaustive matrix lives in a later task)
+# Pairing gate inheritance (dormancy matrix lives in test_setup_dormancy.py)
 # ---------------------------------------------------------------------------
 
 
@@ -464,21 +485,22 @@ def _request(client: TestClient, method: str, path: str, headers: dict[str, str]
 
 
 @pytest.mark.parametrize(("method", "path"), _SETUP_ROUTES)
-def test_setup_routes_are_404_when_token_unset(state_dir, method, path):
+def test_setup_routes_are_404_when_no_live_session(state_dir, method, path):
     state_dir.unconfigured()
-    with _client(state_dir, token="") as client:
+    with _client(state_dir, live=False) as client:
         resp = _request(client, method, path, {"Origin": _ORIGIN})
     assert resp.status_code == 404
-    # Fail closed: indistinguishable from an unknown route.
+    # Fail closed: indistinguishable from an unknown route (FR-005).
     assert resp.json() == {"detail": "Not Found"}
 
 
 @pytest.mark.parametrize(("method", "path"), _SETUP_ROUTES)
-def test_setup_routes_are_401_on_wrong_token(state_dir, method, path):
+def test_setup_routes_are_dormant_404_on_wrong_code(state_dir, method, path):
     state_dir.unconfigured()
-    with _client(state_dir) as client:
+    with _client(state_dir) as client:  # a live session exists, but the code is wrong
         resp = _request(
-            client, method, path, {"Authorization": "Bearer wrong-token", "Origin": _ORIGIN}
+            client, method, path, {"Authorization": "Bearer wrong-code", "Origin": _ORIGIN}
         )
-    assert resp.status_code == 401
-    assert resp.json() == {"detail": "unauthorized"}
+    # FR-006: a wrong-but-present code is the SAME dormant 404, never a 401.
+    assert resp.status_code == 404
+    assert resp.json() == {"detail": "Not Found"}

--- a/tests/unit/web/test_setup_auth.py
+++ b/tests/unit/web/test_setup_auth.py
@@ -1,44 +1,36 @@
-"""Setup-surface auth contract matrix (011-web-adopt T037/T038).
+"""Setup-surface pairing-gate contract (012-web-adopt-pairing).
 
-Exhaustive coverage of the authentication table in
-specs/011-web-adopt/contracts/setup-api.md, over EVERY setup route
-(FR-020/FR-021/FR-022/FR-024):
+Supersedes the 011 static-token matrix. Covers the `require_pairing_code` gate
+(contracts/setup-api.md, FR-005/FR-006) over EVERY setup route:
 
-- valid token        -> the route's own domain code, never 401/404-auth
-- invalid token      -> 401 {"detail": "unauthorized"} (near-miss variants)
-- missing header     -> 401
-- malformed header   -> 401 (no Bearer prefix, empty value, Basic scheme, ...)
-- token unset        -> 404 with FastAPI's stock body on ALL setup routes,
-                        byte-identical to a genuinely unknown route
-- non-setup surface  -> byte-identical behavior with and without a token
-- comparison         -> the verdict comes from `hmac.compare_digest`
-                        (constant-time), proven by a monkeypatch spy
-
-The basic auth-inheritance proofs (each route 404s when unset / 401s on a
-plain wrong token) live in tests/unit/web/test_setup_api.py; this module goes
-deeper rather than repeating them.
-
-T038 (failed-auth observability, FR-022/FR-024): every 401 emits a log line
-with route/method context that never contains any fragment of the presented
-credential, and a worst-case simulated line carrying an Authorization header
-is masked by the configured `RedactingFilter` (same fabricated-record
-convention as tests/unit/web/test_log_redaction.py).
+- live session + correct code -> the route's own domain response, never a 404
+- live session + wrong/missing/malformed bearer -> dormant 404 (never a 401)
+- no live session -> dormant 404 with FastAPI's stock body, byte-identical to an
+  unknown route (indistinguishable from absent), with or without a bearer
+- non-setup surface -> unaffected by the pairing state / Authorization header
+- comparison -> the verdict comes from `hmac.compare_digest` inside the pairing
+  manager (constant-time), proven by a monkeypatch spy
+- observability -> the wrong-code path logs route/method context but never the
+  presented code; the no-session path logs nothing (silent as absent); the
+  RedactingFilter backstop masks a worst-case interpolated code
 """
 
 from __future__ import annotations
 
 import logging
+import time
 from typing import Any
 
 import pytest
 from fastapi.testclient import TestClient
 
 from remo_cli.web import app as app_module
-from remo_cli.web.api import setup as setup_api
+from remo_cli.web import pairing as pairing_module
 from remo_cli.web.logging_config import RedactingFilter
+from remo_cli.web.pairing import PairingSession
 
 _ORIGIN = "http://testserver"
-_TOKEN = "unit-test-setup-token"
+_CODE = "unit-test-pairing-code"
 
 _SETUP_ROUTES = [
     ("GET", "/api/v1/setup/status"),
@@ -47,23 +39,17 @@ _SETUP_ROUTES = [
     ("POST", "/api/v1/setup/verify"),
 ]
 
-#: Expected status per route with a VALID token and a minimal request body
-#: (`{}` for PUT/POST). Registry hits the 422 invalid_payload domain path --
-#: still proof the request got PAST auth (contract: "route handles request").
-_SETUP_ROUTES_VALID_TOKEN = [
+_SETUP_ROUTES_VALID_CODE = [
     ("GET", "/api/v1/setup/status", 200),
     ("GET", "/api/v1/setup/identity", 200),
-    ("PUT", "/api/v1/setup/registry", 422),
+    ("PUT", "/api/v1/setup/registry", 422),  # got PAST the gate into domain code
     ("POST", "/api/v1/setup/verify", 200),
 ]
 
-_UNAUTHORIZED_BODY = {"detail": "unauthorized"}
 _NOT_FOUND_BODY = {"detail": "Not Found"}
 
 
 class _NoopDiscovery:
-    """Stops the app lifespan's initial discovery from opening real SSH."""
-
     async def refresh(self, instance_id: str | None = None, *, force: bool = True) -> None:
         return None
 
@@ -71,81 +57,55 @@ class _NoopDiscovery:
         return []
 
 
-def _client(state_dir, *, token: str = _TOKEN) -> TestClient:
+def _inject_session(application, code: str = _CODE) -> None:
+    application.state.pairing_manager._session = PairingSession(
+        code=code, identity=None, origin="adopt", last_activity=time.monotonic(), ttl_s=1e9
+    )
+
+
+def _client(state_dir, *, live: bool = True) -> TestClient:
     settings = state_dir.settings(
         allowed_hosts=["testserver", "localhost", "127.0.0.1"],
         allowed_origins=[_ORIGIN],
-        api_token=token,
+        operator_auth="none",
     )
     application = app_module.create_app(settings)
     application.state.discovery_service = _NoopDiscovery()
+    if live:
+        _inject_session(application)
     return TestClient(application, base_url=_ORIGIN)
 
 
 def _request(client: TestClient, method: str, path: str, headers: dict[str, str]):
-    """Issue *method path*; PUT/POST always carry an allowed Origin + `{}` body."""
     kwargs: dict[str, Any] = {"headers": {"Origin": _ORIGIN, **headers}}
     if method in {"PUT", "POST"}:
         kwargs["json"] = {}
     return client.request(method, path, **kwargs)
 
 
-# ---------------------------------------------------------------------------
-# (a) Valid token -> the route's own domain response, never an auth code
-# ---------------------------------------------------------------------------
+# --- (a) valid code -> the route's own domain response ---------------------
 
 
-@pytest.mark.parametrize(("method", "path", "expected"), _SETUP_ROUTES_VALID_TOKEN)
-def test_valid_token_reaches_route_handler(state_dir, method, path, expected):
-    state_dir.unconfigured()  # empty registry: verify does no SSH round-trips
-    with _client(state_dir) as client:
-        resp = _request(client, method, path, {"Authorization": f"Bearer {_TOKEN}"})
-    assert resp.status_code == expected
-    assert resp.status_code not in (401, 404)
-    body = resp.json()
-    assert body != _UNAUTHORIZED_BODY
-    assert body != _NOT_FOUND_BODY
-    if path.endswith("/registry"):
-        # The 422 is the route's OWN domain shape, not an auth rejection.
-        assert body["reason"] == "invalid_payload"
-
-
-def test_valid_token_accepts_case_insensitive_scheme_and_padding(state_dir):
-    """RFC 7235: the auth scheme is case-insensitive; token whitespace is trimmed."""
+@pytest.mark.parametrize(("method", "path", "expected"), _SETUP_ROUTES_VALID_CODE)
+def test_valid_code_reaches_route_handler(state_dir, method, path, expected):
     state_dir.unconfigured()
     with _client(state_dir) as client:
-        for header in (f"bearer {_TOKEN}", f"BEARER {_TOKEN}", f"Bearer  {_TOKEN} "):
+        resp = _request(client, method, path, {"Authorization": f"Bearer {_CODE}"})
+    assert resp.status_code == expected
+    assert resp.status_code != 404
+    if path.endswith("/registry"):
+        assert resp.json()["reason"] == "invalid_payload"
+
+
+def test_valid_code_accepts_case_insensitive_scheme(state_dir):
+    state_dir.unconfigured()
+    with _client(state_dir) as client:
+        for header in (f"bearer {_CODE}", f"BEARER {_CODE}", f"Bearer  {_CODE} "):
             resp = _request(client, "GET", "/api/v1/setup/status", {"Authorization": header})
             assert resp.status_code == 200, f"header {header!r} should authenticate"
 
 
-# ---------------------------------------------------------------------------
-# (b) Invalid token -> 401 (near-miss variants, beyond the plain wrong token
-#     already covered by test_setup_api.py's inheritance tests)
-# ---------------------------------------------------------------------------
-
-
-@pytest.mark.parametrize(
-    "presented",
-    [
-        pytest.param(_TOKEN[:-1], id="prefix-of-real-token"),
-        pytest.param(_TOKEN + "x", id="real-token-plus-suffix"),
-        pytest.param(_TOKEN.upper(), id="case-flipped-token"),
-        pytest.param(f"{_TOKEN} {_TOKEN}", id="token-with-trailing-garbage"),
-    ],
-)
-@pytest.mark.parametrize(("method", "path"), _SETUP_ROUTES)
-def test_near_miss_tokens_are_401_on_every_route(state_dir, method, path, presented):
-    state_dir.unconfigured()
-    with _client(state_dir) as client:
-        resp = _request(client, method, path, {"Authorization": f"Bearer {presented}"})
-    assert resp.status_code == 401
-    assert resp.json() == _UNAUTHORIZED_BODY
-
-
-# ---------------------------------------------------------------------------
-# (c) + (d) Missing / malformed Authorization header -> 401 on every route
-# ---------------------------------------------------------------------------
+# --- (b) wrong/malformed bearer with a live session -> dormant 404 ---------
 
 
 @pytest.mark.parametrize(
@@ -153,226 +113,161 @@ def test_near_miss_tokens_are_401_on_every_route(state_dir, method, path, presen
     [
         pytest.param({}, id="missing-header"),
         pytest.param({"Authorization": ""}, id="empty-value"),
-        pytest.param({"Authorization": _TOKEN}, id="bare-token-no-scheme"),
-        pytest.param({"Authorization": f"Basic {_TOKEN}"}, id="basic-scheme"),
-        pytest.param({"Authorization": "Bearer"}, id="scheme-only-no-token"),
-        pytest.param({"Authorization": "Bearer "}, id="scheme-and-space-only"),
-        pytest.param({"Authorization": f"Bearer{_TOKEN}"}, id="no-space-after-scheme"),
-        pytest.param({"Authorization": f"Token {_TOKEN}"}, id="token-scheme"),
+        pytest.param({"Authorization": _CODE}, id="bare-code-no-scheme"),
+        pytest.param({"Authorization": f"Basic {_CODE}"}, id="basic-scheme"),
+        pytest.param({"Authorization": "Bearer"}, id="scheme-only"),
+        pytest.param({"Authorization": f"Bearer {_CODE[:-1]}"}, id="near-miss"),
+        pytest.param({"Authorization": f"Bearer {_CODE.upper()}"}, id="case-flipped"),
     ],
 )
 @pytest.mark.parametrize(("method", "path"), _SETUP_ROUTES)
-def test_missing_or_malformed_header_is_401_on_every_route(state_dir, method, path, headers):
+def test_wrong_or_malformed_bearer_is_dormant_404(state_dir, method, path, headers):
     state_dir.unconfigured()
     with _client(state_dir) as client:
         resp = _request(client, method, path, headers)
-    assert resp.status_code == 401
-    assert resp.json() == _UNAUTHORIZED_BODY
+    # FR-006: never a distinguishable 401.
+    assert resp.status_code == 404
+    assert resp.json() == _NOT_FOUND_BODY
 
 
-# ---------------------------------------------------------------------------
-# (e) Token unset -> 404 with FastAPI's stock body; surface indistinguishable
-#     from absent (FR-021)
-# ---------------------------------------------------------------------------
+# --- (c) no live session -> dormant 404, indistinguishable from absent -----
 
 
-@pytest.mark.parametrize("token", [pytest.param("", id="empty"), pytest.param("   ", id="whitespace-only")])
 @pytest.mark.parametrize(("method", "path"), _SETUP_ROUTES)
-def test_unset_or_blank_token_is_404_even_with_credentials(state_dir, method, path, token):
-    """Fail closed: with no token configured, even a client PRESENTING a
-    bearer credential gets the stock 404 -- never a 401 that would reveal the
-    surface exists."""
+def test_no_session_is_404_even_with_a_bearer(state_dir, method, path):
     state_dir.unconfigured()
-    with _client(state_dir, token=token) as client:
+    with _client(state_dir, live=False) as client:
         resp = _request(client, method, path, {"Authorization": "Bearer anything-at-all"})
     assert resp.status_code == 404
     assert resp.json() == _NOT_FOUND_BODY
 
 
-def test_unset_token_404_is_indistinguishable_from_unknown_route(state_dir):
+def test_dormant_404_is_indistinguishable_from_unknown_route(state_dir):
     state_dir.unconfigured()
-    with _client(state_dir, token="") as client:
-        disabled = client.get("/api/v1/setup/status")
+    with _client(state_dir, live=False) as client:
+        dormant = client.get("/api/v1/setup/status")
         unknown = client.get("/api/v1/setup/no-such-route")
-        unrelated_unknown = client.get("/api/v1/definitely-not-a-route")
-    assert disabled.status_code == unknown.status_code == unrelated_unknown.status_code == 404
-    assert disabled.json() == unknown.json() == unrelated_unknown.json() == _NOT_FOUND_BODY
+        unrelated = client.get("/api/v1/definitely-not-a-route")
+    assert dormant.status_code == unknown.status_code == unrelated.status_code == 404
+    assert dormant.json() == unknown.json() == unrelated.json() == _NOT_FOUND_BODY
 
 
-# ---------------------------------------------------------------------------
-# (f) Non-setup surface unaffected by token configuration (FR-021/FR-023)
-# ---------------------------------------------------------------------------
-
-
-@pytest.mark.parametrize("path", ["/api/v1/health", "/api/v1/ready", "/api/v1/hosts"])
-def test_non_setup_surface_identical_with_and_without_token(state_dir, path):
-    state_dir.adopted()
-    with _client(state_dir, token=_TOKEN) as client:
-        with_token = client.get(path)
-    with _client(state_dir, token="") as client:
-        without_token = client.get(path)
-    assert with_token.status_code == without_token.status_code
-    assert with_token.json() == without_token.json()
-    # And a token-configured deployment never demands the token OUTSIDE /setup.
-    assert with_token.status_code != 401
+# --- (d) non-setup surface unaffected --------------------------------------
 
 
 def test_non_setup_surface_ignores_authorization_header(state_dir):
-    """A bearer header (right or wrong) on non-setup routes changes nothing."""
     state_dir.adopted()
     with _client(state_dir) as client:
         bare = client.get("/api/v1/ready")
-        with_good = client.get("/api/v1/ready", headers={"Authorization": f"Bearer {_TOKEN}"})
-        with_bad = client.get("/api/v1/ready", headers={"Authorization": "Bearer wrong"})
-    assert bare.status_code == with_good.status_code == with_bad.status_code
-    assert bare.json() == with_good.json() == with_bad.json()
+        good = client.get("/api/v1/ready", headers={"Authorization": f"Bearer {_CODE}"})
+        bad = client.get("/api/v1/ready", headers={"Authorization": "Bearer wrong"})
+    assert bare.status_code == good.status_code == bad.status_code
+    assert bare.json() == good.json() == bad.json()
 
 
-# ---------------------------------------------------------------------------
-# (g) Constant-time comparison: `hmac.compare_digest` IS the verdict (FR-022)
-# ---------------------------------------------------------------------------
+# --- (e) constant-time comparison via the pairing manager ------------------
 
 
 class _SpyHmac:
-    """Stands in for setup.py's `hmac` module global; records + delegates."""
-
     def __init__(self, forced: bool | None = None) -> None:
-        self.calls: list[tuple[bytes, bytes]] = []
+        self.calls: list[tuple[str, str]] = []
         self._forced = forced
 
-    def compare_digest(self, a: bytes, b: bytes) -> bool:
+    def compare_digest(self, a, b) -> bool:
         import hmac as real_hmac
 
         self.calls.append((a, b))
         return real_hmac.compare_digest(a, b) if self._forced is None else self._forced
 
 
-def test_token_check_calls_hmac_compare_digest_with_both_tokens(state_dir, monkeypatch):
+def test_code_check_uses_compare_digest(state_dir, monkeypatch):
     state_dir.unconfigured()
     spy = _SpyHmac()
-    monkeypatch.setattr(setup_api, "hmac", spy)
+    monkeypatch.setattr(pairing_module, "hmac", spy)
     with _client(state_dir) as client:
-        ok = client.get("/api/v1/setup/status", headers={"Authorization": f"Bearer {_TOKEN}"})
+        ok = client.get("/api/v1/setup/status", headers={"Authorization": f"Bearer {_CODE}"})
         bad = client.get("/api/v1/setup/status", headers={"Authorization": "Bearer nope"})
     assert ok.status_code == 200
-    assert bad.status_code == 401
-    # Every comparison went through compare_digest, presented vs configured.
-    assert spy.calls == [
-        (_TOKEN.encode(), _TOKEN.encode()),
-        (b"nope", _TOKEN.encode()),
-    ]
+    assert bad.status_code == 404
+    # The comparison is done on UTF-8 bytes (never str — a non-ASCII bearer
+    # would make hmac.compare_digest raise on str and crash the gate).
+    assert (_CODE.encode(), _CODE.encode()) in spy.calls
+    assert (b"nope", _CODE.encode()) in spy.calls
 
 
 def test_compare_digest_verdict_is_authoritative(state_dir, monkeypatch):
-    """Force compare_digest to False: even the CORRECT token must 401, proving
-    no shortcut equality (`==`) path exists beside the constant-time check."""
+    """Force compare_digest False: even the correct code must 404."""
     state_dir.unconfigured()
-    spy = _SpyHmac(forced=False)
-    monkeypatch.setattr(setup_api, "hmac", spy)
+    monkeypatch.setattr(pairing_module, "hmac", _SpyHmac(forced=False))
     with _client(state_dir) as client:
-        resp = client.get("/api/v1/setup/status", headers={"Authorization": f"Bearer {_TOKEN}"})
-    assert resp.status_code == 401
-    assert spy.calls == [(_TOKEN.encode(), _TOKEN.encode())]
-
-
-def test_unset_token_never_reaches_comparison(state_dir, monkeypatch):
-    """The 404 fail-closed branch short-circuits BEFORE any token comparison."""
-    state_dir.unconfigured()
-    spy = _SpyHmac()
-    monkeypatch.setattr(setup_api, "hmac", spy)
-    with _client(state_dir, token="") as client:
-        resp = client.get("/api/v1/setup/status", headers={"Authorization": f"Bearer {_TOKEN}"})
+        resp = client.get("/api/v1/setup/status", headers={"Authorization": f"Bearer {_CODE}"})
     assert resp.status_code == 404
-    assert spy.calls == []
 
 
-# ---------------------------------------------------------------------------
-# T038: failed-auth observability (FR-022/FR-024)
-# ---------------------------------------------------------------------------
+# --- (f) observability ------------------------------------------------------
 
 _SETUP_LOGGER = "remo_cli.web.setup"
-
-#: Deliberately distinctive so any fragment leaking into a log is caught.
-_PRESENTED = "PRESENTEDsecretCREDENTIALxyzzy123456"
+_PRESENTED = "PRESENTEDsecretCODExyzzy123456"
 
 
-def _auth_failure_records(caplog: pytest.LogCaptureFixture) -> list[logging.LogRecord]:
+def _gate_failure_records(caplog):
     return [
         r
         for r in caplog.records
-        if r.name == _SETUP_LOGGER and "authentication failure" in r.getMessage()
+        if r.name == _SETUP_LOGGER and "no valid pairing code" in r.getMessage()
     ]
 
 
 @pytest.mark.parametrize(("method", "path"), _SETUP_ROUTES)
-def test_401_emits_log_with_route_and_method_context(state_dir, caplog, method, path):
+def test_wrong_code_logs_route_context(state_dir, caplog, method, path):
     state_dir.unconfigured()
     with caplog.at_level(logging.WARNING, logger=_SETUP_LOGGER):
         with _client(state_dir) as client:
             resp = _request(client, method, path, {"Authorization": f"Bearer {_PRESENTED}"})
-    assert resp.status_code == 401
-
-    records = _auth_failure_records(caplog)
-    assert len(records) == 1, "exactly one auth-failure log line per rejected request"
+    assert resp.status_code == 404
+    records = _gate_failure_records(caplog)
+    assert len(records) == 1
     message = records[0].getMessage()
-    assert method in message
-    assert path in message
-    assert records[0].levelno == logging.WARNING
+    assert method in message and path in message
 
 
-@pytest.mark.parametrize(
-    "headers",
-    [
-        pytest.param({"Authorization": f"Bearer {_PRESENTED}"}, id="wrong-bearer-token"),
-        pytest.param({"Authorization": f"Basic {_PRESENTED}"}, id="basic-scheme"),
-        pytest.param({"Authorization": _PRESENTED}, id="bare-credential"),
-    ],
-)
-def test_401_log_never_contains_presented_credential(state_dir, caplog, headers):
+def test_wrong_code_log_never_contains_presented_code(state_dir, caplog):
     state_dir.unconfigured()
     with caplog.at_level(logging.WARNING, logger=_SETUP_LOGGER):
         with _client(state_dir) as client:
-            resp = _request(client, "PUT", "/api/v1/setup/registry", headers)
-    assert resp.status_code == 401
-    assert _auth_failure_records(caplog), "the failure must still be observable"
-
-    fragments = (_PRESENTED, _PRESENTED[:12], _PRESENTED[-12:], _TOKEN)
+            resp = _request(
+                client, "PUT", "/api/v1/setup/registry", {"Authorization": f"Bearer {_PRESENTED}"}
+            )
+    assert resp.status_code == 404
+    assert _gate_failure_records(caplog)
+    fragments = (_PRESENTED, _PRESENTED[:12], _PRESENTED[-12:], _CODE)
     for record in caplog.records:
         rendered = record.getMessage() + " " + str(record.args or "")
         for fragment in fragments:
-            assert fragment not in rendered, (
-                f"credential fragment {fragment!r} leaked into log: {rendered!r}"
-            )
+            assert fragment not in rendered
 
 
-def test_disabled_surface_404_emits_no_auth_failure_log(state_dir, caplog):
-    """Fail closed means silent-as-absent: the 404 path logs no auth failure."""
+def test_no_session_404_emits_no_gate_failure_log(state_dir, caplog):
     state_dir.unconfigured()
     with caplog.at_level(logging.DEBUG, logger=_SETUP_LOGGER):
-        with _client(state_dir, token="") as client:
+        with _client(state_dir, live=False) as client:
             resp = client.get(
                 "/api/v1/setup/status", headers={"Authorization": f"Bearer {_PRESENTED}"}
             )
     assert resp.status_code == 404
-    assert _auth_failure_records(caplog) == []
+    assert _gate_failure_records(caplog) == []
 
 
-def test_simulated_authorization_header_log_line_is_redacted(state_dir, caplog):
-    """Backstop (FR-022): if a log line ever DID interpolate the raw header,
-    the app's configured RedactingFilter masks it. Emit such a line through
-    the real logger while the app (and thus `configure_logging()`'s
-    filter-bearing handler) is live, then apply the filter to the captured
-    record per test_log_redaction.py's fabricated-record convention."""
+def test_simulated_code_log_line_is_redacted(state_dir, caplog):
     state_dir.unconfigured()
     with caplog.at_level(logging.WARNING, logger=_SETUP_LOGGER):
-        with _client(state_dir):  # create_app() ran configure_logging()
+        with _client(state_dir):
             logging.getLogger(_SETUP_LOGGER).warning(
                 "rejected request with Authorization: Bearer %s", _PRESENTED
             )
-
     [record] = [r for r in caplog.records if r.name == _SETUP_LOGGER]
     RedactingFilter().filter(record)
     rendered = record.getMessage()
     assert _PRESENTED not in rendered
     assert "<redacted>" in rendered
-    assert "rejected request" in rendered  # context survives, credential doesn't
+    assert "rejected request" in rendered

--- a/tests/unit/web/test_setup_dormancy.py
+++ b/tests/unit/web/test_setup_dormancy.py
@@ -1,0 +1,110 @@
+"""Setup-surface dormancy tests (012-web-adopt-pairing, T018/T019, US2).
+
+Proves the setup surface is `404` (byte-identical to an unknown route) whenever
+no live pairing session exists, responds to the live code once minted, returns
+to dormant on idle expiry and on adoption completion, and that a wrong-but-
+present code yields the same `404` — never a distinguishable `401`
+(FR-005/FR-006, SC-001). Also asserts health/readiness bodies are byte-unchanged
+across dormant / live-session / post-adoption states (SC-008).
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from ._pairing_support import ORIGIN, bearer, make_client, mint
+
+_SETUP_ROUTES = [
+    ("GET", "/api/v1/setup/status"),
+    ("GET", "/api/v1/setup/identity"),
+    ("PUT", "/api/v1/setup/registry"),
+    ("POST", "/api/v1/setup/verify"),
+]
+
+
+def _request(client, method, path, headers=None):
+    h = {"Origin": ORIGIN}
+    if headers:
+        h.update(headers)
+    return client.request(method, path, headers=h, json={} if method in ("PUT", "POST") else None)
+
+
+@pytest.mark.parametrize(("method", "path"), _SETUP_ROUTES)
+def test_dormant_404_without_session(state_dir, method, path):
+    state_dir.adopted()
+    client = make_client(state_dir)
+    # No mint -> dormant. With and without a bearer -> identical 404.
+    for headers in (None, bearer("anything")):
+        resp = _request(client, method, path, headers)
+        assert resp.status_code == 404
+        assert resp.json() == {"detail": "Not Found"}
+
+
+def test_live_code_reaches_routes_then_wrong_code_is_404(state_dir):
+    state_dir.adopted()
+    client = make_client(state_dir)
+    code = mint(client)
+    ok = client.get("/api/v1/setup/status", headers=bearer(code))
+    assert ok.status_code == 200
+    # A wrong-but-present code is the SAME dormant 404, never a 401 (FR-006).
+    bad = client.get("/api/v1/setup/status", headers=bearer("not-the-code"))
+    assert bad.status_code == 404
+    assert bad.json() == {"detail": "Not Found"}
+
+
+def test_idle_expiry_returns_to_dormant(state_dir):
+    state_dir.adopted()
+    client = make_client(state_dir, pairing_ttl_s=60.0)
+    code = mint(client)
+    assert client.get("/api/v1/setup/status", headers=bearer(code)).status_code == 200
+    # Deterministically age the session past its idle TTL (no reliance on the
+    # monotonic clock advancing during the HTTP round-trip).
+    session = client.app.state.pairing_manager._session
+    session.last_activity -= 120.0
+    resp = client.get("/api/v1/setup/status", headers=bearer(code))
+    assert resp.status_code == 404
+
+
+def test_adoption_completion_ends_session(state_dir):
+    state_dir.adopted()
+    client = make_client(state_dir)
+    code = mint(client)
+    payload = {
+        "version": 1,
+        "registry": [{"type": "incus", "name": "dev", "host": "10.0.0.5", "user": "remo"}],
+        "host_keys": {},
+    }
+    applied = client.put(
+        "/api/v1/setup/registry", headers={**bearer(code), "Origin": ORIGIN}, json=payload
+    )
+    assert applied.status_code == 200
+    # The PUT alone does NOT end the session — verify is the terminal step of the
+    # adopt/push flow and must still run with the same code.
+    assert client.get("/api/v1/setup/status", headers=bearer(code)).status_code == 200
+
+    verified = client.post("/api/v1/setup/verify", headers={**bearer(code), "Origin": ORIGIN})
+    assert verified.status_code == 200
+    # FR-007: completing the flow (verify) ends the session -> dormant again.
+    after = client.get("/api/v1/setup/status", headers=bearer(code))
+    assert after.status_code == 404
+
+
+def _health_ready(client):
+    return (
+        client.get("/api/v1/health").json(),
+        client.get("/api/v1/ready").json(),
+    )
+
+
+def test_health_ready_unchanged_across_pairing_states(state_dir):
+    state_dir.adopted()
+    client = make_client(state_dir)
+
+    dormant = _health_ready(client)
+    mint(client)
+    live = _health_ready(client)
+    client.post("/api/v1/pairing/end", headers={"Origin": ORIGIN})
+    post = _health_ready(client)
+
+    # SC-008: pairing state (dormant/live/post) never changes health/ready output.
+    assert dormant == live == post

--- a/tests/unit/web/test_state.py
+++ b/tests/unit/web/test_state.py
@@ -285,8 +285,14 @@ class TestResolvedSshSettings:
         assert settings.ssh_identity_file is None
         assert settings.ssh_known_hosts_file is None
 
-    def test_api_token_from_env(self, state_dir, monkeypatch):
-        monkeypatch.setenv("REMO_WEB_API_TOKEN", "  sekrit-token  ")
-        assert state_dir.settings().api_token == "sekrit-token"
-        monkeypatch.setenv("REMO_WEB_API_TOKEN", "")
-        assert state_dir.settings().api_token == ""
+    def test_pairing_config_from_env(self, state_dir, monkeypatch):
+        # 012: the static REMO_WEB_API_TOKEN field is gone; pairing config
+        # replaces it.
+        assert not hasattr(state_dir.settings(), "api_token")
+        monkeypatch.setenv("REMO_WEB_PAIRING_TTL_S", "300")
+        monkeypatch.setenv("REMO_WEB_OPERATOR_AUTH", "  forward  ")
+        monkeypatch.setenv("REMO_WEB_FORWARD_AUTH_HEADER", "  X-Forwarded-User  ")
+        settings = state_dir.settings()
+        assert settings.pairing_ttl_s == 300.0
+        assert settings.operator_auth == "forward"
+        assert settings.forward_auth_header == "X-Forwarded-User"


### PR DESCRIPTION
## Summary

Replaces 011's static `REMO_WEB_API_TOKEN` gate on `/api/v1/setup/*` with an **ephemeral device-pairing** model (streaming-service QR sign-on style, copy-only for v1).

- The awaiting-adoption page — and a new dashboard **Pair CLI to sync** affordance — mints a short-lived, in-memory **pairing code**; the operator copies it and pastes it into `remo web adopt` / `remo web push`, authorizing exactly one handoff.
- The setup surface is **dormant** (`404`, byte-identical to an unknown route) unless a pairing session is live.
- Minting is gated by **operator authentication** — v1 forward auth (a trusted proxy-injected identity header), behind a pluggable provider seam for a future in-app OIDC verifier.
- **Nothing durable is persisted** — no static service credential anywhere. Every adopt/push obtains a fresh code from the page.

> [!WARNING]
> **BREAKING CHANGE from 011:** `REMO_WEB_API_TOKEN` is removed. A value set for it is ignored (a one-line "now ignored" note is logged at startup).

## What's in it

**Service** — `web/pairing.py` (in-memory session manager: one live session, `token_urlsafe` codes, monotonic sliding TTL, constant-time bytewise compare, rotation-on-open, lock-guarded); `web/operator_auth.py` (provider seam, fail-fast on forward-auth-without-header); `web/api/pairing.py` (`POST /pairing/mint` gated + `POST /pairing/end` beacon); setup gate `require_setup_token → require_pairing_code` (dormant `404`, never `401`, session ends on the terminal `/verify`); posture surfaced in `health`/`check`; code redaction in `logging_config`.

**Workstation** — `web_adopt.py` sends the code as bearer, maps dormant `404` → "reopen the page", drops saved credentials in favor of a **non-secret** deployment-keyed push cache; `cli/web.py` renames prompts, drops `--save`, gives `push` url/token/via.

**Frontend** — `mintPairingCode`/`endPairing`; `AwaitingAdoption` mints-on-open, copy-only (code in a non-rendered ref, never the DOM); new `PairToSync` dashboard affordance; shared `lib/clipboard.ts`.

**Docs/compose** — forward-auth trust boundary + mint-gated / setup-passthrough split; env-var table; `REMO_WEB_OPERATOR_AUTH` / `REMO_WEB_FORWARD_AUTH_HEADER` / `REMO_WEB_PAIRING_TTL_S`.

## Testing

- **1098 unit + 26 integration/image tests pass**; mypy, ruff, and `tsc --noEmit` clean.
- Spec-kit flow: `plan.md`, `research.md`, `data-model.md`, `contracts/`, `quickstart.md`, `tasks.md` (all 39 tasks).
- An xhigh `--fix` code review found and fixed 6 items — most notably a non-ASCII `Authorization` bearer that crashed the gate (500, leaking session existence); now returns the dormant `404` (regression test added).

🤖 Generated with [Claude Code](https://claude.com/claude-code)