### PR TITLE
feat(web): terminal header — size-ordered mode cluster + grid drag-to-reorder

### DIFF
--- a/docs/web-session-interface.md
+++ b/docs/web-session-interface.md
@@ -99,10 +99,12 @@ The SPA is a two-pane **web console**:
   chips, and an "⚡ Active only" toggle narrow the list; "⊞ Open all · N" opens every available
   target as a grid.
 - **Terminal pane** (right). Clicking a row opens that target **solo** (single view); ⌘/Ctrl-click a
-  row (or its `+` button) **adds** it to a responsive grid (1/2/3 columns by count). Clicking a grid
-  tile solos it; **Esc** collapses the grid back to the focused terminal; number keys **1–9** jump to
-  the numbered sessions (⌘ 1–9 add to the grid). Hidden terminals stay connected and keep their
-  scrollback. Each terminal header shows `provider · instance · region`, connection state, and a
+  row (or its `+` button) **adds** it to a responsive grid (1/2/3 columns by count). In a grid, **drag
+  a tile's header onto another to swap their positions** (the arrangement persists until the grid is
+  rebuilt); the **◻** control solos a tile; **Esc** collapses the grid back to the focused terminal;
+  number keys **1–9** jump to the numbered sessions (⌘ 1–9 add to the grid). Hidden terminals stay
+  connected and keep their scrollback. Each terminal header shows `provider · instance · region`
+  (doubling as the drag handle), connection state, and a
   window-control cluster of the display modes, ordered by how much space they take: **⊞ Grid** (smaller —
   a tile in the grid, when one is available), **◻ Normal** (fills the app's main pane — single view),
   **⤢ Fullscreen** (the terminal fills the whole window — shell chrome hidden, plus best-effort browser

--- a/docs/web-session-interface.md
+++ b/docs/web-session-interface.md
@@ -103,9 +103,10 @@ The SPA is a two-pane **web console**:
   tile solos it; **Esc** collapses the grid back to the focused terminal; number keys **1–9** jump to
   the numbered sessions (⌘ 1–9 add to the grid). Hidden terminals stay connected and keep their
   scrollback. Each terminal header shows `provider · instance · region`, connection state, and a
-  window-control cluster of the display modes — **▭ Normal** (single view), **⊞ Grid** (the grid, when
-  one is available), **⤢ Fullscreen** (the terminal fills the whole window — shell chrome hidden, plus
-  best-effort browser fullscreen), and **✕ Close** — with the current mode shown active. Press **f** to
+  window-control cluster of the display modes, ordered by how much space they take: **⊞ Grid** (smaller —
+  a tile in the grid, when one is available), **◻ Normal** (fills the app's main pane — single view),
+  **⤢ Fullscreen** (the terminal fills the whole window — shell chrome hidden, plus best-effort browser
+  fullscreen), and **✕ Close** — with the current mode shown active. Press **f** to
   toggle fullscreen on the focused terminal; **Esc** exits it. Fullscreen is a presentation overlay: it
   never disturbs the single/grid layout underneath, so exiting returns to exactly where you were.
 

--- a/frontend/src/components/TerminalCard.css
+++ b/frontend/src/components/TerminalCard.css
@@ -15,9 +15,8 @@
   box-shadow: 0 0 0 3px color-mix(in oklch, var(--accent) 12%, transparent);
 }
 
-/* Grid tile: compact, clickable to solo. */
+/* Grid tile: compact. Reorder by dragging its header; the ◻ control solos it. */
 .terminal-card--grid {
-  cursor: pointer;
   border-color: var(--border);
 }
 
@@ -40,6 +39,34 @@
 .terminal-card--grid .terminal-card-header {
   padding: 7px 10px;
   gap: 8px;
+}
+
+/* Left portion of the header: the identity cluster, doubling as the drag handle
+ * for reordering grid tiles. flex:1 makes it a generously large grab target. */
+.terminal-card-grip {
+  display: flex;
+  align-items: center;
+  gap: 9px;
+  min-width: 0;
+  flex: 1;
+}
+.terminal-card--grid .terminal-card-grip {
+  gap: 8px;
+}
+.terminal-card-grip[draggable="true"] {
+  cursor: grab;
+}
+.terminal-card-grip[draggable="true"]:active {
+  cursor: grabbing;
+}
+
+/* Reorder drag feedback. */
+.terminal-card--dragging {
+  opacity: 0.5;
+}
+.terminal-card--drop-target {
+  border-color: color-mix(in oklch, var(--accent) 65%, var(--border));
+  box-shadow: 0 0 0 3px color-mix(in oklch, var(--accent) 22%, transparent);
 }
 
 .terminal-card-num {

--- a/frontend/src/components/TerminalCard.tsx
+++ b/frontend/src/components/TerminalCard.tsx
@@ -42,6 +42,18 @@ export type TerminalCardMode = "single" | "grid";
  * Drives the window-control cluster's active/disabled state. */
 export type TerminalViewState = "normal" | "grid" | "fullscreen";
 
+/** Drag-to-reorder wiring for a grid tile. Present only when reordering is
+ * possible (a grid of two-plus); the header acts as the drag handle and the
+ * whole tile is a drop target — dropping swaps the two tiles' positions. */
+export interface TerminalReorder {
+  isDragging: boolean;
+  isDropTarget: boolean;
+  onDragStart: () => void;
+  onDragEnter: () => void;
+  onDrop: () => void;
+  onDragEnd: () => void;
+}
+
 interface TerminalCardProps {
   target: SessionTarget;
   /** Registry region for this target's instance (badge only). */
@@ -56,8 +68,8 @@ interface TerminalCardProps {
   /** The display mode this card is currently in (window-control cluster state). */
   viewState: TerminalViewState;
   onClose: () => void;
-  /** Grid tile clicked → solo it (single view). */
-  onSolo?: () => void;
+  /** Drag-to-reorder wiring; present only for a reorderable grid tile. */
+  reorder?: TerminalReorder;
   /** Window-control "Normal": solo this terminal into the single view. */
   onNormal: () => void;
   /** Window-control "Grid": show the grid — omitted when none is available. */
@@ -91,7 +103,7 @@ export function TerminalCard({
   num,
   viewState,
   onClose,
-  onSolo,
+  reorder,
   onNormal,
   onGrid,
   onToggleFullscreen,
@@ -290,30 +302,51 @@ export function TerminalCard({
   const prov = providerMeta(target.instance_type);
   const badge = [prov.label, target.instance_name, region].filter(Boolean).join(" · ");
 
-  // Grid tile: clicking anywhere on the tile (outside the buttons) solos it.
-  const handleTileClick = mode === "grid" ? onSolo : undefined;
+  const dragClasses = reorder
+    ? `${reorder.isDragging ? " terminal-card--dragging" : ""}${reorder.isDropTarget ? " terminal-card--drop-target" : ""}`
+    : "";
 
   return (
     <div
-      className={`terminal-card terminal-card--${mode}${isFocused ? " terminal-card--focused" : ""}`}
+      className={`terminal-card terminal-card--${mode}${isFocused ? " terminal-card--focused" : ""}${dragClasses}`}
       data-testid={`terminal-card-${target.id}`}
       data-focused={isFocused}
       data-connection-state={connectionState}
       style={{ display: isVisible ? undefined : "none" }}
-      onClick={handleTileClick}
+      // Whole tile is the drop target for a reorder drag (see the header grip).
+      onDragOver={reorder ? (e) => e.preventDefault() : undefined}
+      onDragEnter={reorder ? (e) => { e.preventDefault(); reorder.onDragEnter(); } : undefined}
+      onDrop={reorder ? (e) => { e.preventDefault(); reorder.onDrop(); } : undefined}
     >
       <header className="terminal-card-header">
-        {mode === "grid" && num !== undefined && (
-          <span className="terminal-card-num">{num}</span>
-        )}
-        <span className="terminal-card-provider-dot" style={{ background: prov.color }} />
-        <div className="terminal-card-identity">
-          <span className="terminal-card-project">{target.project}</span>
-          {mode === "single" ? (
-            <span className="terminal-card-badge">{badge}</span>
-          ) : (
-            <span className="terminal-card-instance">{target.instance_name}</span>
+        {/* The header (left of the controls) is the drag handle for reordering
+         * grid tiles; it no longer solos on click — the ◻ control does that. */}
+        <div
+          className="terminal-card-grip"
+          draggable={reorder ? true : undefined}
+          onDragStart={
+            reorder
+              ? (e) => {
+                  e.dataTransfer.setData("text/plain", target.id);
+                  e.dataTransfer.effectAllowed = "move";
+                  reorder.onDragStart();
+                }
+              : undefined
+          }
+          onDragEnd={reorder ? () => reorder.onDragEnd() : undefined}
+        >
+          {mode === "grid" && num !== undefined && (
+            <span className="terminal-card-num">{num}</span>
           )}
+          <span className="terminal-card-provider-dot" style={{ background: prov.color }} />
+          <div className="terminal-card-identity">
+            <span className="terminal-card-project">{target.project}</span>
+            {mode === "single" ? (
+              <span className="terminal-card-badge">{badge}</span>
+            ) : (
+              <span className="terminal-card-instance">{target.instance_name}</span>
+            )}
+          </div>
         </div>
         <span
           className={`terminal-card-state terminal-card-state--${connectionState}`}

--- a/frontend/src/components/TerminalCard.tsx
+++ b/frontend/src/components/TerminalCard.tsx
@@ -335,25 +335,12 @@ export function TerminalCard({
               ↻ Reconnect
             </button>
           )}
-          {/* Window-control cluster: mutually-exclusive display modes (the
-           * current one shown active + disabled) plus close. Fullscreen toggles.
-           * Icons only; the label is the tooltip. */}
+          {/* Window-control cluster: mutually-exclusive display modes ordered
+           * by how much space they take — Grid (smaller/tiled) → Normal (fills
+           * the app's main pane) → Fullscreen (whole window) — plus close. The
+           * current mode is shown active + disabled; Fullscreen toggles. Icons
+           * only; the label is the tooltip. */}
           <div className="tc-winctl" role="group" aria-label="Terminal display mode">
-            <button
-              type="button"
-              className={`tc-btn tc-btn--icon${viewState === "normal" ? " tc-btn--active" : ""}`}
-              data-testid={`terminal-normal-${target.id}`}
-              title="Normal (single view)"
-              aria-label="Normal view"
-              aria-pressed={viewState === "normal"}
-              disabled={viewState === "normal"}
-              onClick={(e) => {
-                e.stopPropagation();
-                onNormal();
-              }}
-            >
-              ▭
-            </button>
             <button
               type="button"
               className={`tc-btn tc-btn--icon${viewState === "grid" ? " tc-btn--active" : ""}`}
@@ -368,6 +355,21 @@ export function TerminalCard({
               }}
             >
               ⊞
+            </button>
+            <button
+              type="button"
+              className={`tc-btn tc-btn--icon${viewState === "normal" ? " tc-btn--active" : ""}`}
+              data-testid={`terminal-normal-${target.id}`}
+              title="Fill the main pane (single view)"
+              aria-label="Fill the main pane"
+              aria-pressed={viewState === "normal"}
+              disabled={viewState === "normal"}
+              onClick={(e) => {
+                e.stopPropagation();
+                onNormal();
+              }}
+            >
+              ◻
             </button>
             <button
               type="button"

--- a/frontend/src/components/WorkspacePane.tsx
+++ b/frontend/src/components/WorkspacePane.tsx
@@ -2,7 +2,7 @@
 // terminal (each mounted for its lifetime so hidden ones stay connected),
 // laid out as a single view (one visible) or a responsive grid (two-plus).
 
-import { useMemo } from "react";
+import { useMemo, useState } from "react";
 import type { SessionTarget } from "../api/client";
 import { requestBrowserFullscreen } from "../lib/fullscreen";
 import { useWorkspace } from "../state/workspace";
@@ -46,16 +46,27 @@ export function WorkspacePane({
   const workspace = useWorkspace();
   const { attached, visible, focusedId, prevGrid, maximizedId } = workspace;
 
-  // Only attached ids that still resolve to a live target get a card.
-  const attachedTargets = useMemo(
-    () =>
-      attached
-        .map((id) => targetsById.get(id))
-        .filter((t): t is SessionTarget => t !== undefined),
-    [attached, targetsById],
-  );
+  // Transient drag-to-reorder state (which tile is being dragged, and which it's
+  // hovering over). Not persisted — only the resulting order (`visible`) is.
+  const [dragId, setDragId] = useState<string | null>(null);
+  const [overId, setOverId] = useState<string | null>(null);
 
-  if (attachedTargets.length === 0) {
+  // Render visible tiles in `visible` order (so the grid layout follows the
+  // reorderable order + the number badges), then the hidden-but-attached cards
+  // (kept mounted for their live connections; display:none, order irrelevant).
+  const orderedTargets = useMemo(() => {
+    const visibleSet = new Set(visible);
+    const inGridOrder = visible
+      .map((id) => targetsById.get(id))
+      .filter((t): t is SessionTarget => t !== undefined);
+    const hidden = attached
+      .filter((id) => !visibleSet.has(id))
+      .map((id) => targetsById.get(id))
+      .filter((t): t is SessionTarget => t !== undefined);
+    return [...inGridOrder, ...hidden];
+  }, [visible, attached, targetsById]);
+
+  if (orderedTargets.length === 0) {
     return (
       <main className="workspace" data-testid="workspace">
         <div className="workspace-empty">
@@ -101,6 +112,13 @@ export function WorkspacePane({
     }
   };
 
+  // Reordering is possible only within a real grid (two-plus visible tiles).
+  const reorderable = !maximized && mode === "grid" && visible.length > 1;
+  const clearDrag = (): void => {
+    setDragId(null);
+    setOverId(null);
+  };
+
   return (
     <main className="workspace" data-testid="workspace">
       <div
@@ -114,26 +132,47 @@ export function WorkspacePane({
             : undefined
         }
       >
-        {attachedTargets.map((target) => {
-          const isVisible = maximized ? target.id === maximized : visible.includes(target.id);
-          const viewState = maximized === target.id ? "fullscreen" : mode === "grid" ? "grid" : "normal";
+        {orderedTargets.map((target) => {
+          const id = target.id;
+          const isVisible = maximized ? id === maximized : visible.includes(id);
+          const viewState = maximized === id ? "fullscreen" : mode === "grid" ? "grid" : "normal";
+          const reorder =
+            reorderable && isVisible
+              ? {
+                  isDragging: dragId === id,
+                  isDropTarget: overId === id && dragId !== null && dragId !== id,
+                  onDragStart: () => setDragId(id),
+                  onDragEnter: () => {
+                    if (dragId && dragId !== id) {
+                      setOverId(id);
+                    }
+                  },
+                  onDrop: () => {
+                    if (dragId && dragId !== id) {
+                      workspace.swapVisible(dragId, id);
+                    }
+                    clearDrag();
+                  },
+                  onDragEnd: clearDrag,
+                }
+              : undefined;
           return (
             <TerminalCard
-              key={target.id}
+              key={id}
               target={target}
               region={regionByKey.get(`${target.instance_type}::${target.instance_name}`)}
               mode={mode}
               isVisible={isVisible}
-              isFocused={focusedId === target.id}
-              num={visibleIndex.get(target.id)}
+              isFocused={focusedId === id}
+              num={visibleIndex.get(id)}
               viewState={viewState}
-              onClose={() => workspace.closeTerm(target.id)}
-              onSolo={mode === "grid" ? () => workspace.soloTile(target.id) : undefined}
-              onNormal={() => workspace.soloTile(target.id)}
+              reorder={reorder}
+              onClose={() => workspace.closeTerm(id)}
+              onNormal={() => workspace.soloTile(id)}
               onGrid={canGrid ? workspace.backToGrid : undefined}
-              onToggleFullscreen={() => toggleFullscreen(target.id)}
-              onFocusRequest={() => workspace.setFocused(target.id)}
-              onActivity={() => workspace.markUnread(target.id)}
+              onToggleFullscreen={() => toggleFullscreen(id)}
+              onFocusRequest={() => workspace.setFocused(id)}
+              onActivity={() => workspace.markUnread(id)}
               onEnded={() => onTerminalEnded(target)}
             />
           );

--- a/frontend/src/state/workspace.test.ts
+++ b/frontend/src/state/workspace.test.ts
@@ -66,3 +66,33 @@ describe("workspace fullscreen overlay", () => {
     expect(result.current.visible).toEqual(["b"]);
   });
 });
+
+describe("workspace grid reorder (swapVisible)", () => {
+  it("swaps two tiles' positions in the grid order", async () => {
+    const { result } = await mount();
+    act(() => result.current.openMany([target("a"), target("b"), target("c")]));
+    expect(result.current.visible).toEqual(["a", "b", "c"]);
+
+    act(() => result.current.swapVisible("a", "c"));
+    expect(result.current.visible).toEqual(["c", "b", "a"]);
+  });
+
+  it("is a no-op when an id isn't visible or both are the same", async () => {
+    const { result } = await mount();
+    act(() => result.current.openMany([target("a"), target("b")]));
+    act(() => result.current.swapVisible("a", "zzz")); // zzz not visible
+    expect(result.current.visible).toEqual(["a", "b"]);
+    act(() => result.current.swapVisible("a", "a"));
+    expect(result.current.visible).toEqual(["a", "b"]);
+  });
+
+  it("rebuilding the grid (open-many) discards a custom order", async () => {
+    const { result } = await mount();
+    act(() => result.current.openMany([target("a"), target("b")]));
+    act(() => result.current.swapVisible("a", "b"));
+    expect(result.current.visible).toEqual(["b", "a"]);
+    // The grid "goes away" and is rebuilt fresh.
+    act(() => result.current.openMany([target("a"), target("b")]));
+    expect(result.current.visible).toEqual(["a", "b"]);
+  });
+});

--- a/frontend/src/state/workspace.ts
+++ b/frontend/src/state/workspace.ts
@@ -195,6 +195,20 @@ function openMany(targets: SessionTarget[]): void {
   setState({ attached, visible, focusedId: visible[0], prevGrid: null, maximizedId: null });
 }
 
+/** Swap two tiles' positions in the grid. The order lives in `visible` (which is
+ * persisted), so a custom arrangement survives until the grid is rebuilt by a
+ * solo/select/open-many. No-op if either id isn't currently visible. */
+function swapVisible(a: string, b: string): void {
+  const i = state.visible.indexOf(a);
+  const j = state.visible.indexOf(b);
+  if (i === -1 || j === -1 || i === j) {
+    return;
+  }
+  const visible = [...state.visible];
+  [visible[i], visible[j]] = [visible[j], visible[i]];
+  setState({ visible });
+}
+
 /** Close a terminal: reap it and re-pick focus / restore grid if soloed. */
 function closeTerm(id: string): void {
   const attached = state.attached.filter((a) => a !== id);
@@ -263,6 +277,7 @@ export interface UseWorkspaceResult {
   backToGrid: () => void;
   openMany: (targets: SessionTarget[]) => void;
   closeTerm: (id: string) => void;
+  swapVisible: (a: string, b: string) => void;
   maximize: (id: string) => void;
   restore: () => void;
   setFocused: (id: string | null) => void;
@@ -284,6 +299,7 @@ export function useWorkspace(): UseWorkspaceResult {
     backToGrid,
     openMany,
     closeTerm,
+    swapVisible,
     maximize,
     restore,
     setFocused,

--- a/tests/e2e/fixtures.ts
+++ b/tests/e2e/fixtures.ts
@@ -70,6 +70,10 @@ export const TESTID = {
   terminalSurface: (targetId: string) => `terminal-surface-${targetId}`,
   terminalReconnect: (targetId: string) => `terminal-reconnect-${targetId}`,
   terminalClose: (targetId: string) => `terminal-close-${targetId}`,
+  // Window-control cluster (display modes).
+  terminalNormal: (targetId: string) => `terminal-normal-${targetId}`,
+  terminalGrid: (targetId: string) => `terminal-grid-${targetId}`,
+  terminalFullscreen: (targetId: string) => `terminal-fullscreen-${targetId}`,
 } as const;
 
 /** Seeds the browser-local settings store so the console boots with a specific

--- a/tests/e2e/workspace-layout.spec.ts
+++ b/tests/e2e/workspace-layout.spec.ts
@@ -53,15 +53,16 @@ test.describe("workspace layout", () => {
     }
   });
 
-  test("clicking a grid tile solos it; Esc returns to the grid", async ({ page }) => {
+  test("the ◻ control solos a grid tile; Esc returns to the grid", async ({ page }) => {
     const discoveredIds = await waitForDiscoveredTargets(page);
     expect(discoveredIds.length).toBeGreaterThan(1);
     await page.getByTestId(TESTID.openAll).click();
     const openIds = await openTerminalCardIds(page);
     const [firstId, secondId] = openIds;
 
-    // Solo the first tile — only it is visible, the rest stay mounted+hidden.
-    await page.getByTestId(TESTID.terminalCard(firstId)).click();
+    // Solo the first tile via its "fill the main pane" control (the header is a
+    // drag handle now, not a click-to-solo target). Only it stays visible.
+    await page.getByTestId(TESTID.terminalNormal(firstId)).click();
     await expect(page.getByTestId(TESTID.terminalCard(firstId))).toBeVisible();
     await expect(page.getByTestId(TESTID.terminalCard(secondId))).toBeHidden();
     // Hidden card keeps its live connection (US3 scenario 3).


### PR DESCRIPTION
Two related changes to the terminal header (bundled since they touch the same UI region).

## 1. Size-ordered window-control cluster
Reorders the display-mode buttons left-to-right as a size progression, and reglyphs "Normal" from `▭` to a square `◻` (window-restore/maximize look) to signal it fills the app's main pane:

`⊞ Grid` (a tile) → `◻ Normal` (fills the main pane) → `⤢ Fullscreen` (whole window, best-effort) → `✕ Close`

## 2. Grid drag-to-reorder; header is now a drag handle
Now that the cluster covers mode switching, the header is repurposed:
- **Removed** click-to-solo on the grid tile body. Soloing is done via the `◻` control.
- The header's identity cluster is a **drag handle** (`.terminal-card-grip`, draggable only in a grid).
- **Drag a tile's header onto another tile to swap their positions** (HTML5 DnD; the whole tile is the drop target, with dragging/drop-target styling).
- The arrangement lives in `visible` (new `swapVisible` store action); `WorkspacePane` renders tiles in `visible` order so the grid layout **and** the number badges follow it. `visible` is persisted, so a custom order **survives until the grid is rebuilt** (solo / select / open-many) — then it resets. This matches "saved until the grid goes away."

Behavior, testids, and the underlying view-state model are otherwise unchanged; the terminal surface still focuses on click, and connections survive tile reordering (React reconciles by stable key — no remount).

## Tests
- `swapVisible` unit tests: swap, no-op (id not visible / same id), reset-on-rebuild.
- Vitest suite 17/17; `tsc --noEmit` + `vite build` green.
- e2e `workspace-layout` updated to solo via the `◻` control (tile-click no longer solos); added `terminalNormal`/`terminalGrid`/`terminalFullscreen` testids.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018SrwtyNKt4Y24pU748URrT