### PR TITLE
fix(web): reliable ⌘C copy in Safari via the native copy event

### DIFF
--- a/frontend/src/terminal/GhosttyRenderer.ts
+++ b/frontend/src/terminal/GhosttyRenderer.ts
@@ -78,9 +78,20 @@ export class GhosttyRenderer implements RendererAdapter {
     return true;
   }
 
+  // Native `copy` event (⌘C, Edit▸Copy, right-click▸Copy): write the selection
+  // synchronously via clipboardData — reliable in Safari (see XtermRenderer).
+  private readonly handleCopyEvent = (e: ClipboardEvent): void => {
+    const selection = this.getSelection();
+    if (selection && e.clipboardData) {
+      e.clipboardData.setData("text/plain", selection);
+      e.preventDefault();
+    }
+  };
+
   open(container: HTMLElement): void {
     this.container = container;
     this.terminal.open(container);
+    container.addEventListener("copy", this.handleCopyEvent);
   }
 
   write(data: Uint8Array | string): void {
@@ -149,6 +160,7 @@ export class GhosttyRenderer implements RendererAdapter {
   }
 
   dispose(): void {
+    this.container?.removeEventListener("copy", this.handleCopyEvent);
     this.terminal.dispose();
   }
 }

--- a/frontend/src/terminal/XtermRenderer.ts
+++ b/frontend/src/terminal/XtermRenderer.ts
@@ -55,6 +55,7 @@ export class XtermRenderer implements RendererAdapter {
   private readonly fitAddon: FitAddon;
   private ligaturesAddon: LigaturesAddon | null = null;
   private webglAddon: WebglAddon | null = null;
+  private container: HTMLElement | null = null;
   private opened = false;
   /** Desired ligature state; the addon is only actually (un)loaded after
    * open() since it registers a character joiner that needs an opened terminal. */
@@ -92,6 +93,18 @@ export class XtermRenderer implements RendererAdapter {
       handler(data);
     }
   }
