### PR TITLE
feat(web): hide the 1–9 rail numbers and grid-tile number badges

### DIFF
--- a/frontend/src/components/SessionRail.css
+++ b/frontend/src/components/SessionRail.css
@@ -244,14 +244,6 @@
   color: var(--accent);
   flex: none;
 }
-.rail-row-num {
-  font-family: var(--font-mono);
-  font-size: 10px;
-  color: var(--text-faint);
-  width: 12px;
-  text-align: right;
-  flex: none;
-}
 .rail-row-name {
   font-family: var(--font-mono);
   font-size: 12.5px;

--- a/frontend/src/components/SessionRail.tsx
+++ b/frontend/src/components/SessionRail.tsx
@@ -228,7 +228,6 @@ function RailInstance({
         <RailSessionRow
           key={row.target.id}
           target={row.target}
-          num={row.num}
           providerColor={meta.color}
           attached={attached.includes(row.target.id)}
           visible={visible.includes(row.target.id)}
@@ -243,7 +242,6 @@ function RailInstance({
 
 interface RailSessionRowProps {
   target: SessionTarget;
-  num: number | null;
   providerColor: string;
   attached: boolean;
   visible: boolean;
@@ -254,7 +252,6 @@ interface RailSessionRowProps {
 
 function RailSessionRow({
   target,
-  num,
   attached,
   visible,
   focused,
@@ -282,7 +279,6 @@ function RailSessionRow({
       onClick={(e) => onSelect(target, e)}
     >
       <span className="rail-row-mark">{mark}</span>
-      <span className="rail-row-num">{num ?? ""}</span>
       <span className="rail-row-name">{target.project}</span>
       <span className="rail-row-glyphs">
         {target.git_dirty && (

--- a/frontend/src/components/TerminalCard.css
+++ b/frontend/src/components/TerminalCard.css
@@ -69,12 +69,6 @@
   box-shadow: 0 0 0 3px color-mix(in oklch, var(--accent) 22%, transparent);
 }
 
-.terminal-card-num {
-  font-family: var(--font-mono);
-  font-size: 9px;
-  color: var(--text-faint);
-}
-
 .terminal-card-provider-dot {
   width: 10px;
   height: 10px;

--- a/frontend/src/components/TerminalCard.tsx
+++ b/frontend/src/components/TerminalCard.tsx
@@ -63,8 +63,6 @@ interface TerminalCardProps {
   isVisible: boolean;
   /** Whether this card currently receives keyboard input + the focus ring. */
   isFocused: boolean;
-  /** 1-based position label shown on a grid tile. */
-  num?: number;
   /** The display mode this card is currently in (window-control cluster state). */
   viewState: TerminalViewState;
   onClose: () => void;
@@ -100,7 +98,6 @@ export function TerminalCard({
   mode,
   isVisible,
   isFocused,
-  num,
   viewState,
   onClose,
   reorder,
@@ -335,9 +332,6 @@ export function TerminalCard({
           }
           onDragEnd={reorder ? () => reorder.onDragEnd() : undefined}
         >
-          {mode === "grid" && num !== undefined && (
-            <span className="terminal-card-num">{num}</span>
-          )}
           <span className="terminal-card-provider-dot" style={{ background: prov.color }} />
           <div className="terminal-card-identity">
             <span className="terminal-card-project">{target.project}</span>

--- a/frontend/src/components/WorkspacePane.tsx
+++ b/frontend/src/components/WorkspacePane.tsx
@@ -99,9 +99,6 @@ export function WorkspacePane({
     visible.filter((id) => attached.includes(id)).length > 1 ||
     (prevGrid ?? []).filter((id) => attached.includes(id)).length > 1;
 
-  // 1-based position for each visible id (grid tile number badge).
-  const visibleIndex = new Map(visible.map((id, i) => [id, i + 1]));
-
   const toggleFullscreen = (id: string): void => {
     if (maximized === id) {
       workspace.restore();
@@ -164,7 +161,6 @@ export function WorkspacePane({
               mode={mode}
               isVisible={isVisible}
               isFocused={focusedId === id}
-              num={visibleIndex.get(id)}
               viewState={viewState}
               reorder={reorder}
               onClose={() => workspace.closeTerm(id)}


### PR DESCRIPTION
Removes two on-screen numbering systems that conflicted and misled:
- the rail's **1–9 row badges**, and
- the **per-terminal grid number badges**.

They showed different orders (rail order vs grid position) that could disagree, and the grid badges *looked* like keyboard shortcuts but weren't. Removing both declutters the UI until a proper favorites/ordering feature (drag-arranged, its own rail view) gives numbers a coherent meaning.

The underlying `1`–`9` **keyboard shortcut is unchanged** (`useConsoleKeyboard` / `railModel.flatOpenable`) — only the visible badges are removed.

## Notes / follow-ups (left as-is on purpose)
- The empty-workspace hint ("press 1–9 to jump") and the Shortcuts panel (`?`) still mention the 1–9 binding, which is now invisible. Left intact since the binding still works; can be quieted when favorites lands.

## Verification
`tsc --noEmit`, Vitest 17/17, `vite build` all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018SrwtyNKt4Y24pU748URrT