### PR TITLE
fix(web): auto-focus on session switch, Shift+Enter newline, wake-from-sleep recovery

### DIFF
--- a/frontend/src/components/TerminalCard.tsx
+++ b/frontend/src/components/TerminalCard.tsx
@@ -257,6 +257,18 @@ export function TerminalCard({
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [target.id, settings.renderer]);
 
+  // Move DOM keyboard focus into the terminal whenever this card becomes the
+  // focused, visible one — e.g. after clicking a rail row (selectOnly) or a
+  // number-key jump. Without this the card is "focused" in workspace state (our
+  // input gate opens) but the xterm textarea has no DOM focus, so keystrokes go
+  // nowhere until the user clicks into the surface. Guarded on isVisible: a
+  // hidden card must never steal focus.
+  useEffect(() => {
+    if (isFocused && isVisible) {
+      adapterRef.current?.focus();
+    }
+  }, [isFocused, isVisible]);
+
   const handleReconnect = useCallback(() => {
     setError(null);
     void connectionRef.current?.reconnect();

--- a/frontend/src/terminal/GhosttyRenderer.ts
+++ b/frontend/src/terminal/GhosttyRenderer.ts
@@ -33,6 +33,9 @@ export class GhosttyRenderer implements RendererAdapter {
   private readonly terminal: Terminal;
   private container: HTMLElement | null = null;
   private font: TerminalFontOptions;
+  /** Input subscribers — see XtermRenderer for the rationale (fan real input in,
+   * plus synthesize Shift+Enter, through one path). */
+  private readonly dataHandlers = new Set<(data: Uint8Array | string) => void>();
 
   constructor(font: TerminalFontOptions = DEFAULT_FONT) {
     this.font = font;
@@ -42,6 +45,31 @@ export class GhosttyRenderer implements RendererAdapter {
       fontFamily: font.fontFamily,
       fontSize: font.fontSize,
     });
+    this.terminal.onData((data: string | Uint8Array) => this.emit(data));
+    // Best-effort Shift+Enter → ESC+CR (newline), matching XtermRenderer. Guarded
+    // because ghostty-web's custom-key-handler API is unconfirmed at 0.4.0; if
+    // absent this is a no-op and Shift+Enter falls back to the engine default.
+    const t = this.terminal as unknown as {
+      attachCustomKeyEventHandler?: (h: (e: KeyboardEvent) => boolean) => void;
+    };
+    t.attachCustomKeyEventHandler?.((e) => this.handleKeyEvent(e));
+  }
+
+  private emit(data: Uint8Array | string): void {
+    for (const handler of this.dataHandlers) {
+      handler(data);
+    }
+  }
+
+  private handleKeyEvent(e: KeyboardEvent): boolean {
+    if (e.key === "Enter" && e.shiftKey && !e.ctrlKey && !e.altKey && !e.metaKey) {
+      if (e.type === "keydown") {
+        e.preventDefault();
+        this.emit("\x1b\r");
+      }
+      return false;
+    }
+    return true;
   }
 
   open(container: HTMLElement): void {
@@ -54,10 +82,8 @@ export class GhosttyRenderer implements RendererAdapter {
   }
 
   onData(handler: (data: Uint8Array | string) => void): () => void {
-    const disposable = this.terminal.onData((data: string | Uint8Array) => handler(data)) as
-      | Disposable
-      | undefined;
-    return () => disposable?.dispose();
+    this.dataHandlers.add(handler);
+    return () => this.dataHandlers.delete(handler);
   }
 
   fit(): TerminalDimensions {

--- a/frontend/src/terminal/TerminalConnection.ts
+++ b/frontend/src/terminal/TerminalConnection.ts
@@ -65,6 +65,13 @@ export class TerminalConnection {
   private reconnectAttempts = 0;
   private reconnectTimer: ReturnType<typeof setTimeout> | undefined;
   private _needsManualReconnect = false;
+  /** True while an attach() is between requesting a fresh terminal and having a
+   * socket assigned — serializes the burst of wake events (visibilitychange +
+   * focus + online all fire near-simultaneously on resume). */
+  private attaching = false;
+  /** Bumped each attach() so a slow, superseded attach can't assign a socket. */
+  private attachGen = 0;
+  private wakeListenersBound = false;
 
   constructor(
     sessionTargetId: string,
@@ -88,6 +95,7 @@ export class TerminalConnection {
 
   /** Starts the initial connection. Call once after construction. */
   async connect(): Promise<void> {
+    this.addWakeListeners();
     await this.attach("connecting");
   }
 
@@ -121,6 +129,7 @@ export class TerminalConnection {
   /** Client-initiated clean close (WS code 1000) plus server-side cleanup. */
   async close(): Promise<void> {
     this.clientInitiatedClose = true;
+    this.removeWakeListeners();
     this.clearReconnectTimer();
     const socket = this.socket;
     const terminalId = this.terminalId;
@@ -157,8 +166,70 @@ export class TerminalConnection {
     }
   }
 
+  private addWakeListeners(): void {
+    if (this.wakeListenersBound) {
+      return;
+    }
+    this.wakeListenersBound = true;
+    if (typeof window !== "undefined") {
+      window.addEventListener("online", this.onWake);
+      window.addEventListener("focus", this.onWake);
+    }
+    if (typeof document !== "undefined") {
+      document.addEventListener("visibilitychange", this.onWake);
+    }
+  }
+
+  private removeWakeListeners(): void {
+    if (!this.wakeListenersBound) {
+      return;
+    }
+    this.wakeListenersBound = false;
+    if (typeof window !== "undefined") {
+      window.removeEventListener("online", this.onWake);
+      window.removeEventListener("focus", this.onWake);
+    }
+    if (typeof document !== "undefined") {
+      document.removeEventListener("visibilitychange", this.onWake);
+    }
+  }
+
+  // Regaining focus/visibility/connectivity (e.g. reopening a slept laptop lid)
+  // is our cue that a socket that died while backgrounded should recover NOW,
+  // rather than waiting out a backoff that may have already been exhausted while
+  // hidden. Reset the auto-retry budget and force a fresh attach.
+  private readonly onWake = (): void => {
+    if (typeof document !== "undefined" && document.visibilityState === "hidden") {
+      return; // visibilitychange firing on the way OUT — ignore.
+    }
+    if (this.clientInitiatedClose || this.state === "closed" || this.attaching) {
+      return;
+    }
+    const readyState = this.socket?.readyState;
+    if (readyState === WebSocket.OPEN) {
+      // Looks alive; prod it so a silently-dead (post-sleep) socket surfaces an
+      // onclose and takes the reconnect path. Best-effort — a throw here just
+      // means the close is imminent anyway.
+      try {
+        this.sendPing();
+      } catch {
+        /* dead socket; onclose will drive the reconnect */
+      }
+      return;
+    }
+    if (readyState === WebSocket.CONNECTING) {
+      return; // a handshake is already in flight.
+    }
+    this._needsManualReconnect = false;
+    this.reconnectAttempts = 0;
+    this.clearReconnectTimer();
+    void this.attach("reconnecting");
+  };
+
   /** Creates a fresh terminal_id + token and opens a new WS to it. */
   private async attach(nextState: "connecting" | "reconnecting"): Promise<void> {
+    const gen = ++this.attachGen;
+    this.attaching = true;
     this.clientInitiatedClose = false;
     this.setState(nextState);
 
@@ -166,7 +237,17 @@ export class TerminalConnection {
     try {
       created = await createTerminal(this.sessionTargetId, this.cols, this.rows);
     } catch (error) {
-      this.handleFatalError(error);
+      this.attaching = false;
+      // A newer attach (e.g. a wake-triggered one) has superseded this; stay quiet.
+      if (gen === this.attachGen) {
+        this.handleFatalError(error);
+      }
+      return;
+    }
+
+    // Superseded while awaiting the fresh terminal — don't open a second socket.
+    if (gen !== this.attachGen) {
+      this.attaching = false;
       return;
     }
 
@@ -174,6 +255,7 @@ export class TerminalConnection {
     const socket = openTerminalSocket(created.terminal_id, created.ws_token);
     socket.binaryType = "arraybuffer";
     this.socket = socket;
+    this.attaching = false;
 
     socket.onopen = () => {
       // Server confirms readiness via the `ready` control frame, not onopen.
@@ -274,7 +356,8 @@ export class TerminalConnection {
       this.reconnectTimer = setTimeout(resolve, delay);
     });
 
-    if (this.clientInitiatedClose) {
+    if (this.clientInitiatedClose || this.attaching || this.socket) {
+      // A wake-triggered reconnect already took over while we were backing off.
       return;
     }
     await this.attach("reconnecting");

--- a/frontend/src/terminal/XtermRenderer.ts
+++ b/frontend/src/terminal/XtermRenderer.ts
@@ -44,6 +44,10 @@ export class XtermRenderer implements RendererAdapter {
   /** Desired ligature state; the addon is only actually (un)loaded after
    * open() since it registers a character joiner that needs an opened terminal. */
   private ligaturesEnabled = false;
+  /** Input subscribers. We fan xterm's own onData into these AND synthesize
+   * input for keys xterm doesn't distinguish (Shift+Enter), so both reach the
+   * remote PTY through the same path. */
+  private readonly dataHandlers = new Set<(data: Uint8Array | string) => void>();
 
   constructor(font: TerminalFontOptions = DEFAULT_FONT) {
     this.terminal = new Terminal({
@@ -58,7 +62,33 @@ export class XtermRenderer implements RendererAdapter {
     });
     this.fitAddon = new FitAddon();
     this.terminal.loadAddon(this.fitAddon);
+    // Real typed input flows through here to every subscriber.
+    this.terminal.onData((data: string) => this.emit(data));
+    // Distinguish Shift+Enter from Enter: xterm sends a plain CR for both, but
+    // Claude Code and other TUIs expect Shift+Enter to insert a newline. Emit
+    // ESC+CR (what `claude /terminal-setup` configures desktop terminals to
+    // send) and suppress xterm's default CR so it isn't ALSO submitted.
+    this.terminal.attachCustomKeyEventHandler((e) => this.handleKeyEvent(e));
     this.applyLigatures(font.ligatures);
+  }
+
+  private emit(data: Uint8Array | string): void {
+    for (const handler of this.dataHandlers) {
+      handler(data);
+    }
+  }
+
+  private handleKeyEvent(e: KeyboardEvent): boolean {
+    if (e.key === "Enter" && e.shiftKey && !e.ctrlKey && !e.altKey && !e.metaKey) {
+      if (e.type === "keydown") {
+        // preventDefault stops the browser from also inserting a newline into
+        // xterm's hidden textarea (which would double-send via its input event).
+        e.preventDefault();
+        this.emit("\x1b\r");
+      }
+      return false; // suppress xterm's default CR (which would submit the line)
+    }
+    return true;
   }
 
   private applyLigatures(enabled: boolean): void {
@@ -110,8 +140,8 @@ export class XtermRenderer implements RendererAdapter {
   }
 
   onData(handler: (data: Uint8Array | string) => void): () => void {
-    const disposable = this.terminal.onData((data: string) => handler(data));
-    return () => disposable.dispose();
+    this.dataHandlers.add(handler);
+    return () => this.dataHandlers.delete(handler);
   }
 
   fit(): TerminalDimensions {


### PR DESCRIPTION
Three browser-terminal UX/reliability fixes reported from real use.

## 1. Auto-focus the surfaced terminal
Clicking a rail row (or a number-key jump) set the workspace `focusedId` — which opens our input *gate* — but never moved **DOM focus** into the xterm textarea. Result: keystrokes went nowhere until you clicked into the terminal surface. `TerminalCard` now calls `adapter.focus()` when it becomes the focused **and** visible card (guarded so a hidden card can't steal focus).

## 2. Shift+Enter inserts a newline instead of submitting
xterm emits a plain CR for both Enter and Shift+Enter, so Claude Code treated Shift+Enter as submit. Claude Code (and `claude /terminal-setup` on desktop terminals) expect Shift+Enter to send **ESC+CR** (`\x1b\r`). Both renderers now intercept Shift+Enter, `preventDefault()`, and emit `\x1b\r` through the same input path as real typed input.
- `XtermRenderer`: via `attachCustomKeyEventHandler`; `onData` refactored to a handler set so synthetic input fans out to subscribers.
- `GhosttyRenderer`: same, but the custom-key hook is **best-effort/guarded** (ghostty-web's key API is unconfirmed at 0.4.0 — degrades to the engine default if absent).

## 3. Recover terminals after sleep / lid-close
Reconnect was capped at 3 attempts, then stranded in "needs manual reconnect" — a lid-close that outlasted the retries (or woke before the network) left the terminal dead. `TerminalConnection` now listens for `online` / `focus` / `visibilitychange` and, on resume:
- if the socket is dead/closed → resets the retry budget and forces a fresh attach immediately;
- if it looks alive → pings it so a silently-dead (post-sleep) socket surfaces its `onclose` and takes the reconnect path.

Wake events fire in a burst on resume (visibilitychange + focus + online), so concurrent attaches are serialized with an `attaching` flag, and a slow superseded attach can't open a second socket (attach-generation guard). Listeners are removed on `close()`.

## Testing
- `tsc --noEmit` + `vite build` green.
- ⚠️ No frontend unit runner (Playwright e2e only, needs a live service) — **not** browser-exercised yet. Items 2 and 3 in particular want a real click-through against a live session.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018SrwtyNKt4Y24pU748URrT