+
+  // Native `copy` event (⌘C on macOS, Edit▸Copy, right-click▸Copy). Writing the
+  // xterm selection synchronously via clipboardData is reliable everywhere
+  // including Safari — unlike an async clipboard write off a keydown. Bare Ctrl+C
+  // never reaches here: xterm preventDefaults it (SIGINT), so no copy event fires.
+  private readonly handleCopyEvent = (e: ClipboardEvent): void => {
+    const selection = this.getSelection();
+    if (selection && e.clipboardData) {
+      e.clipboardData.setData("text/plain", selection);
+      e.preventDefault();
+    }
+  };
 
   private handleKeyEvent(e: KeyboardEvent): boolean {
     // Copy the selection on ⌘C / Ctrl+Shift+C — but only when something is
@@ -133,6 +146,8 @@ export class XtermRenderer implements RendererAdapter {
 
   open(container: HTMLElement): void {
     this.terminal.open(container);
+    this.container = container;
+    container.addEventListener("copy", this.handleCopyEvent);
     this.opened = true;
     this.enableWebgl();
     // Now that the terminal is attached, load the ligatures addon if wanted.
@@ -221,6 +236,8 @@ export class XtermRenderer implements RendererAdapter {
   }
 
   dispose(): void {
+    this.container?.removeEventListener("copy", this.handleCopyEvent);
+    this.container = null;
     // Dispose the WebGL addon before the terminal so its GPU context/canvas is
     // released cleanly (Terminal.dispose would also drop it, but ordering is
     // explicit here).

--- a/frontend/src/terminal/keymap.test.ts
+++ b/frontend/src/terminal/keymap.test.ts
@@ -32,9 +32,12 @@ describe("inputForKeyEvent", () => {
 });
 
 describe("isCopyChord", () => {
-  it("recognizes ⌘C and Ctrl+Shift+C", () => {
-    expect(isCopyChord(key({ key: "c", metaKey: true }))).toBe(true);
+  it("recognizes Ctrl+Shift+C", () => {
     expect(isCopyChord(key({ key: "C", ctrlKey: true, shiftKey: true }))).toBe(true);
+  });
+
+  it("does NOT match ⌘C — that goes through the native copy event", () => {
+    expect(isCopyChord(key({ key: "c", metaKey: true }))).toBe(false);
   });
 
   it("leaves bare Ctrl+C alone (stays SIGINT)", () => {
@@ -42,8 +45,8 @@ describe("isCopyChord", () => {
   });
 
   it("ignores other keys, plain c, and non-keydown events", () => {
-    expect(isCopyChord(key({ key: "v", metaKey: true }))).toBe(false);
+    expect(isCopyChord(key({ key: "v", ctrlKey: true, shiftKey: true }))).toBe(false);
     expect(isCopyChord(key({ key: "c" }))).toBe(false);
-    expect(isCopyChord(key({ key: "c", metaKey: true, type: "keyup" }))).toBe(false);
+    expect(isCopyChord(key({ key: "c", ctrlKey: true, shiftKey: true, type: "keyup" }))).toBe(false);
   });
 });

--- a/frontend/src/terminal/keymap.ts
+++ b/frontend/src/terminal/keymap.ts
@@ -27,16 +27,15 @@ export function inputForKeyEvent(e: KeyboardEvent): string | null {
 }
 
 /**
- * Whether a key event is the "copy the selection" chord: **Cmd+C** (macOS) or
- * **Ctrl+Shift+C** (Linux/Windows). Bare `Ctrl+C` is deliberately excluded so it
- * stays SIGINT. The renderer only copies when there is actually a selection —
- * otherwise the chord is left alone.
+ * Whether a key event is the **Ctrl+Shift+C** explicit-copy chord (Linux/Windows).
+ * Bare `Ctrl+C` is excluded so it stays SIGINT. **⌘C on macOS is intentionally
+ * NOT handled here** — it fires the browser's native `copy` event, which the
+ * renderer handles via `clipboardData` (synchronous, and reliable in Safari,
+ * unlike an async `navigator.clipboard.writeText()` off a preventDefault'd key).
  */
 export function isCopyChord(e: KeyboardEvent): boolean {
   if (e.type !== "keydown" || (e.key !== "c" && e.key !== "C")) {
     return false;
   }
-  const cmdC = e.metaKey && !e.ctrlKey && !e.altKey; // macOS ⌘C
-  const ctrlShiftC = e.ctrlKey && e.shiftKey && !e.metaKey && !e.altKey; // Linux/Win
-  return cmdC || ctrlShiftC;
+  return e.ctrlKey && e.shiftKey && !e.metaKey && !e.altKey;
 }


### PR DESCRIPTION
Addresses "copy is still not great in Safari."

## Root cause
The ⌘C path intercepted the **keydown**, `preventDefault`'d it (which **suppresses Safari's native `copy` event**), then did an **async** `navigator.clipboard.writeText()`. Safari treats an async clipboard write off a preventDefault'd key as gesture-sensitive and frequently drops it — so ⌘C often copied nothing.

## Fix
Handle the browser's **native `copy` event** and write the xterm selection **synchronously** via `clipboardData.setData("text/plain", …)`. That's reliable in every browser including Safari, and also covers **Edit▸Copy** and **right-click▸Copy** for free.
- Bare **Ctrl+C never reaches it** — xterm `preventDefault`s it as SIGINT, so no copy event fires. SIGINT preserved.
- `isCopyChord` narrowed to **Ctrl+Shift+C** (Linux/Windows), which has no native copy event, keeping its `writeText` path.
- Applied to both renderers (xterm + ghostty); listener removed on dispose.

The ⧉ Copy button (already a direct click gesture) is unchanged.

## Verification
`tsc --noEmit`, Vitest **24/24** (updated `isCopyChord` tests), `vite build` green.

⚠️ Not Safari-verified here — please re-test ⌘C on the next rc. If it's still off, tell me the exact symptom (copies nothing / wrong text / only the button works) and I'll dig further.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018SrwtyNKt4Y24pU748URrT