### PR TITLE
chore: repo hygiene fixes (SHA-pin actions, SECURITY.md, CODEOWNERS, dep review)

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,5 @@
+# Code owners for remo.
+# These owners are the default reviewers for every pull request in this repo.
+# See https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
+
+*       @pofallon

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,6 +7,10 @@ updates:
       interval: "weekly"
       day: "monday"
     open-pull-requests-limit: 5
+    # Let a new release settle before we bump to it, so we don't chase
+    # immediately-yanked or regression releases.
+    cooldown:
+      default-days: 7
     groups:
       # One PR per week with all minor/patch production deps bumped together.
       production-minor-patch:
@@ -29,6 +33,8 @@ updates:
       interval: "weekly"
       day: "monday"
     open-pull-requests-limit: 5
+    cooldown:
+      default-days: 7
     groups:
       actions:
         update-types:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,9 +15,9 @@ jobs:
         python-version: ["3.11", "3.12", "3.13"]
 
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
-      - uses: astral-sh/setup-uv@v7
+      - uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7
 
       - name: Set up Python ${{ matrix.python-version }}
         run: uv python install ${{ matrix.python-version }}
@@ -39,16 +39,16 @@ jobs:
     # runs npm ci and pip install under QEMU.
     timeout-minutes: 45
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
       # Registers binfmt handlers so the arm64 half of tests/image/ can build
       # under emulation on an amd64 runner. The arch-selection branch
       # (FR-027/FR-042) has no other way to be exercised here.
-      - uses: docker/setup-qemu-action@v4
+      - uses: docker/setup-qemu-action@96fe6ef7f33517b61c61be40b68a1882f3264fb8 # v4
 
-      - uses: docker/setup-buildx-action@v4
+      - uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4
 
-      - uses: astral-sh/setup-uv@v7
+      - uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7
 
       - name: Install dependencies
         run: uv sync --all-extras
@@ -68,9 +68,9 @@ jobs:
     name: Wheel install smoke test
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
-      - uses: astral-sh/setup-uv@v7
+      - uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7
 
       - name: Build wheel
         run: uv build --wheel
@@ -96,9 +96,9 @@ jobs:
     name: Lint
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
-      - uses: astral-sh/setup-uv@v7
+      - uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7
 
       - name: Install dependencies
         run: uv sync --all-extras
@@ -117,9 +117,9 @@ jobs:
       run:
         working-directory: frontend
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
-      - uses: actions/setup-node@v7
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
         with:
           node-version: "20"
           cache: npm

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -1,0 +1,18 @@
+name: Dependency Review
+
+# Scans dependency manifest changes on pull requests for known-vulnerable
+# packages and disallowed licenses, blocking the PR before they reach main.
+on:
+  pull_request:
+
+permissions:
+  contents: read
+
+jobs:
+  dependency-review:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+      - uses: actions/dependency-review-action@2031cfc080254a8a887f58cffee85186f0e49e48 # v4
+        with:
+          fail-on-severity: high

--- a/.github/workflows/provision.yml
+++ b/.github/workflows/provision.yml
@@ -16,10 +16,10 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7
 
       - name: Install Ansible and dependencies
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,9 +13,9 @@ jobs:
         python-version: ["3.11", "3.12", "3.13"]
 
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
-      - uses: astral-sh/setup-uv@v7
+      - uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7
 
       - name: Set up Python ${{ matrix.python-version }}
         run: uv python install ${{ matrix.python-version }}
@@ -38,7 +38,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           fetch-depth: 0
 
@@ -137,7 +137,7 @@ jobs:
           fi
 
       - name: Create Release
-        uses: softprops/action-gh-release@v3
+        uses: softprops/action-gh-release@3d0d9888cb7fd7b750713d6e236d1fcb99157228 # v3
         with:
           tag_name: ${{ steps.tag.outputs.tag }}
           name: ${{ steps.tag.outputs.tag }}
@@ -153,15 +153,15 @@ jobs:
     environment: pypi
 
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
-      - uses: astral-sh/setup-uv@v7
+      - uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7
 
       - name: Build package
         run: uv build
 
       - name: Publish to PyPI
-        uses: pypa/gh-action-pypi-publish@release/v1
+        uses: pypa/gh-action-pypi-publish@ba38be9e461d3875417946c167d0b5f3d385a247 # release/v1
 
   publish-image:
     # Publishes the remo-web container image that docker/compose.example.yml
@@ -177,16 +177,16 @@ jobs:
     timeout-minutes: 60
 
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
       # Needed for the linux/arm64 half of the manifest: GitHub's runners are
       # amd64, so arm64 is cross-built under emulation.
-      - uses: docker/setup-qemu-action@v4
+      - uses: docker/setup-qemu-action@96fe6ef7f33517b61c61be40b68a1882f3264fb8 # v4
 
-      - uses: docker/setup-buildx-action@v4
+      - uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4
 
       - name: Log in to GHCR
-        uses: docker/login-action@v4
+        uses: docker/login-action@af1e73f918a031802d376d3c8bbc3fe56130a9b0 # v4
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -194,7 +194,7 @@ jobs:
 
       - name: Derive image tags and labels
         id: meta
