### PR TITLE
ci: add CodeQL code scanning workflow

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,44 @@
+name: CodeQL
+
+# Static analysis (code scanning) for the repo's compiled/interpreted sources.
+# Results appear under the Security tab and annotate pull requests.
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  schedule:
+    # Weekly full scan so newly published CodeQL queries catch existing code.
+    - cron: "27 4 * * 1"
+
+permissions:
+  contents: read
+
+jobs:
+  analyze:
+    name: Analyze (${{ matrix.language }})
+    runs-on: ubuntu-latest
+    permissions:
+      security-events: write  # upload CodeQL results
+      packages: read          # fetch CodeQL packs
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - language: python
+            build-mode: none
+          - language: javascript-typescript
+            build-mode: none
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@4187e74d05793876e9989daffde9c3e66b4acd07 # v3
+        with:
+          languages: ${{ matrix.language }}
+          build-mode: ${{ matrix.build-mode }}
+
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@4187e74d05793876e9989daffde9c3e66b4acd07 # v3
+        with:
+          category: "/language:${{ matrix.language }}"


### PR DESCRIPTION
Follow-up to #71 — closes the one remaining hangar **security** check that can be satisfied in-repo rather than via a settings toggle.

## Change
Adds `.github/workflows/codeql.yml`: CodeQL static analysis for **Python** and **JavaScript/TypeScript** (both no-build), running on pushes/PRs to `main` and a weekly schedule. Results surface under the Security tab and annotate PRs.

- Least-privilege token: top-level `contents: read`, with `security-events: write` scoped to the analyze job only.
- Actions SHA-pinned (`actions/checkout`, `github/codeql-action/{init,analyze}`), consistent with the rest of the workflows after #70.

Once merged, this closes the **Code scanning (CodeQL)** check → repo reaches **14/23**. The remaining failures in #71 are all repo/org settings toggles.

🤖 Generated with [Claude Code](https://claude.com/claude-code)