### PR TITLE
feat(web): show WebSocket latency in the header (dot colored by latency)

### DIFF
--- a/docs/web-session-interface.md
+++ b/docs/web-session-interface.md
@@ -137,13 +137,16 @@ they can be stale until something else fetches. Git glyphs only appear on instan
 `remo-host` new enough to report git status; see [Upgrade compatibility](#upgrade-compatibility).
 
 **Settings** (⚙, top bar; stored in this browser only, FR-034): accent color, terminal font, font
-size, program ligatures, grid display mode (actual-size vs scale-to-fit), and a **Nerd Font uploader**.
-Because a browser can't read fonts installed on the instance, uploading a patched Nerd Font once
-registers it via the `FontFace` API (persisted in IndexedDB) and offers it as a terminal font — that's
-how Powerline/Git/devicon glyphs in a prompt or Zellij status bar render. Font changes apply live to
-every open terminal. The top bar also shows a health indicator (from `GET /api/v1/ready`) and an
-offline overlay if the service becomes unreachable (terminals reattach automatically when it returns).
-Press **?** for the keyboard-shortcut reference.
+size, program ligatures, grid display mode (actual-size vs scale-to-fit), **focus dwell** (how long the
+pointer rests before focus-follows-mouse fires), terminal engine, a **Nerd Font uploader**, and **Pair
+CLI to sync** (mint a re-sync pairing code). Because a browser can't read fonts installed on the
+instance, uploading a patched Nerd Font once registers it via the `FontFace` API (persisted in
+IndexedDB) and offers it as a terminal font — that's how Powerline/Git/devicon glyphs in a prompt or
+Zellij status bar render. Font changes apply live to every open terminal. The top bar shows the
+**WebSocket round-trip latency** (median across open terminals, with the dot green/yellow/red by
+latency), falling back to the service health status when no terminal is connected; an offline overlay
+appears if the service becomes unreachable (terminals reattach automatically when it returns). Press
+**?** for the keyboard-shortcut reference.
 
 All fonts are self-hosted (bundled `@fontsource` assets), never fetched from a CDN, so the restrictive
 same-origin CSP (`default-src 'self'`) is satisfied.

--- a/frontend/src/components/AppShell.tsx
+++ b/frontend/src/components/AppShell.tsx
@@ -8,6 +8,7 @@ import type { SessionTarget } from "../api/client";
 import { exitBrowserFullscreen } from "../lib/fullscreen";
 import { useDiscovery } from "../state/discovery";
 import { useHealth } from "../state/health";
+import { useLatency } from "../state/latency";
 import { settingsActions, useSettings } from "../state/settings";
 import { useConsoleKeyboard } from "../state/useConsoleKeyboard";
 import { useWorkspace } from "../state/workspace";
@@ -25,6 +26,7 @@ const NARROW_BREAKPOINT = 820;
 export function AppShell(): JSX.Element {
   const discovery = useDiscovery();
   const health = useHealth();
+  const latency = useLatency();
   const settings = useSettings();
   const workspace = useWorkspace();
 
@@ -192,6 +194,7 @@ export function AppShell(): JSX.Element {
         openCount={workspace.attached.length}
         health={health.status}
         healthDetail={health.detail}
+        latencyMs={latency.rttMs}
         refreshing={discovery.isRefreshing}
         onRefresh={() => void discovery.refresh()}
         onSettings={() => setSettingsOpen(true)}

--- a/frontend/src/components/TerminalCard.tsx
+++ b/frontend/src/components/TerminalCard.tsx
@@ -19,6 +19,7 @@ import {
   type SettingsState,
   type TerminalFontOptions,
 } from "../state/settings";
+import { removeLatency, reportLatency } from "../state/latency";
 import type { RendererAdapter } from "../terminal/RendererAdapter";
 import { createDefaultRenderer } from "../terminal/defaultRenderer";
 import { TerminalConnection, type TerminalConnectionState } from "../terminal/TerminalConnection";
@@ -244,7 +245,12 @@ export function TerminalCard({
       onStateChange: (state) => {
         setConnectionState(state);
         setNeedsManualReconnect(connectionRef.current?.needsManualReconnect ?? false);
+        // Only a connected terminal contributes to the header latency median.
+        if (state !== "ready") {
+          removeLatency(target.id);
+        }
       },
+      onLatency: (rttMs) => reportLatency(target.id, rttMs),
     });
     connectionRef.current = connection;
 
@@ -272,6 +278,7 @@ export function TerminalCard({
         fitRafRef.current = null;
       }
       lastSentDimsRef.current = null;
+      removeLatency(target.id);
       unsubscribeInput();
       unsubscribeSelection();
       resizeObserver.disconnect();

--- a/frontend/src/components/TopBar.tsx
+++ b/frontend/src/components/TopBar.tsx
@@ -31,9 +31,22 @@ interface TopBarProps {
   health: HealthStatus;
   healthDetail: string | null;
   refreshing: boolean;
+  /** Median WS round-trip latency (ms) across open terminals, or null if none. */
+  latencyMs: number | null;
   onRefresh: () => void;
   onSettings: () => void;
   onShortcuts: () => void;
+}
+
+/** Latency → dot color: good (green) / so-so (yellow) / poor (red). */
+function latencyColor(ms: number): string {
+  if (ms < 100) {
+    return "var(--ok)";
+  }
+  if (ms < 300) {
+    return "var(--warn)";
+  }
+  return "var(--danger)";
 }
 
 export function TopBar({
@@ -44,10 +57,19 @@ export function TopBar({
   health,
   healthDetail,
   refreshing,
+  latencyMs,
   onRefresh,
   onSettings,
   onShortcuts,
 }: TopBarProps): JSX.Element {
+  // Prefer live WS latency (the real data-path measure); fall back to the
+  // health status when no terminal is connected to measure.
+  const showLatency = latencyMs != null;
+  const dotColor = showLatency ? latencyColor(latencyMs) : HEALTH_COLOR[health];
+  const statusLabel = showLatency ? `${Math.round(latencyMs)} ms` : HEALTH_LABEL[health];
+  const statusTitle = showLatency
+    ? "WebSocket round-trip latency (median across open terminals)"
+    : (healthDetail ?? HEALTH_LABEL[health]);
   return (
     <header className="topbar">
       {showRailToggle && (
@@ -81,9 +103,9 @@ export function TopBar({
         {openCount} open
       </span>
 
-      <span className="topbar-health" title={healthDetail ?? HEALTH_LABEL[health]}>
-        <span className="topbar-health-dot" style={{ background: HEALTH_COLOR[health] }} />
-        <span>{HEALTH_LABEL[health]}</span>
+      <span className="topbar-health" title={statusTitle} data-testid="topbar-status">
+        <span className="topbar-health-dot" style={{ background: dotColor }} />
+        <span>{statusLabel}</span>
       </span>
 
       <button type="button" className="topbar-btn" onClick={onRefresh} data-testid="refresh-button">

--- a/frontend/src/state/latency.test.ts
+++ b/frontend/src/state/latency.test.ts
@@ -1,0 +1,35 @@
+import { beforeEach, describe, expect, it } from "vitest";
+import { getLatencySnapshot, removeLatency, reportLatency } from "./latency";
+
+describe("latency store", () => {
+  beforeEach(() => {
+    // Clear any samples left by a prior test (module singleton).
+    for (const id of ["a", "b", "c", "d"]) {
+      removeLatency(id);
+    }
+  });
+
+  it("reports the median across connected terminals", () => {
+    reportLatency("a", 40);
+    reportLatency("b", 80);
+    reportLatency("c", 120);
+    const snap = getLatencySnapshot();
+    expect(snap.rttMs).toBe(80);
+    expect(snap.count).toBe(3);
+  });
+
+  it("updates a terminal's latest sample in place", () => {
+    reportLatency("a", 40);
+    reportLatency("a", 300);
+    expect(getLatencySnapshot()).toEqual({ rttMs: 300, count: 1 });
+  });
+
+  it("drops a terminal's sample on removal; null when none remain", () => {
+    reportLatency("a", 40);
+    reportLatency("b", 80);
+    removeLatency("a");
+    expect(getLatencySnapshot()).toEqual({ rttMs: 80, count: 1 });
+    removeLatency("b");
+    expect(getLatencySnapshot()).toEqual({ rttMs: null, count: 0 });
+  });
+});

--- a/frontend/src/state/latency.ts
+++ b/frontend/src/state/latency.ts
@@ -1,0 +1,69 @@
+// WebSocket latency store (header indicator).
+//
+// Each connected terminal measures its WS round-trip (ping→pong in
+// TerminalConnection) and reports it here keyed by session-target id. The header
+// shows the MEDIAN across open terminals — since every terminal's WebSocket
+// terminates at the same remo-web service, they all measure the same
+// browser↔service path, so the median is a robust single number. Terminals
+// remove their sample when they disconnect/unmount, so the store only ever holds
+// currently-healthy connections (no freshness timer needed).
+//
+// The cached-snapshot pattern keeps `getSnapshot()` referentially stable between
+// mutations (returning a fresh object each call would loop useSyncExternalStore).
+
+import { useSyncExternalStore } from "react";
+
+const samples = new Map<string, number>();
+const listeners = new Set<() => void>();
+
+export interface LatencySnapshot {
+  /** Median WS round-trip in ms across open terminals, or null if none. */
+  rttMs: number | null;
+  /** How many terminals are currently reporting. */
+  count: number;
+}
+
+let snapshot: LatencySnapshot = { rttMs: null, count: 0 };
+
+function recompute(): void {
+  if (samples.size === 0) {
+    snapshot = { rttMs: null, count: 0 };
+    return;
+  }
+  const sorted = [...samples.values()].sort((a, b) => a - b);
+  const median = sorted[Math.floor(sorted.length / 2)];
+  snapshot = { rttMs: median, count: sorted.length };
+}
+
+function emit(): void {
+  for (const listener of listeners) {
+    listener();
+  }
+}
+
+export function reportLatency(id: string, rttMs: number): void {
+  samples.set(id, rttMs);
+  recompute();
+  emit();
+}
+
+export function removeLatency(id: string): void {
+  if (samples.delete(id)) {
+    recompute();
+    emit();
+  }
+}
+
+/** Test/inspection accessor for the current aggregate. */
+export function getLatencySnapshot(): LatencySnapshot {
+  return snapshot;
+}
+
+function subscribe(listener: () => void): () => void {
+  listeners.add(listener);
+  return () => listeners.delete(listener);
+}
+
+export function useLatency(): LatencySnapshot {
+  return useSyncExternalStore(subscribe, getLatencySnapshot, getLatencySnapshot);
+}

--- a/frontend/src/terminal/TerminalConnection.ts
+++ b/frontend/src/terminal/TerminalConnection.ts
@@ -38,6 +38,8 @@ interface ControlMessage {
 
 const MAX_AUTO_RECONNECT_ATTEMPTS = 3;
 const RECONNECT_BACKOFF_MS = [500, 1500, 3500];
+/** How often to ping the WS to measure round-trip latency (also a keepalive). */
+const PING_INTERVAL_MS = 4000;
 
 export interface TerminalConnectionCallbacks {
   onData?: (data: Uint8Array) => void;
@@ -45,6 +47,8 @@ export interface TerminalConnectionCallbacks {
   onExit?: (code: number) => void;
   onError?: (error: TypedError) => void;
   onStateChange?: (state: TerminalConnectionState) => void;
+  /** WS round-trip time in ms, from each ping→pong while connected. */
+  onLatency?: (rttMs: number) => void;
 }
 
 /**
@@ -72,6 +76,9 @@ export class TerminalConnection {
   /** Bumped each attach() so a slow, superseded attach can't assign a socket. */
   private attachGen = 0;
   private wakeListenersBound = false;
+  private pingTimer: ReturnType<typeof setInterval> | undefined;
+  /** performance.now() when the outstanding ping was sent (null if none). */
+  private pingSentAt: number | null = null;
 
   constructor(
     sessionTargetId: string,
@@ -130,6 +137,7 @@ export class TerminalConnection {
   async close(): Promise<void> {
     this.clientInitiatedClose = true;
     this.removeWakeListeners();
+    this.stopPinging();
     this.clearReconnectTimer();
     const socket = this.socket;
     const terminalId = this.terminalId;
@@ -278,12 +286,35 @@ export class TerminalConnection {
 
     socket.onclose = (event: CloseEvent) => {
       this.socket = null;
+      this.stopPinging();
       if (this.clientInitiatedClose || event.code === 1000) {
         this.setState("closed");
         return;
       }
       void this.handleUnexpectedClose();
     };
+  }
+
+  /** Begin (or restart) the latency ping loop; call once per fresh connection. */
+  private startPinging(): void {
+    this.stopPinging();
+    const sendMeasuredPing = (): void => {
+      if (this.socket?.readyState !== WebSocket.OPEN) {
+        return;
+      }
+      this.pingSentAt = performance.now();
+      this.sendPing();
+    };
+    sendMeasuredPing(); // one immediately, for a fast first sample
+    this.pingTimer = setInterval(sendMeasuredPing, PING_INTERVAL_MS);
+  }
+
+  private stopPinging(): void {
+    if (this.pingTimer !== undefined) {
+      clearInterval(this.pingTimer);
+      this.pingTimer = undefined;
+    }
+    this.pingSentAt = null;
   }
 
   private handleControlMessage(raw: string): void {
@@ -306,6 +337,7 @@ export class TerminalConnection {
         // so re-send them now to size the remote terminal to the real surface.
         this.sendControl({ v: 1, type: "resize", cols: this.cols, rows: this.rows });
         this.callbacks.onReady?.();
+        this.startPinging();
         break;
       case "exit":
         this.callbacks.onExit?.(message.code ?? 0);
@@ -320,6 +352,11 @@ export class TerminalConnection {
         this.setState("error");
         break;
       case "pong":
+        if (this.pingSentAt !== null) {
+          const rtt = performance.now() - this.pingSentAt;
+          this.pingSentAt = null;
+          this.callbacks.onLatency?.(rtt);
+        }
         break;
     }
   }


### PR DESCRIPTION
Replaces the green "service healthy" text with the **live WebSocket round-trip latency** — you can already tell the service is healthy by looking at the windows, and ms is a more useful, interesting measure.

- **`TerminalConnection`** measures RTT via a lightweight **ping→pong every 4s** (doubles as a keepalive), started on `ready` and stopped on close, surfaced through a new `onLatency` callback. Measurement is entirely **off the render path** — no UI lag (your explicit caveat).
- **New latency store** aggregates the **median** across open terminals. Every terminal's WS terminates at the same remo-web service, so they all measure the same browser↔service path — the median is a robust single number. Terminals drop their sample when they disconnect/unmount, so no freshness timer is needed.
- **`TopBar`** shows `<n> ms` with the dot **green (<100ms) / yellow (<300ms) / red (≥300ms)**, and **falls back to the service health status** (green/offline) when no terminal is connected to measure.

Thresholds are a starting point — easy to tune.

## Verification
`tsc --noEmit`, Vitest **23/23** (added latency-store median/removal tests), `vite build` green. No test depended on the old health label (the fallback preserves it when no terminal is open).

⚠️ Not browser-verified here — the actual ms readout + dot colors want a real click-through.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018SrwtyNKt4Y24pU748URrT