### PR TITLE
feat(web): move "Pair CLI to sync" into Settings + add a Focus dwell slider

### DIFF
--- a/frontend/src/components/PairToSync.css
+++ b/frontend/src/components/PairToSync.css
@@ -1,33 +1,51 @@
+/* "Pair CLI to sync" — rendered inline inside a Settings section (no longer a
+ * top-bar popover), so the minted-code panel expands in place below the button. */
 .pairsync {
-  position: relative;
-  display: inline-flex;
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 10px;
+}
+
+.pairsync-btn {
+  padding: 7px 12px;
+  border-radius: 7px;
+  border: 1px solid var(--border-strong, #444);
+  background: var(--bg-btn, #24262c);
+  color: var(--text-1, #e6e8ec);
+  font-size: 13px;
+  font-family: inherit;
+  cursor: pointer;
+}
+.pairsync-btn:hover {
+  background: var(--bg-btn-hover, #2c2f36);
+}
+.pairsync-btn:disabled {
+  opacity: 0.6;
+  cursor: default;
 }
 
 .pairsync-popover {
-  position: absolute;
-  top: calc(100% + 8px);
-  right: 0;
-  z-index: 50;
-  width: 280px;
+  width: 100%;
+  max-width: 380px;
   padding: 12px;
   display: flex;
   flex-direction: column;
   gap: 10px;
-  background: var(--panel, #1b1d22);
-  border: 1px solid var(--border, #333);
+  background: var(--bg-header, #1b1d22);
+  border: 1px solid var(--border-soft, #333);
   border-radius: 8px;
-  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.35);
 }
 
 .pairsync-body {
   margin: 0;
   font-size: 12px;
   line-height: 1.5;
-  color: var(--text-muted, #b8bcc4);
+  color: var(--text-dim, #b8bcc4);
 }
 
 .pairsync-body code {
-  font-family: var(--mono, monospace);
+  font-family: var(--font-mono, monospace);
   color: var(--text, #e6e8ec);
 }
 
@@ -42,7 +60,7 @@
   align-self: flex-end;
   background: none;
   border: none;
-  color: var(--text-muted, #b8bcc4);
+  color: var(--text-dim, #b8bcc4);
   font-size: 12px;
   cursor: pointer;
   padding: 2px 4px;

--- a/frontend/src/components/PairToSync.tsx
+++ b/frontend/src/components/PairToSync.tsx
@@ -1,10 +1,11 @@
-// Dashboard "Pair CLI to sync" affordance (012-web-adopt-pairing, US4 / FR-017).
+// "Pair CLI to sync" affordance (012-web-adopt-pairing, US4 / FR-017), shown in
+// Settings once the service has been adopted.
 //
 // Mints a fresh pairing code (origin="resync") through the same lifecycle and
 // operator-auth gate as the awaiting-adoption page, and offers a Copy button.
 // The code value is held only in a ref and is NEVER rendered into the DOM
-// (FR-015/FR-016); opening the popover mints, closing it ends the session
-// best-effort (the idle TTL is the backstop).
+// (FR-015/FR-016); opening mints, closing (or unmounting, e.g. leaving Settings)
+// ends the session best-effort (the idle TTL is the backstop).
 
 import { useCallback, useEffect, useRef, useState } from "react";
 import { ApiError, endPairing, mintPairingCode } from "../api/client";
@@ -19,6 +20,9 @@ export function PairToSync(): JSX.Element {
   const [copyState, setCopyState] = useState<"idle" | "copied" | "failed">("idle");
   const codeRef = useRef<string | null>(null);
   const copyResetHandle = useRef<ReturnType<typeof setTimeout>>();
+  // Track "open" for the unmount cleanup below without stale-closure issues.
+  const openRef = useRef(false);
+  openRef.current = open;
 
   const close = useCallback(() => {
     setOpen(false);
@@ -46,6 +50,12 @@ export function PairToSync(): JSX.Element {
   }, []);
 
   useEffect(() => () => clearTimeout(copyResetHandle.current), []);
+  // End the pairing session if Settings is closed with a code still live.
+  useEffect(() => () => {
+    if (openRef.current) {
+      endPairing();
+    }
+  }, []);
 
   const onCopy = useCallback(() => {
     const code = codeRef.current;
@@ -64,12 +74,12 @@ export function PairToSync(): JSX.Element {
     <div className="pairsync">
       <button
         type="button"
-        className="topbar-btn"
+        className="pairsync-btn"
         onClick={open ? close : openAndMint}
         data-testid="pair-to-sync"
         title="Mint a pairing code to run `remo web push` from your workstation"
       >
-        Pair CLI to sync
+        {open ? "Cancel" : "Mint pairing code"}
       </button>
 
       {open && (
@@ -88,7 +98,7 @@ export function PairToSync(): JSX.Element {
           ) : (
             <button
               type="button"
-              className="topbar-btn"
+              className="pairsync-btn"
               onClick={onCopy}
               disabled={mintState !== "ready"}
               data-testid="pairsync-copy"

--- a/frontend/src/components/SettingsPage.tsx
+++ b/frontend/src/components/SettingsPage.tsx
@@ -14,6 +14,7 @@ import {
   useSettings,
   type FontOption,
 } from "../state/settings";
+import { PairToSync } from "./PairToSync";
 import "./SettingsPage.css";
 
 interface SettingsPageProps {
@@ -243,6 +244,17 @@ export function SettingsPage({ onClose }: SettingsPageProps): JSX.Element {
                 );
               })}
             </div>
+          </section>
+
+          {/* Pair CLI to sync (post-adoption re-sync) */}
+          <section>
+            <div className="settings-heading">Pair CLI to sync</div>
+            <p className="settings-sub">
+              Mint a one-time code to run <code>remo web push &lt;url&gt;</code> from your
+              workstation and push registry / host-key updates to this service. The code is copied
+              to your clipboard — it is never shown.
+            </p>
+            <PairToSync />
           </section>
         </div>
       </div>

--- a/frontend/src/components/SettingsPage.tsx
+++ b/frontend/src/components/SettingsPage.tsx
@@ -7,7 +7,9 @@ import { listUploadedFonts, registerUploadedFont } from "../state/fonts";
 import {
   ACCENT_OPTIONS,
   FONT_OPTIONS,
+  MAX_FOCUS_DWELL_MS,
   MAX_TERM_SIZE,
+  MIN_FOCUS_DWELL_MS,
   MIN_TERM_SIZE,
   RENDERER_OPTIONS,
   settingsActions,
@@ -155,6 +157,30 @@ export function SettingsPage({ onClose }: SettingsPageProps): JSX.Element {
                 );
               })}
             </div>
+          </section>
+
+          {/* Focus-follows-mouse dwell */}
+          <section>
+            <div className="settings-row2-head">
+              <span className="settings-heading">Focus dwell</span>
+              <span className="settings-value">
+                {settings.focusDwellMs === 0 ? "instant" : `${settings.focusDwellMs} ms`}
+              </span>
+            </div>
+            <p className="settings-sub">
+              In a grid, how long the pointer must rest on a tile before it takes focus
+              (focus-follows-mouse). Lower is snappier; higher is calmer. 0 = instant.
+            </p>
+            <input
+              type="range"
+              min={MIN_FOCUS_DWELL_MS}
+              max={MAX_FOCUS_DWELL_MS}
+              step={20}
+              value={settings.focusDwellMs}
+              onChange={(e) => settingsActions.setFocusDwell(Number(e.target.value))}
+              className="settings-range"
+              data-testid="focus-dwell-range"
+            />
           </section>
 
           {/* Size + ligatures */}

--- a/frontend/src/components/TerminalCard.tsx
+++ b/frontend/src/components/TerminalCard.tsx
@@ -28,9 +28,6 @@ const DEFAULT_COLS = 80;
 const DEFAULT_ROWS = 24;
 /** How much to shrink the terminal font in a grid tile when "scale to fit". */
 const GRID_FIT_SCALE = 0.8;
-/** Focus-follows-mouse dwell: the pointer must REST on a tile this long before
- * it takes focus, so passing through tiles (or a small drift) doesn't steal it. */
-const HOVER_FOCUS_DELAY_MS = 220;
 
 const STATE_LABELS: Record<TerminalConnectionState, string> = {
   connecting: "Connecting…",
@@ -124,6 +121,9 @@ export function TerminalCard({
   const lastSentDimsRef = useRef<{ cols: number; rows: number } | null>(null);
   // Pending focus-follows-mouse dwell timer (cleared if the pointer leaves first).
   const hoverTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  // Latest focus-dwell setting, read inside the timer without re-creating the handler.
+  const dwellMsRef = useRef(settings.focusDwellMs);
+  dwellMsRef.current = settings.focusDwellMs;
 
   const [connectionState, setConnectionState] = useState<TerminalConnectionState>("connecting");
   const [needsManualReconnect, setNeedsManualReconnect] = useState(false);
@@ -343,7 +343,7 @@ export function TerminalCard({
     hoverTimerRef.current = setTimeout(() => {
       hoverTimerRef.current = null;
       onHoverFocus();
-    }, HOVER_FOCUS_DELAY_MS);
+    }, dwellMsRef.current);
   }, [onHoverFocus, clearHoverTimer]);
 
   // Cancel a pending dwell when the pointer leaves or the card unmounts.

--- a/frontend/src/components/TopBar.tsx
+++ b/frontend/src/components/TopBar.tsx
@@ -2,7 +2,6 @@
 // health indicator, refresh, settings, and shortcuts.
 
 import type { HealthStatus } from "../state/health";
-import { PairToSync } from "./PairToSync";
 import "./TopBar.css";
 
 // "unconfigured" is included for Record exhaustiveness, but in practice the
@@ -90,8 +89,6 @@ export function TopBar({
       <button type="button" className="topbar-btn" onClick={onRefresh} data-testid="refresh-button">
         <span className={refreshing ? "rail-spin" : undefined}>⟳</span> Refresh
       </button>
-
-      <PairToSync />
 
       <button
         type="button"

--- a/frontend/src/state/settings.ts
+++ b/frontend/src/state/settings.ts
@@ -69,6 +69,10 @@ export const MAX_TERM_SIZE = 18;
 export const MIN_RAIL_WIDTH = 262;
 export const MAX_RAIL_WIDTH = 520;
 const DEFAULT_RAIL_WIDTH = 320;
+/** Focus-follows-mouse dwell (ms): 0 = instant, higher = calmer. */
+export const MIN_FOCUS_DWELL_MS = 0;
+export const MAX_FOCUS_DWELL_MS = 1000;
+const DEFAULT_FOCUS_DWELL_MS = 220;
 
 export interface SettingsState {
   accent: string;
@@ -83,6 +87,8 @@ export interface SettingsState {
   nerdFontName: string | null;
   /** Browser terminal engine to back each terminal. */
   renderer: RendererChoice;
+  /** Focus-follows-mouse dwell in ms (how long the pointer rests before focus). */
+  focusDwellMs: number;
 }
 
 export interface TerminalFontOptions {
@@ -101,6 +107,7 @@ const DEFAULTS: SettingsState = {
   railCollapsed: false,
   nerdFontName: null,
   renderer: "xterm",
+  focusDwellMs: DEFAULT_FOCUS_DWELL_MS,
 };
 
 function clamp(n: number, lo: number, hi: number): number {
@@ -137,6 +144,10 @@ function loadPersisted(): SettingsState {
       railCollapsed: typeof c.railCollapsed === "boolean" ? c.railCollapsed : DEFAULTS.railCollapsed,
       nerdFontName: typeof c.nerdFontName === "string" ? c.nerdFontName : null,
       renderer: c.renderer === "ghostty" || c.renderer === "xterm" ? c.renderer : DEFAULTS.renderer,
+      focusDwellMs:
+        typeof c.focusDwellMs === "number"
+          ? clamp(Math.round(c.focusDwellMs), MIN_FOCUS_DWELL_MS, MAX_FOCUS_DWELL_MS)
+          : DEFAULTS.focusDwellMs,
     };
   } catch (error) {
     console.error("settings: failed to restore from localStorage", error);
@@ -214,6 +225,10 @@ export const settingsActions = {
   toggleRailCollapsed: () => setState({ railCollapsed: !state.railCollapsed }),
   setNerdFontName: (nerdFontName: string | null) => setState({ nerdFontName }),
   setRenderer: (renderer: RendererChoice) => setState({ renderer }),
+  setFocusDwell: (focusDwellMs: number) =>
+    setState({
+      focusDwellMs: clamp(Math.round(focusDwellMs), MIN_FOCUS_DWELL_MS, MAX_FOCUS_DWELL_MS),
+    }),
 };
 
 export function useSettings(): SettingsState {


### PR DESCRIPTION
Two Settings changes bundled (neither warrants its own rc — both ride the next one).

## 1. Move "Pair CLI to sync" into Settings
Relocates the re-sync pairing affordance from the top bar into a **Settings section**, since it's a post-adoption action (it was already only reachable in the adopted console).
- Renders **inline** (the minted-code panel expands in place, not a floating popover that would clip inside the scrolling settings page); trigger relabeled **"Mint pairing code"** under the section heading; button styling decoupled from `.topbar-btn` into its own `.pairsync-btn`.
- Ends the pairing session **on unmount** (leaving Settings), in addition to the existing Done/idle-TTL paths.
- Removed from `TopBar`. Minting still goes through the same lifecycle + operator-auth gate; the code is never rendered (FR-015/FR-016).

## 2. Focus dwell slider
Makes the focus-follows-mouse dwell configurable instead of a hardcoded 220ms.
- New browser-local setting `focusDwellMs` (0–1000ms, default 220; **0 = instant**), persisted like the other prefs.
- A slider in Settings ("Focus dwell"); `TerminalCard` reads it live via a ref (no handler churn).

## Verification
`tsc --noEmit`, Vitest 20/20, `vite build` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018SrwtyNKt4Y24pU748URrT