-        uses: docker/metadata-action@v6
+        uses: docker/metadata-action@dc802804100637a589fabce1cb79ff13a1411302 # v6
         with:
           images: ghcr.io/${{ github.repository_owner }}/remo-web
           # latest=false disables this action's automatic `latest`; the raw
@@ -207,7 +207,7 @@ jobs:
             type=raw,value=latest,enable=${{ needs.release.outputs.is_prerelease == 'false' }}
 
       - name: Build and push (amd64 + arm64)
-        uses: docker/build-push-action@v7
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7
         with:
           context: .
           file: docker/Dockerfile

--- a/.github/workflows/smoke-test-cleanup.yml
+++ b/.github/workflows/smoke-test-cleanup.yml
@@ -20,7 +20,7 @@ jobs:
     timeout-minutes: 10
     steps:
       - name: Configure AWS credentials (OIDC)
-        uses: aws-actions/configure-aws-credentials@v6
+        uses: aws-actions/configure-aws-credentials@517a711dbcd0e402f90c77e7e2f81e849156e31d # v6
         with:
           role-to-assume: ${{ secrets.AWS_OIDC_ROLE_ARN }}
           role-session-name: remo-cleanup-${{ github.run_id }}
@@ -81,7 +81,7 @@ jobs:
     timeout-minutes: 10
     steps:
       - name: Setup hcloud CLI
-        uses: hetznercloud/setup-hcloud@v2
+        uses: hetznercloud/setup-hcloud@ac9e7d74fb41a3ca44a6a3da123bd5aa70731e3a # v2
 
       - name: Delete stale CI servers
         env:

--- a/.github/workflows/smoke-test.yml
+++ b/.github/workflows/smoke-test.yml
@@ -49,16 +49,16 @@ jobs:
       INSTANCE_NAME: ci-${{ github.run_id }}-aws
 
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7
 
       - name: Install remo
         run: uv sync
 
       - name: Configure AWS credentials (OIDC)
-        uses: aws-actions/configure-aws-credentials@v6
+        uses: aws-actions/configure-aws-credentials@517a711dbcd0e402f90c77e7e2f81e849156e31d # v6
         with:
           role-to-assume: ${{ secrets.AWS_OIDC_ROLE_ARN }}
           role-session-name: remo-ci-${{ github.run_id }}
@@ -206,10 +206,10 @@ jobs:
       HETZNER_API_TOKEN: ${{ secrets.HETZNER_API_TOKEN }}
 
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7
 
       - name: Install remo
         run: uv sync
@@ -325,10 +325,10 @@ jobs:
       CONTAINER_NAME: ci-test
 
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7
 
       - name: Install remo
         run: uv sync

--- a/.github/workflows/teardown.yml
+++ b/.github/workflows/teardown.yml
@@ -16,10 +16,10 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7
 
       - name: Install Ansible and dependencies
         run: |

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,31 @@
+# Security Policy
+
+## Supported Versions
+
+remo is developed as a rolling release; only the latest published version on the
+`main` branch (and the most recent tagged release) receives security fixes.
+
+| Version        | Supported          |
+| -------------- | ------------------ |
+| Latest release | :white_check_mark: |
+| Older releases | :x:                |
+
+## Reporting a Vulnerability
+
+**Please do not report security vulnerabilities through public GitHub issues.**
+
+Instead, use GitHub's private vulnerability reporting:
+
+1. Go to the [Security tab](https://github.com/get2knowio/remo/security) of this
+   repository.
+2. Click **Report a vulnerability** to open a private advisory.
+
+Please include:
+
+- A description of the vulnerability and its impact.
+- Steps to reproduce, or a proof of concept.
+- The affected version(s) and, if known, any suggested remediation.
+
+You can expect an initial acknowledgement within a few days. We will keep you
+informed as we work on a fix and will coordinate disclosure with you once a patch
+is available.


### PR DESCRIPTION
Closes several file-based repository best-practice gaps flagged by a [hangar](https://github.com/get2knowio/hangar) policy scan of this repo.

## Changes

| Hangar check | Fix |
|---|---|
| **Actions pinned to SHA** | Pinned all 12 actions (38 usages) to full commit SHAs, keeping the version as a `# vN` comment so Dependabot still tracks upgrades. |
| **SECURITY.md present** | Added `SECURITY.md` with GitHub private-vulnerability-reporting instructions and a supported-versions table. |
| **CODEOWNERS present** | Added `.github/CODEOWNERS` with `@pofallon` as the default reviewer. |
| **Dependency review enabled** | Added `.github/workflows/dependency-review.yml` (runs on PRs, `fail-on-severity: high`, least-privilege `contents: read`). |
| **Update cooldown ≥ target** | Added a 7-day `cooldown` to both the pip and github-actions Dependabot ecosystems. |

## Notes
- SHA pins were resolved from the current tip of each action's major tag, so behavior is unchanged from the previous `@vN` refs.
- The new dependency-review workflow itself uses least-privilege token permissions and SHA-pinned actions.

## Not covered here (require repo/org settings, not files)
Branch protection, secret scanning + push protection, CodeQL, org 2FA, and the repo-level default workflow-token permission are settings-based and need to be toggled in GitHub — happy to walk through those separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)