### PR TITLE
feat(web): dwell delay for focus-follows-mouse (less sloppy focus)

### DIFF
--- a/docs/web-session-interface.md
+++ b/docs/web-session-interface.md
@@ -102,9 +102,10 @@ The SPA is a two-pane **web console**:
   row (or its `+` button) **adds** it to a responsive grid (1/2/3 columns by count). In a grid, **drag
   a tile's header onto another to swap their positions** — a window outline follows the cursor and the
   swap target shows a dashed outline (mouse or touch press-and-hold; keyboard-accessible via the
-  handle); the arrangement persists until the grid is rebuilt. In a grid, **hovering a tile focuses it**
-  (focus-follows-mouse) so keystrokes go where the pointer is — no click needed. The **◻** control solos
-  a tile; **Esc** collapses the grid back to the focused terminal;
+  handle); the arrangement persists until the grid is rebuilt. In a grid, **resting the pointer on a
+  tile focuses it** (focus-follows-mouse, with a short dwell so passing through tiles doesn't steal
+  focus) — keystrokes go where the pointer is, no click needed. The **◻** control solos a tile; **Esc**
+  collapses the grid back to the focused terminal;
   number keys **1–9** jump to the numbered sessions (⌘ 1–9 add to the grid). Hidden terminals stay
   connected and keep their scrollback. Each terminal header shows `provider · instance · region`
   (doubling as the drag handle), connection state, and a

--- a/frontend/src/components/TerminalCard.tsx
+++ b/frontend/src/components/TerminalCard.tsx
@@ -28,6 +28,9 @@ const DEFAULT_COLS = 80;
 const DEFAULT_ROWS = 24;
 /** How much to shrink the terminal font in a grid tile when "scale to fit". */
 const GRID_FIT_SCALE = 0.8;
+/** Focus-follows-mouse dwell: the pointer must REST on a tile this long before
+ * it takes focus, so passing through tiles (or a small drift) doesn't steal it. */
+const HOVER_FOCUS_DELAY_MS = 220;
 
 const STATE_LABELS: Record<TerminalConnectionState, string> = {
   connecting: "Connecting…",
@@ -119,6 +122,8 @@ export function TerminalCard({
   // (to skip redundant resize frames).
   const fitRafRef = useRef<number | null>(null);
   const lastSentDimsRef = useRef<{ cols: number; rows: number } | null>(null);
+  // Pending focus-follows-mouse dwell timer (cleared if the pointer leaves first).
+  const hoverTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   const [connectionState, setConnectionState] = useState<TerminalConnectionState>("connecting");
   const [needsManualReconnect, setNeedsManualReconnect] = useState(false);
@@ -306,6 +311,29 @@ export function TerminalCard({
     onFocusRequest?.();
   }, [onFocusRequest]);
 
+  const clearHoverTimer = useCallback(() => {
+    if (hoverTimerRef.current !== null) {
+      clearTimeout(hoverTimerRef.current);
+      hoverTimerRef.current = null;
+    }
+  }, []);
+
+  // Focus-follows-mouse with a dwell delay: arm a timer on enter, fire only if
+  // the pointer is still resting here after HOVER_FOCUS_DELAY_MS.
+  const handleMouseEnter = useCallback(() => {
+    if (!onHoverFocus) {
+      return;
+    }
+    clearHoverTimer();
+    hoverTimerRef.current = setTimeout(() => {
+      hoverTimerRef.current = null;
+      onHoverFocus();
+    }, HOVER_FOCUS_DELAY_MS);
+  }, [onHoverFocus, clearHoverTimer]);
+
+  // Cancel a pending dwell when the pointer leaves or the card unmounts.
+  useEffect(() => clearHoverTimer, [clearHoverTimer]);
+
   const prov = providerMeta(target.instance_type);
   const badge = [prov.label, target.instance_name, region].filter(Boolean).join(" · ");
 
@@ -322,7 +350,8 @@ export function TerminalCard({
       data-focused={isFocused}
       data-connection-state={connectionState}
       style={{ display: isVisible ? undefined : "none" }}
-      onMouseEnter={onHoverFocus}
+      onMouseEnter={handleMouseEnter}
+      onMouseLeave={clearHoverTimer}
     >
       <header className="terminal-card-header">
         {/* The header (left of the controls) is the drag handle for reordering


### PR DESCRIPTION
Follow-up to the focus-follows-mouse change: it was too twitchy — focus jumped the instant the pointer crossed **any** tile (passing through to reach a control, or a small drift).

Now the pointer must **rest** on a tile for `HOVER_FOCUS_DELAY_MS` (220ms) before it takes focus: a dwell timer is armed on `mouseenter` and cancelled on `mouseleave`/unmount. Sweeping the mouse across tiles to reach one only focuses the tile you settle on — no flicker through the ones in between.

## Verification
`tsc --noEmit`, Vitest 17/17, `vite build` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018SrwtyNKt4Y24pU748URrT