### PR TITLE
feat(add): provider-neutral `remo add`/`remo remove` for SSH-reachable hosts (014)

### DIFF
--- a/.specify/feature.json
+++ b/.specify/feature.json
@@ -1,3 +1,3 @@
 {
-  "feature_directory": "specs/013-managed-instance-tags"
+  "feature_directory": "specs/014-register-ssh-host"
 }

--- a/README.md
+++ b/README.md
@@ -205,6 +205,54 @@ The `destroy` command on each provider checks for existing snapshots first and
 offers to clean them up. Decline and the snapshots remain (you'll be warned
 they continue to incur storage costs on AWS/Hetzner).
 
+---
+
+## Register an SSH-reachable host
+
+Already have SSH access to a box — a VM, a bare-metal server, someone else's
+container — but no hypervisor host access, cloud credentials, or API token?
+`remo add` registers it directly into your registry. Provider `sync` is bulk
+discovery that needs provider/host access; `add` is a single manual
+registration that needs only SSH reachability.
+
+```bash
+remo add NAME TARGET [--user USER] [--port PORT] [--identity PATH] [--verify] [--yes]
+```
+
+`TARGET` is `[user@]host[:port]`. `--user`, `--port`, and `--identity` override
+(or fill in) the corresponding parts of `TARGET`. When no user is given, the
+default SSH user is `remo` (reported back to you); the default port is `22`.
+
+- **`--identity PATH`** records a private key that is persisted and passed to
+  `ssh -i` on connect — no `~/.ssh/config` editing needed for a host that
+  requires a non-default key.
+- **`--verify`** does an opt-in, fail-closed SSH reachability check *before*
+  registering: on failure it surfaces the SSH error, writes nothing, and exits
+  non-zero. Without `--verify` there is no network round-trip at all.
+- **Re-running `add`** with an existing added-host name and a changed target
+  updates it in place (confirm unless `--yes`) — it never creates a duplicate.
+  It refuses to overwrite a provider-managed entry (incus/proxmox/aws/hetzner)
+  of the same name.
+- **IPv6:** un-bracketed IPv6 literals are rejected — use a hostname or an
+  `~/.ssh/config` alias instead (bracketed `[::1]:22` is not supported in this
+  release).
+
+Once added, `remo shell NAME` and `remo cp` work over the same direct SSH path
+as any other host.
+
+```bash
+remo add mybox 10.0.0.5 --port 2222 --identity ~/.ssh/mybox_ed25519 --verify
+remo shell mybox                    # open a shell over direct SSH
+remo cp ./deploy.sh mybox:/tmp/     # copy a file up
+remo remove mybox                   # deregister when you're done
+```
+
+`remo remove NAME [--yes]` deregisters an added host by deleting **only** the
+local registry entry — it makes no connection to and no change on the remote
+environment (unlike a provider `destroy`, which tears down infrastructure). It
+refuses to act on a provider-managed host and points you at that provider's
+`destroy` instead.
+
 ## CLI Reference
 
 ```bash
@@ -228,6 +276,13 @@ remo cp --progress big.tar :/tmp/   # Show progress
 
 # Setup
 remo init                           # Install Ansible collections
+
+# Register an SSH-reachable host (provider-neutral; needs only SSH access)
+remo add NAME [user@]host[:port]    # Register a single SSH host
+remo add NAME host --port 2222 --identity ~/.ssh/key   # Custom port + key
+remo add NAME host --verify         # Fail-closed SSH reachability check first
+remo add NAME host --user alice     # Override default SSH user (default: remo)
+remo remove NAME [--yes]            # Deregister an added host (local-only)
 
 # Hetzner Cloud
 remo hetzner create                 # Provision VM

--- a/specs/014-register-ssh-host/contracts/add-command.md
+++ b/specs/014-register-ssh-host/contracts/add-command.md
@@ -1,0 +1,47 @@
+# Contract: `remo add`
+
+Register a single SSH-reachable environment into the registry. Provider-neutral;
+requires only SSH reachability (FR-001).
+
+## Synopsis
+
+```text
+remo add NAME TARGET [--user USER] [--port PORT] [--identity PATH] [--verify] [--yes]
+```
+
+- `NAME` (arg, required): user-facing name. Validated by `validate_name`
+  (FR-013). Must not collide with a provider-managed entry (FR-010).
+- `TARGET` (arg, required): `[user@]host[:port]`. Parsed per data-model D4.
+- `--user USER`: SSH user; overrides any `user@` in TARGET. Default
+  `DEFAULT_ADDED_HOST_USER` (`remo`), reported back (FR-003).
+- `--port PORT`: SSH port (int); overrides any `:port` in TARGET. Default `22`.
+- `--identity PATH`: SSH private key path, persisted and used via `ssh -i` on
+  connect (FR-004). Must not contain `:` (D5).
+- `--verify`: opt-in SSH reachability check before registering (FR-014).
+- `--yes`: bypass the confirmation prompt on an in-place update (FR-007).
+
+## Behavior
+
+| # | Precondition | Action | Result | Exit |
+|---|--------------|--------|--------|------|
+| 1 | Name unused, valid target | register | `ssh` entry written; success names `remo shell <name>` and the effective user | 0 |
+| 2 | Name held by a **provider** entry | — | refuse; message names the conflicting entry; **no write** (FR-010/SC-005) | ≠0 |
+| 3 | Name held by an existing **`ssh`** entry, target changed | update in place | confirm (unless `--yes`) → replace line; no duplicate (FR-007/SC-003) | 0 |
+| 4 | Target is an un-bracketed IPv6 literal, or bracketed `[::1]:…` | — | reject with "use a hostname or `~/.ssh/config` alias"; **no write** (D4) | ≠0 |
+| 5 | Port out of `1..65535`, or invalid name | — | reject via `validate_port`/`validate_name`; **no write** | ≠0 |
+| 6 | `--identity` path contains `:` | — | reject; **no write** (D5) | ≠0 |
+| 7 | `--verify`, target reachable | probe then register | success line reports verified | 0 |
+| 8 | `--verify`, target unreachable/auth-fails | probe | surface SSH error; **decline (no write)**; fail-closed (FR-014/US3.2) | ≠0 |
+| 9 | no `--verify` | register | no network round-trip at all (FR-014/US3.3) | 0 |
+
+## Post-conditions
+
+- On success (non-verify or verified): exactly one `ssh:NAME:…` line exists;
+  `remo shell NAME` and `remo cp` connect via the direct path with the recorded
+  port/identity (FR-005, SC-001, SC-002).
+- On any rejection/verify-failure: the registry is **unchanged**.
+
+## Storage
+
+Writes a `KnownHost(type="ssh", access_mode="direct")` via `save_known_host`.
+Encoding: see [data-model.md](../data-model.md).

--- a/specs/014-register-ssh-host/contracts/remove-command.md
+++ b/specs/014-register-ssh-host/contracts/remove-command.md
@@ -1,0 +1,33 @@
+# Contract: `remo remove`
+
+Deregister a manually-added SSH host. Local-only — never contacts or mutates the
+remote environment (FR-008, SC-004).
+
+## Synopsis
+
+```text
+remo remove NAME [--yes]
+```
+
+- `NAME` (arg, required): the added host to deregister.
+- `--yes`: bypass the confirmation prompt.
+
+## Behavior
+
+| # | Precondition | Action | Result | Exit |
+|---|--------------|--------|--------|------|
+| 1 | NAME is an existing **`ssh`** entry | confirm (unless `--yes`) → delete | `remove_known_host("ssh", NAME)`; entry gone from registry & picker; **no network call** (SC-004) | 0 |
+| 2 | NAME is a **provider-managed** entry (`incus`/`proxmox`/`aws`/`hetzner`) | — | refuse with a message distinguishing deregister from the provider's `destroy` (FR-009) | ≠0 |
+| 3 | NAME not found | — | clear "no such added host" message | ≠0 |
+| 4 | NAME already absent after a prior remove | — | idempotent no-op path (Constitution III) | per #3 |
+
+## Post-conditions
+
+- Case 1: the `ssh:NAME:…` line is gone; `remo shell NAME` now reports "no
+  environment named NAME"; the remote host is untouched (no SSH/API call occurred).
+- Cases 2–3: the registry is **unchanged**.
+
+## Guarantees
+
+- **Never** performs destroy/stop/mutation of the remote environment (contrast
+  with provider `destroy`). Removal is a registry delete only.

--- a/specs/014-register-ssh-host/data-model.md
+++ b/specs/014-register-ssh-host/data-model.md
@@ -1,0 +1,91 @@
+# Phase 1 Data Model: Register an SSH-Reachable Host (`remo add`)
+
+This feature introduces **no new persisted entity** — it adds a new `type` value
+(`ssh`) to the existing `KnownHost` registry model and two type-gated accessors.
+See [research.md](./research.md) D1–D2 for the rationale.
+
+## Entity: `KnownHost` (existing) — new `ssh` type
+
+`src/remo_cli/models/host.py`. Fields are unchanged; the `ssh` type reuses the
+provider-specific slots for SSH coordinates.
+
+| Field         | `ssh`-type meaning            | Notes |
+|---------------|-------------------------------|-------|
+| `type`        | `"ssh"`                       | New value. Distinguishes added hosts from providers. |
+| `name`        | user-facing name              | Globally unique (enforced at add time, D6). Validated by `validate_name`. |
+| `host`        | SSH host / address            | Hostname, IPv4, or `~/.ssh/config` alias. Un-bracketed IPv6 rejected (D4). |
+| `user`        | effective SSH user            | From `user@` in target, or `--user`, else `DEFAULT_ADDED_HOST_USER` (`remo`). |
+| `instance_id` | SSH **port** (string)         | e.g. `"22"`, `"2222"`. Numeric — no colon risk. |
+| `access_mode` | `"direct"`                    | Routes through the existing direct-SSH connection path. |
+| `region`      | **identity** path (optional)  | e.g. `"/home/dev/.ssh/box_ed25519"`. Colon rejected at add time (D5). |
+
+### Serialized form (colon-delimited registry line)
+
+No format change — the existing 4/6/7-field encoding covers every case:
+
+```text
+ssh:<name>:<host>:<user>[:<port>:direct[:<identity>]]
+```
+
+```text
+ssh:box:1.2.3.4:remo:22:direct                              # default port, no identity
+ssh:api:10.0.0.9:dev:2222:direct                            # custom port
+ssh:api:10.0.0.9:dev:2222:direct:/home/dev/.ssh/box_ed25519 # custom port + identity
+```
+
+`to_line()`/`from_line()` are **unmodified**: setting `instance_id` (port)
+triggers the 6-field form with `access_mode="direct"`; a non-empty `region`
+appends the 7th (identity) field; missing trailing fields default on read
+(SC-007 backward-compat).
+
+### New accessors (type-gated)
+
+```text
+KnownHost.ssh_port     -> int          # int(instance_id) for type=="ssh" else DEFAULT_SSH_PORT
+KnownHost.ssh_identity -> str | None   # region or None for type=="ssh" else None
+```
+
+Both return neutral values for non-`ssh` types, so no existing behavior changes.
+
+### Display
+
+`display_name` returns `name` unchanged for `ssh` (the `host/container` special
+case is `incus`/`proxmox`-only), so added hosts appear by their plain name in the
+picker (FR-006).
+
+## Validation rules (at `remo add` time)
+
+| Rule | Source | Enforcement |
+|------|--------|-------------|
+| Name matches registry name rules, ≤63 chars | FR-013 | `validate_name` (existing) |
+| Name not already used by a **provider** entry | FR-010/SC-005 | whole-registry scan (D6) → refuse |
+| Name already used by an existing **`ssh`** entry | FR-007/SC-003 | in-place update (confirm unless `--yes`) |
+| Port is an int in `1..65535` | FR-013 | `validate_port` (existing) |
+| Target is not an un-bracketed IPv6 literal | FR-013/Edge | colon-count parse (D4) → refuse |
+| Bracketed `[::1]:22` form | Out of scope | rejected with "use hostname/alias" (D4) |
+| Identity path contains no `:` | FR-013 | reject (D5); existence **not** required |
+
+## State & lifecycle
+
+An added host has **no remote/infrastructure lifecycle** owned by `remo`
+(spec Out of Scope). Registry-entry lifecycle only:
+
+```text
+(absent) --remo add--> registered --remo add (same name, new target)--> updated-in-place
+registered --remo remove--> (absent)          # local-only; no remote action (SC-004)
+registered --remo shell/cp--> connected       # direct-mode SSH; port+identity applied
+```
+
+`remo remove` on an absent entry is a no-op (`remove_known_host` already tolerates
+a missing entry) — idempotent (Constitution III).
+
+## Relationships
+
+- **Registry** (`core/known_hosts.py`): added hosts are ordinary lines; they
+  participate in `get_known_hosts()`, `resolve_remo_host_by_name()`, and the
+  picker exactly like provider entries. `save_known_host` dedupes `(type, name)`;
+  cross-type uniqueness is enforced by the add-time scan (D6), not the store.
+- **Connection** (`core/ssh.py`): `build_ssh_opts` reads `ssh_port`/`ssh_identity`
+  for `type=="ssh"` only (D3).
+- **Providers**: unrelated — provider groups filter by their own `type`; FR-012
+  guard ensures a mis-targeted provider op on an `ssh` host fails clearly (D9).

--- a/specs/014-register-ssh-host/plan.md
+++ b/specs/014-register-ssh-host/plan.md
@@ -1,0 +1,147 @@
+# Implementation Plan: Register an SSH-Reachable Host (`remo add`)
+
+**Branch**: `014-register-ssh-host` | **Date**: 2026-07-22 | **Spec**: [spec.md](./spec.md)
+
+**Input**: Feature specification from `/specs/014-register-ssh-host/spec.md`
+
+## Summary
+
+Add a provider-neutral `remo add <name> <target>` that registers a single
+SSH-reachable environment into the existing colon-delimited known-hosts registry,
+and a matching `remo remove <name>` that deregisters it (local-only, no remote
+action). Added hosts are stored as a **new registry `type` = `ssh`** with
+`access_mode = direct`, so they flow through the *existing* `direct`-mode SSH
+connection path (`remo shell`, `remo cp`) and the interactive picker with no
+special-casing by the user.
+
+Technical approach, grounded in the current code:
+
+- **Storage**: reuse the existing `KnownHost` positional serialization — no
+  format extension. For `type=ssh`, the otherwise-provider-specific slots carry
+  the SSH coordinates: `instance_id` = port, `access_mode` = `direct`,
+  `region` = identity path. This keeps the current 4/6/7-field forms intact and
+  backward-compatible (SC-007). Two type-gated helper properties (`ssh_port`,
+  `ssh_identity`) localize the field-overloading in the model.
+- **Connection**: extend `build_ssh_opts()` (the single shared SSH-argv builder
+  used by both CLI and web) to emit `-o Port=<port>` and fold in the stored
+  identity **only for `type=ssh`**, so existing incus/proxmox/aws/hetzner argv is
+  byte-identical. The `identity_file` param already exists there (web-adopt R6);
+  an explicit param still wins over the stored identity.
+- **Unmanaged degradation (FR-011)**: `remo shell` skips the pre-connect
+  `remo-host`/tools version check for `type=ssh` — a missing marker on an added
+  host is "unknown/unmanaged," not a prompt to run a nonexistent provider update.
+- **Safety**: `add` checks the *whole* registry for a name collision (the
+  registry dedupes only within `(type, name)`), refusing to shadow a
+  provider-managed entry (FR-010) and treating a same-named existing `ssh` entry
+  as an in-place update (FR-007). `remove` refuses non-`ssh` names (FR-009).
+  Target parsing rejects un-bracketed IPv6 literals and colon-bearing identity
+  paths before any write (FR-013), so a malformed target never corrupts the
+  colon-delimited registry.
+
+## Technical Context
+
+**Language/Version**: Python 3.11+ (`from __future__ import annotations`, type hints)
+
+**Primary Dependencies**: Click (CLI). No new runtime dependencies. SSH is the
+system `ssh` binary via `subprocess` (already the connection substrate).
+
+**Storage**: Existing flat-file registry `~/.config/remo/known_hosts`
+(colon-delimited `KnownHost` lines). No schema/format change — a new `type`
+value only.
+
+**Testing**: pytest (`uv run pytest`), `mocker.patch` of SSH/subprocess and
+registry helpers, Click `CliRunner` for the command layer. mypy + ruff.
+
+**Target Platform**: Developer workstation CLI (Linux/macOS).
+
+**Project Type**: Single-project Python CLI (three-layer: `cli/` → `providers/`
+→ `core/`).
+
+**Performance Goals**: N/A — one registry read/write per invocation; the only
+network round-trip is the *opt-in* `--verify` SSH check (FR-014).
+
+**Constraints**: Backward-compatible registry parsing (SC-007); no hypervisor/
+cloud access required (FR-001); `--verify` fail-closed and network-free when not
+requested (FR-014).
+
+**Scale/Scope**: Two new CLI commands (`add`, `remove`); one new provider module;
+small extensions to the model, the SSH builder, and the shell version-check gate.
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
+
+The constitution's principles I and the Ansible-Specific Standards target Ansible
+code; this feature adds **no Ansible** (pure Python CLI + registry), so those are
+N/A. The generally-applicable principles:
+
+- **II. Test All Conditional Paths** — PASS (planned). The feature is branch-heavy
+  (verify pass/fail; collision refuse vs in-place update; IPv6 reject; port
+  present/default; identity present/absent; added-host version-check skip;
+  remove refuses provider host). Tasks enumerate a test per branch, both truthy
+  and falsy, matching the 013 test approach.
+- **III. Idempotent by Default** — PASS. Re-running `add` with the same name
+  updates in place (no duplicate line, FR-007/SC-003); `remove` is a no-op when
+  the entry is already absent (`remove_known_host` already tolerates this).
+- **IV. Fail Fast with Clear Messages** — PASS. Name collisions, malformed/IPv6
+  targets, colon-bearing identities, `--verify` failures, and provider ops on an
+  added host all exit non-zero with an actionable message (FR-009/010/012/013/014).
+- **V. Documentation Reflects Reality** — PASS (planned). README gains an `add`/
+  `remove` section; the quickstart doubles as the tested validation guide.
+
+No violations → Complexity Tracking is empty.
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/014-register-ssh-host/
+├── plan.md              # This file
+├── research.md          # Phase 0 output — decisions & rationale
+├── data-model.md        # Phase 1 output — KnownHost `ssh` type & encoding
+├── quickstart.md        # Phase 1 output — tested validation scenarios
+├── contracts/           # Phase 1 output — CLI command contracts
+│   ├── add-command.md
+│   └── remove-command.md
+└── tasks.md             # Phase 2 output (/speckit-tasks — NOT created here)
+```
+
+### Source Code (repository root)
+
+```text
+src/remo_cli/
+├── cli/
+│   ├── main.py              # + register `add` and `remove` top-level commands
+│   └── added.py             # NEW — Click layer for `remo add` / `remo remove`
+├── providers/
+│   └── added.py             # NEW — add/remove/verify business logic + target parse
+│                            #        (no Click imports; three-layer compliant)
+├── core/
+│   ├── config.py            # + ADDED_HOST_TYPE="ssh", DEFAULT_ADDED_HOST_USER,
+│   │                        #   DEFAULT_SSH_PORT (fixed constants, single site)
+│   ├── ssh.py               # build_ssh_opts(): type-gated `-o Port=` + stored
+│   │                        #   identity; shell version-check gate lives in shell.py
+│   └── validation.py        # (reuse validate_name / validate_port; add target/
+│                            #   identity checks as needed)
+├── cli/
+│   └── shell.py             # skip pre-connect tools version check for type=ssh
+└── models/
+    └── host.py              # + ssh_port / ssh_identity type-gated properties
+
+tests/unit/
+├── providers/test_added.py          # NEW — target parsing, add/remove, verify, collisions
+├── cli/test_added_cmd.py            # NEW — CliRunner: add/remove flags, exit codes
+├── test_host_ssh_type.py            # NEW — serialization round-trip, ssh_port/ssh_identity
+└── core/test_ssh_added.py           # NEW — build_ssh_opts port/identity for ssh; others unchanged
+```
+
+**Structure Decision**: Single-project Python CLI, existing three-layer
+architecture (`cli/` parsing only → `providers/` business logic → `core/`
+provider-agnostic utilities). The added-host logic is a new `providers/added.py`
+(not a hypervisor/cloud provider, but occupies the same layer and pattern);
+`core/` changes are minimal, backward-compatible extensions to shared utilities.
+
+## Complexity Tracking
+
+No constitution violations — no entries.

--- a/specs/014-register-ssh-host/quickstart.md
+++ b/specs/014-register-ssh-host/quickstart.md
@@ -1,0 +1,121 @@
+# Quickstart & Validation: Register an SSH-Reachable Host (`remo add`)
+
+Runnable scenarios that prove the feature end-to-end. Maps to the spec's Success
+Criteria (SC-001..007) and the command contracts. Use an isolated registry so you
+never touch your real one:
+
+```bash
+export REMO_HOME="$(mktemp -d)/remo"      # scratch registry for this walkthrough
+uv sync                                    # dev install
+```
+
+Prerequisites: a box you can already `ssh` into (any VM/container/host). No
+hypervisor or cloud access required (FR-001).
+
+---
+
+## Scenario 1 — Add and connect (SC-001, US1)
+
+```bash
+uv run remo add mybox user@192.0.2.10
+# → success; reports effective user and "remo shell mybox"
+uv run remo shell mybox                    # lands in a shell on the box
+```
+
+**Expect**: one `ssh:mybox:…` line in `$REMO_HOME/known_hosts`; `remo shell`
+opens a direct SSH session. Two commands, no manual registry editing.
+
+## Scenario 2 — Custom port + identity (SC-002)
+
+```bash
+uv run remo add api dev@10.0.0.9:2222 --identity ~/.ssh/api_ed25519
+grep '^ssh:api:' "$REMO_HOME/known_hosts"
+# → ssh:api:10.0.0.9:dev:2222:direct:/home/you/.ssh/api_ed25519
+uv run remo shell api                      # connects on :2222 using -i the identity
+```
+
+**Expect**: connection succeeds with **no** hand-editing of the registry or
+`~/.ssh/config` after `add`.
+
+## Scenario 3 — Default user reported & overridable (US1.4, FR-003)
+
+```bash
+uv run remo add plainbox 192.0.2.20        # no user@ → defaults to 'remo', reported back
+uv run remo add plainbox 192.0.2.20 --user ubuntu   # override; in-place update
+```
+
+## Scenario 4 — In-place update, no duplicate (SC-003, US2)
+
+```bash
+uv run remo add api dev@10.0.0.9:2222
+uv run remo add api dev@10.0.0.99:2222 --yes        # changed IP
+grep -c '^ssh:api:' "$REMO_HOME/known_hosts"        # → 1 (updated, not duplicated)
+```
+
+## Scenario 5 — Remove is local-only (SC-004, US2)
+
+```bash
+uv run remo remove api --yes
+grep '^ssh:api:' "$REMO_HOME/known_hosts" || echo "gone"   # → gone
+uv run remo shell api                                       # → "no environment named 'api'"
+```
+
+**Expect**: entry deleted; **no** SSH/API call made to the remote host.
+
+## Scenario 6 — Name collision with a provider host is refused (SC-005, FR-010)
+
+```bash
+# Given some provider entry, e.g. an incus 'devbox' already registered:
+uv run remo add devbox user@192.0.2.30
+# → refused; message names the conflicting provider entry; exit ≠ 0; no write
+```
+
+## Scenario 7 — Plain login shell when remo-host is absent (SC-006, FR-011)
+
+```bash
+# 'mybox' has no remo-host / managed tooling installed:
+uv run remo shell mybox
+# → NO "has no version info / Update tools?" prompt; drops straight into a login shell
+```
+
+## Scenario 8 — IPv6 literal rejected, not persisted (FR-013, D4)
+
+```bash
+uv run remo add v6box '::1'                 # → rejected: use a hostname or ~/.ssh/config alias
+uv run remo add v6box 'user@[2001:db8::1]:22'   # → rejected (bracketed form out of scope)
+grep -c '^ssh:v6box:' "$REMO_HOME/known_hosts"  # → 0 (nothing written)
+```
+
+## Scenario 9 — `--verify` is fail-closed (FR-014, US3)
+
+```bash
+uv run remo add deadbox user@203.0.113.254 --verify   # unreachable
+echo "exit=$?"                                         # → non-zero
+grep -c '^ssh:deadbox:' "$REMO_HOME/known_hosts"       # → 0 (declined; no entry)
+
+uv run remo add mybox user@192.0.2.10 --verify         # reachable → registers after check
+```
+
+## Scenario 10 — Backward-compatible registry parsing (SC-007)
+
+```bash
+# Pre-existing provider lines (4/6/7-field) load unchanged alongside new ssh lines:
+uv run remo shell           # picker lists provider hosts AND added hosts together (FR-006)
+```
+
+---
+
+## Automated checks
+
+```bash
+uv run pytest tests/unit/providers/test_added.py \
+              tests/unit/cli/test_added_cmd.py \
+              tests/unit/test_host_ssh_type.py \
+              tests/unit/core/test_ssh_added.py
+uv run mypy src/remo_cli
+uv run ruff check src/remo_cli
+```
+
+See [contracts/add-command.md](./contracts/add-command.md) and
+[contracts/remove-command.md](./contracts/remove-command.md) for the full
+precondition/exit-code matrices these scenarios exercise.

--- a/specs/014-register-ssh-host/research.md
+++ b/specs/014-register-ssh-host/research.md
@@ -1,0 +1,192 @@
+# Phase 0 Research: Register an SSH-Reachable Host (`remo add`)
+
+All four spec ambiguities were resolved in `/speckit-clarify` (see spec
+`## Clarifications`, Session 2026-07-22). This document records the remaining
+technical decisions, each grounded in the current code.
+
+---
+
+## D1. Registry encoding for an added host
+
+**Decision**: Introduce a new registry `type = "ssh"` and reuse the existing
+`KnownHost` positional serialization with **no format change**:
+
+```text
+ssh:<name>:<host>:<user>[:<port>:direct[:<identity>]]
+```
+
+- `type`        = `"ssh"`
+- `name`        = user-facing name
+- `host`        = SSH host/address
+- `user`        = SSH user (effective, after default/override)
+- `instance_id` = SSH port (e.g. `22`, `2222`)
+- `access_mode` = `"direct"`  (drives the existing connection dispatch)
+- `region`      = identity path (optional; 7th field)
+
+Examples:
+```text
+ssh:box:1.2.3.4:remo:22:direct
+ssh:box:1.2.3.4:dev:2222:direct:/home/dev/.ssh/box_ed25519
+```
+
+**Rationale**:
+- `KnownHost.to_line()` already emits the 6-field form whenever `instance_id`
+  is set (appending `instance_id` + an effective access mode) and appends
+  `region` as the 7th field only when non-empty. Setting `access_mode="direct"`
+  makes it emit `direct` (not the `ssm` default), so port + identity round-trip
+  through the **unmodified** serializer. `from_line()` already parses 4/6/7
+  fields and ignores extras → **SC-007 backward-compat is free**.
+- Port is numeric → never introduces a stray colon. Identity is the only
+  colon-risk; guarded by validation (D5).
+- A brand-new `type` keeps provider command groups operating only on their own
+  inventory (`get_known_hosts(type_filter=...)`), so an added host is visibly
+  *not* a provider instance (spec Assumptions, FR-012).
+
+**Alternatives considered**:
+- *New trailing 8th/9th fields for port/identity*: clearer field semantics but
+  extends the serialized format for **all** types and touches `to_line` globally
+  (AWS already uses all 7 fields). Higher blast radius for zero functional gain;
+  rejected. The spec explicitly blesses "fit the existing serialization."
+- *Bracketed IPv6 storage / URL-style target*: deferred — see D4.
+
+## D2. Type-gated model helpers (`ssh_port`, `ssh_identity`)
+
+**Decision**: Add two read-only properties to `KnownHost`, meaningful only for
+`type=="ssh"`:
+- `ssh_port -> int` → `int(instance_id)` when set & type is `ssh`, else
+  `DEFAULT_SSH_PORT` (22).
+- `ssh_identity -> str | None` → `region or None` when type is `ssh`, else
+  `None`.
+
+**Rationale**: Localizes the D1 field-overloading to one place instead of
+scattering `instance_id`/`region` reinterpretation across the connection layer.
+Non-`ssh` types return the neutral defaults, so nothing else changes.
+
+**Alternatives**: raw `instance_id`/`region` access at every call site (leaky,
+error-prone); real new dataclass fields (see D1 rejection).
+
+## D3. Wiring port + identity into the connection path
+
+**Decision**: Extend `core/ssh.py::build_ssh_opts()` — the single shared
+SSH-argv builder used by both `shell_connect` (CLI) and the web terminal
+service — to, **only when `host.type == "ssh"`**:
+- append `-o Port=<host.ssh_port>` when the port differs from 22, and
+- use `host.ssh_identity` as the identity when the caller passed no explicit
+  `identity_file` (explicit param keeps precedence — web-adopt R6).
+
+**Rationale**:
+- `build_ssh_opts` is already the one place that turns a `KnownHost` into SSH
+  argv (SSM ProxyCommand, direct target, timezone, ControlMaster, and the
+  existing `identity_file`/`known_hosts_file` params). Adding port/identity here
+  means `remo shell`, `remo cp`, **and** the `--verify` check (which also builds
+  via `build_ssh_opts`) all honor them with no per-call-site duplication.
+- The `type=="ssh"` gate is essential: proxmox stores a **numeric vmid** in
+  `instance_id` and incus stores the host user there — reading `instance_id` as a
+  port unconditionally would corrupt their argv. Gating on the new type keeps
+  every existing provider's argv byte-identical (verified against `build_ssh_opts`
+  branches).
+- `-o Port=` (not `-p`) matches the file's `-o`-style option convention and
+  composes cleanly with the existing option list.
+
+**Alternatives**: a separate ssh-only builder (duplicates SSM/timezone/control
+logic); passing port/identity as `shell_connect` kwargs threaded from the CLI
+(misses `remo cp` and `--verify`, and re-duplicates the read).
+
+## D4. IPv6 literal handling (fail-closed parse)
+
+**Decision**: Reject un-bracketed IPv6 literals at parse time with guidance to
+use a hostname or an `~/.ssh/config` alias; the bracketed `[::1]:22` form is
+**out of scope** for this feature (documented as a possible future enhancement).
+
+Parsing `[user@]host[:port]`:
+1. Split one optional leading `user@` (first `@`).
+2. On the remainder: a leading `[` (bracketed) → reject (unsupported this
+   release); `>1` colon → IPv6 literal → reject with guidance; exactly `1`
+   colon → `host:port` (port must be a valid int, FR-013/`validate_port`);
+   `0` colons → host only, default port.
+3. `--user`/`--port` options override the parsed values (FR-002).
+
+**Rationale**: Matches the clarified decision and FR-013's "reject rather than
+persist a broken line." Detecting IPv6 by colon-count on the post-`user@`
+remainder is unambiguous because a legal `host:port` has exactly one colon.
+
+**Alternatives**: full bracketed-IPv6 support (more parser + encoding surface
+now; deferred by clarification).
+
+## D5. Identity path validation
+
+**Decision**: Reject an `--identity` value containing a colon (it would corrupt
+the colon-delimited `region` slot) with a clear message. Do **not** require the
+key file to exist at add time (the path may be valid only at connect time / on
+another machine profile); existence is SSH's concern at connect.
+
+**Rationale**: Upholds FR-013 (no broken registry line) with the minimum
+constraint. Tilde/relative paths pass through unchanged and are expanded by SSH.
+
+## D6. Name-collision policy (FR-007 / FR-010)
+
+**Decision**: In `providers/added.add()`, scan the **entire** registry
+(`get_known_hosts()`, no type filter) for an entry whose `name` equals the
+requested name:
+- match is a **provider-managed** type (`incus`/`proxmox`/`aws`/`hetzner`) →
+  **refuse**, message naming the conflicting entry (FR-010/SC-005).
+- match is an existing **`ssh`** entry → **in-place update** path (FR-007): prompt
+  to confirm the change unless `--yes`, then `save_known_host` (which replaces the
+  `(ssh, name)` line — no duplicate, SC-003).
+- no match → create.
+
+**Rationale**: `save_known_host` only dedupes within `(type, name)`, so an
+`ssh` add with a name already held by a *different* type would silently create a
+second line that `resolve_remo_host_by_name` could then shadow. The explicit
+whole-registry pre-check is required for FR-010 and keeps names globally unique.
+
+## D7. Unmanaged shell degradation (FR-011)
+
+**Decision**: In `cli/shell.py`, gate the pre-connect tools/version check with
+`host.type != "ssh"` (i.e., skip it for added hosts). The connection itself is
+unchanged.
+
+**Rationale**: For an added host, `check_remote_version` returning "no marker"
+currently triggers a `confirm("...has no version info. Update tools?")` whose
+"yes" calls `_run_provider_update`, which is a no-op for an unknown type — a
+confusing prompt offering an action that does nothing. Treating `ssh` as
+"unknown/unmanaged" and skipping the check lands the user straight in a plain
+login shell (FR-011/SC-006). `remo-host`-dependent server-side features simply
+aren't invoked by a plain `remo shell` (no `-p`), so a plain login shell is the
+natural result.
+
+## D8. `remo remove` semantics (FR-008 / FR-009)
+
+**Decision**: New top-level `remo remove <name>` → resolve the entry by name;
+if its type is not `ssh`, **refuse** with a message pointing at the provider's
+`destroy` (FR-009); otherwise confirm (unless `--yes`) and call
+`remove_known_host("ssh", name)`. **No** network/SSH call is made (SC-004).
+
+**Rationale**: Deregistration is local-only by definition (`remo` owns no
+infrastructure for an added host). Refusing non-`ssh` names prevents mistaking
+"deregister" for "destroy my provider instance."
+
+## D9. Provider lifecycle ops against an added host (FR-012)
+
+**Decision**: Provider command groups already resolve within their own type
+(`remo incus …` operates on incus inventory), so an added host is not in scope
+for them. Where a provider path resolves purely by name, add a guard that the
+resolved `host.type` matches the provider and otherwise emits the FR-012 message
+("manually-registered SSH host with no managed infrastructure"). Audited and
+covered as a dedicated task rather than a broad refactor.
+
+**Rationale**: Keeps the fix at the right altitude — a targeted, clear-message
+guard, not special-casing sprinkled through every provider.
+
+## D10. Default SSH user
+
+**Decision**: Default the SSH user to `remo` (via a new
+`DEFAULT_ADDED_HOST_USER` constant in `core/config.py`) when neither the target's
+`user@` nor `--user` supplies one; report the effective user back at add time so
+the user can re-add with an override (FR-003).
+
+**Rationale**: `remo` is the user convention across managed providers
+(incus/proxmox/aws/hetzner all register `user="remo"`); matching it keeps the
+mental model consistent, and the spec's Assumptions already name `remo` as the
+natural candidate. Centralizing it as a constant (like the 013 markers) keeps a
+single definition site.

--- a/specs/014-register-ssh-host/spec.md
+++ b/specs/014-register-ssh-host/spec.md
@@ -37,6 +37,15 @@ reachability. It establishes a clean division of the mental model:
 (The error message in `resolve_remo_host_by_name` already tells users to
 "Use 'remo add' to register an environment" — this feature makes that real.)
 
+## Clarifications
+
+### Session 2026-07-22
+
+- Q: On `remo add --verify`, when the SSH reachability check fails, decline or register-with-warning? → A: Decline (fail-closed) — surface the SSH error, write no registry entry, exit non-zero.
+- Q: How is a custom SSH private key for an added host supported? → A: A persisted `--identity <path>` registry field, passed to `ssh -i` on connect (no `~/.ssh/config` editing required).
+- Q: How are raw IPv6 literal targets handled? → A: Reject un-bracketed IPv6 literals with guidance to use a hostname or `~/.ssh/config` alias; never store a malformed line.
+- Q: What command deregisters an added host? → A: A new top-level, provider-neutral `remo remove <name>` command (mirrors `remo add`).
+
 ## User Scenarios & Testing *(mandatory)*
 
 ### User Story 1 - Register a host I can already SSH to (Priority: P1)
@@ -89,8 +98,8 @@ rots. Necessary for the feature to be usable over time, but secondary to being
 able to add at all.
 
 **Independent Test**: Add a host, re-run `add` with a changed target, confirm
-the entry reflects the new target; then remove it and confirm it is gone from
-the registry and the picker.
+the entry reflects the new target; then run `remo remove <name>` and confirm it
+is gone from the registry and the picker.
 
 **Acceptance Scenarios**:
 
@@ -98,11 +107,11 @@ the registry and the picker.
    the same name and a different target, **Then** the entry is updated in place
    (after confirming, unless a bypass flag is given), and no duplicate is
    created.
-2. **Given** an existing added host, **When** the user runs the remove command
+2. **Given** an existing added host, **When** the user runs `remo remove <name>`
    for it, **Then** the registry entry is deleted and the host no longer appears
    in `remo shell` or the picker. No connection to the remote environment is
    made and nothing on the remote side is changed.
-3. **Given** the remove command targets an added host, **When** it runs, **Then**
+3. **Given** `remo remove` targets an added host, **When** it runs, **Then**
    it only deregisters; it never attempts to destroy, stop, or otherwise mutate
    the remote environment (unlike provider `destroy`).
 
@@ -119,8 +128,8 @@ fully usable without it (the first `remo shell` would reveal a bad target), so
 it is lowest priority.
 
 **Independent Test**: Run `remo add` against an unreachable target with the
-verify option and confirm the command reports the failure clearly and does not
-silently register a broken entry (or registers it with a visible warning).
+verify option and confirm the command reports the failure clearly, writes no
+registry entry, and exits non-zero.
 
 **Acceptance Scenarios**:
 
@@ -129,8 +138,8 @@ silently register a broken entry (or registers it with a visible warning).
    and reports success before registering.
 2. **Given** an unreachable or auth-failing target, **When** the user runs
    `remo add` with the verify option, **Then** the command surfaces the SSH
-   error and either declines to register or registers with an explicit warning
-   (behavior chosen consistently and documented), exiting non-zero on failure.
+   error, declines to register (no registry entry is written), and exits
+   non-zero (fail-closed).
 3. **Given** the verify option is not used, **When** the user runs `remo add`,
    **Then** no connectivity check is performed and the entry is registered
    immediately (today's low-friction default for other registry writes).
@@ -152,13 +161,15 @@ silently register a broken entry (or registers it with a visible warning).
   round-trips correctly through save → load → connect).
 - **IPv6 literal targets**: A raw IPv6 address contains colons and collides with
   both the `host:port` syntax and the colon-delimited registry format. The
-  command MUST either support a documented bracketed form (`[::1]:22`) or clearly
-  reject IPv6 literals with guidance to use a hostname/alias — it MUST NOT store
-  a malformed entry that breaks registry parsing.
+  command MUST reject un-bracketed IPv6 literals with a clear message directing
+  the user to a hostname or an `~/.ssh/config` alias. It MUST NOT store a
+  malformed entry that breaks registry parsing. (A bracketed `[::1]:22` form is
+  out of scope for this feature and may be a future enhancement.)
 - **Custom identity file / SSH key**: Users whose target needs a specific private
-  key MUST have a way to record that (an identity option), or a documented
-  reliance on their `~/.ssh/config`. A target that only works with a non-default
-  key MUST be connectable after `add` without hand-editing.
+  key record it with an explicit `--identity <path>` option, which is persisted
+  and passed to `ssh -i` on connect. A target that only works with a non-default
+  key MUST be connectable after `add` without hand-editing the registry or
+  `~/.ssh/config`.
 - **Host key trust on first connect**: `remo add` does not pre-seed the local
   SSH `known_hosts`. The first `remo shell` to an added host follows normal SSH
   host-key behavior (prompt/accept), consistent with existing `direct`-mode
@@ -191,10 +202,11 @@ silently register a broken entry (or registers it with a visible warning).
 - **FR-003**: When no user is given, the command MUST apply a documented default
   SSH user and report the effective user back to the caller. When no port is
   given, the standard SSH port MUST be used.
-- **FR-004**: The command MUST allow the user to record an explicit SSH identity
-  (private key) for the host, or MUST document that connection relies on the
-  user's `~/.ssh/config`, such that an added host requiring a non-default key is
-  connectable without manual registry or config edits after `add`.
+- **FR-004**: The command MUST provide an explicit `--identity <path>` option that
+  records the SSH private key for the host; the identity MUST be persisted in the
+  registry and supplied to SSH (`ssh -i`) on connect, so that an added host
+  requiring a non-default key is connectable after `add` without manual edits to
+  the registry or `~/.ssh/config`.
 - **FR-005**: A registered added host MUST be connectable via `remo shell` and
   usable with `remo cp` through the existing `direct`-mode SSH connection path,
   with no special-casing required from the user.
@@ -206,10 +218,11 @@ silently register a broken entry (or registers it with a visible warning).
 - **FR-007**: Re-running the add command with an existing added host's name and a
   changed target MUST update that entry in place (guarded by a confirmation
   prompt unless a bypass flag is supplied) rather than creating a duplicate.
-- **FR-008**: `remo` MUST provide a way to remove/deregister an added host that
-  deletes only the local registry entry and performs no action against the
+- **FR-008**: `remo` MUST provide a top-level, provider-neutral `remo remove
+  <name>` command (mirroring `remo add`) that deregisters an added host by
+  deleting only the local registry entry and performing no action against the
   remote environment (no destroy, stop, or mutation).
-- **FR-009**: The remove path MUST refuse (or clearly distinguish itself) when
+- **FR-009**: `remo remove` MUST refuse (or clearly distinguish itself) when
   asked to act on a provider-managed host, so that a user cannot mistake
   "deregister my manually-added SSH host" for "destroy my provider instance."
 
@@ -228,16 +241,17 @@ silently register a broken entry (or registers it with a visible warning).
   infrastructure.
 - **FR-013**: The command MUST validate the supplied name against the same rules
   used for other registry names, and MUST validate/parse the target so that a
-  malformed target (including an un-bracketed IPv6 literal, per Edge Cases) is
-  rejected with a clear message rather than persisted as a broken registry line.
+  malformed target is rejected with a clear message rather than persisted as a
+  broken registry line. Un-bracketed IPv6 literals MUST be rejected with guidance
+  to use a hostname or `~/.ssh/config` alias (per Edge Cases).
 
 **Optional verification**
 
-- **FR-014**: The command SHOULD offer an opt-in reachability check that performs
-  a lightweight SSH connection test at add time; on failure it MUST surface the
-  SSH error and exit non-zero (declining to register, or registering only with an
-  explicit warning — chosen consistently and documented). When the check is not
-  requested, registration MUST proceed without any network round-trip.
+- **FR-014**: The command MUST offer an opt-in `--verify` reachability check that
+  performs a lightweight SSH connection test at add time; on failure it MUST
+  surface the SSH error, decline to register (write no registry entry), and exit
+  non-zero (fail-closed). When the check is not requested, registration MUST
+  proceed without any network round-trip.
 
 ### Out of Scope
 

--- a/specs/014-register-ssh-host/tasks.md
+++ b/specs/014-register-ssh-host/tasks.md
@@ -24,7 +24,7 @@ each user story owns its own test file(s) so stories stay independently testable
 
 **Purpose**: Fixed constants used across every layer.
 
-- [ ] T001 [P] Add `ADDED_HOST_TYPE = "ssh"`, `DEFAULT_ADDED_HOST_USER = "remo"`, and `DEFAULT_SSH_PORT = 22` as fixed module constants in `src/remo_cli/core/config.py` (single definition site, alongside the 013 marker constants)
+- [X] T001 [P] Add `ADDED_HOST_TYPE = "ssh"`, `DEFAULT_ADDED_HOST_USER = "remo"`, and `DEFAULT_SSH_PORT = 22` as fixed module constants in `src/remo_cli/core/config.py` (single definition site, alongside the 013 marker constants)
 
 ---
 
@@ -35,10 +35,10 @@ each user story owns its own test file(s) so stories stay independently testable
 
 **⚠️ CRITICAL**: No user story work can begin until this phase is complete.
 
-- [ ] T002 [P] Write serialization/property tests in `tests/unit/test_host_ssh_type.py`: `ssh`-type 4/6/7-field `to_line`/`from_line` round-trip; `ssh_port` returns 22 by default and the parsed port when set; `ssh_identity` returns the identity or `None`; non-`ssh` types return neutral values (22 / `None`); pre-existing provider lines still parse (SC-007)
-- [ ] T003 Add type-gated `ssh_port -> int` and `ssh_identity -> str | None` properties to `src/remo_cli/models/host.py` (per data-model.md; makes T002 pass — no change to `to_line`/`from_line`)
-- [ ] T004 [P] Write SSH-builder tests in `tests/unit/core/test_ssh_added.py`: for `type=="ssh"`, `build_ssh_opts` emits `-o Port=<n>` only when port ≠ 22, uses the stored identity, and an explicit `identity_file=` argument still wins; assert incus/proxmox/aws/hetzner argv is byte-identical to before (proxmox numeric vmid in `instance_id` must NOT become a port). NOTE: `build_ssh_opts` is the exact builder `remo cp` uses (`cli/cp.py`), so these opts also cover file transfer to an added host (FR-005) — no separate cp builder exists.
-- [ ] T005 Wire type-gated `-o Port=` + stored-identity handling into `build_ssh_opts` in `src/remo_cli/core/ssh.py` (gated on `host.type == "ssh"`, using `ssh_port`/`ssh_identity`; explicit `identity_file` param retains precedence — research D3; makes T004 pass)
+- [X] T002 [P] Write serialization/property tests in `tests/unit/test_host_ssh_type.py`: `ssh`-type 4/6/7-field `to_line`/`from_line` round-trip; `ssh_port` returns 22 by default and the parsed port when set; `ssh_identity` returns the identity or `None`; non-`ssh` types return neutral values (22 / `None`); pre-existing provider lines still parse (SC-007)
+- [X] T003 Add type-gated `ssh_port -> int` and `ssh_identity -> str | None` properties to `src/remo_cli/models/host.py` (per data-model.md; makes T002 pass — no change to `to_line`/`from_line`)
+- [X] T004 [P] Write SSH-builder tests in `tests/unit/core/test_ssh_added.py`: for `type=="ssh"`, `build_ssh_opts` emits `-o Port=<n>` only when port ≠ 22, uses the stored identity, and an explicit `identity_file=` argument still wins; assert incus/proxmox/aws/hetzner argv is byte-identical to before (proxmox numeric vmid in `instance_id` must NOT become a port). NOTE: `build_ssh_opts` is the exact builder `remo cp` uses (`cli/cp.py`), so these opts also cover file transfer to an added host (FR-005) — no separate cp builder exists.
+- [X] T005 Wire type-gated `-o Port=` + stored-identity handling into `build_ssh_opts` in `src/remo_cli/core/ssh.py` (gated on `host.type == "ssh"`, using `ssh_port`/`ssh_identity`; explicit `identity_file` param retains precedence — research D3; makes T004 pass)
 
 **Checkpoint**: Registry model and connection substrate ready.
 
@@ -52,16 +52,16 @@ each user story owns its own test file(s) so stories stay independently testable
 
 ### Tests for User Story 1
 
-- [ ] T006 [P] [US1] Target-parse + add provider tests in `tests/unit/providers/test_added_add.py`: parse `[user@]host[:port]`; default user applied & reported; `--user`/`--port` override; un-bracketed IPv6 and bracketed `[::1]:22` rejected with no write (D4); identity path containing `:` rejected (D5); create writes a single `ssh:` entry; a name already held by a provider entry is refused with no write (FR-010/SC-005); and, after add, assert the host resolves via `resolve_remo_host_by_name(name)` and is included in `get_known_hosts()` (the picker source) so it is selectable alongside provider hosts (FR-006/US1 scenario 5)
-- [ ] T007 [P] [US1] CLI add tests in `tests/unit/cli/test_add_cmd.py` (Click `CliRunner`): argument/flag wiring, success message names `remo shell <name>` + effective user, non-zero exit on collision and on malformed target
-- [ ] T008 [P] [US1] Shell-degradation test in `tests/unit/cli/test_shell_added.py`: a `type="ssh"` host skips the pre-connect tools/version check (no "has no version info / Update tools?" prompt) and proceeds to `shell_connect` (FR-011/SC-006)
+- [X] T006 [P] [US1] Target-parse + add provider tests in `tests/unit/providers/test_added_add.py`: parse `[user@]host[:port]`; default user applied & reported; `--user`/`--port` override; un-bracketed IPv6 and bracketed `[::1]:22` rejected with no write (D4); identity path containing `:` rejected (D5); create writes a single `ssh:` entry; a name already held by a provider entry is refused with no write (FR-010/SC-005); and, after add, assert the host resolves via `resolve_remo_host_by_name(name)` and is included in `get_known_hosts()` (the picker source) so it is selectable alongside provider hosts (FR-006/US1 scenario 5)
+- [X] T007 [P] [US1] CLI add tests in `tests/unit/cli/test_add_cmd.py` (Click `CliRunner`): argument/flag wiring, success message names `remo shell <name>` + effective user, non-zero exit on collision and on malformed target
+- [X] T008 [P] [US1] Shell-degradation test in `tests/unit/cli/test_shell_added.py`: a `type="ssh"` host skips the pre-connect tools/version check (no "has no version info / Update tools?" prompt) and proceeds to `shell_connect` (FR-011/SC-006)
 
 ### Implementation for User Story 1
 
-- [ ] T009 [US1] Create `src/remo_cli/providers/added.py` (no Click imports): `parse_ssh_target(target, user_override, port_override)` (D4 colon-count IPv6 rejection), and `add(...)` performing name validation (`validate_name`), port validation (`validate_port`), identity `:` rejection (D5), whole-registry collision scan refusing provider-managed names (FR-010, D6), effective-user resolution/report (FR-003), and `save_known_host(KnownHost(type="ssh", access_mode="direct", instance_id=port, region=identity))`
-- [ ] T010 [US1] Create `src/remo_cli/cli/added.py`: `add` Click command with `NAME` + `TARGET` args and `--user/--port/--identity/--yes` options, delegating to `providers.added.add` (the `--verify` option is added in US3/T020 so the US1 increment never ships a non-functional flag — F1)
-- [ ] T011 [US1] Register the `add` command in `_register_commands()` in `src/remo_cli/cli/main.py`
-- [ ] T012 [US1] Gate the pre-connect tools/version check on `host.type != "ssh"` in `src/remo_cli/cli/shell.py` so added hosts skip it and drop into a plain login shell (FR-011)
+- [X] T009 [US1] Create `src/remo_cli/providers/added.py` (no Click imports): `parse_ssh_target(target, user_override, port_override)` (D4 colon-count IPv6 rejection), and `add(...)` performing name validation (`validate_name`), port validation (`validate_port`), identity `:` rejection (D5), whole-registry collision scan refusing provider-managed names (FR-010, D6), effective-user resolution/report (FR-003), and `save_known_host(KnownHost(type="ssh", access_mode="direct", instance_id=port, region=identity))`
+- [X] T010 [US1] Create `src/remo_cli/cli/added.py`: `add` Click command with `NAME` + `TARGET` args and `--user/--port/--identity/--yes` options, delegating to `providers.added.add` (the `--verify` option is added in US3/T020 so the US1 increment never ships a non-functional flag — F1)
+- [X] T011 [US1] Register the `add` command in `_register_commands()` in `src/remo_cli/cli/main.py`
+- [X] T012 [US1] Gate the pre-connect tools/version check on `host.type != "ssh"` in `src/remo_cli/cli/shell.py` so added hosts skip it and drop into a plain login shell (FR-011)
 
 **Checkpoint**: MVP — add a host and `remo shell`/`remo cp` into it; unmanaged hosts land in a plain shell.
 
@@ -75,15 +75,15 @@ each user story owns its own test file(s) so stories stay independently testable
 
 ### Tests for User Story 2
 
-- [ ] T013 [P] [US2] Update/remove provider tests in `tests/unit/providers/test_added_update_remove.py`: re-adding an existing `ssh` name with a changed target updates in place with exactly one line (FR-007/SC-003, `--yes` bypasses confirm); `remove()` deletes an `ssh` entry making **no** network call (SC-004); `remove()` refuses a provider-managed name (FR-009); removing an absent name is a clear no-op/not-found
-- [ ] T014 [P] [US2] CLI remove tests in `tests/unit/cli/test_remove_cmd.py` (`CliRunner`): remove success with confirmation and with `--yes`; refusal (non-zero) on a provider host; not-found (non-zero)
+- [X] T013 [P] [US2] Update/remove provider tests in `tests/unit/providers/test_added_update_remove.py`: re-adding an existing `ssh` name with a changed target updates in place with exactly one line (FR-007/SC-003, `--yes` bypasses confirm); `remove()` deletes an `ssh` entry making **no** network call (SC-004); `remove()` refuses a provider-managed name (FR-009); removing an absent name is a clear no-op/not-found
+- [X] T014 [P] [US2] CLI remove tests in `tests/unit/cli/test_remove_cmd.py` (`CliRunner`): remove success with confirmation and with `--yes`; refusal (non-zero) on a provider host; not-found (non-zero)
 
 ### Implementation for User Story 2
 
-- [ ] T015 [US2] Extend `add()` in `src/remo_cli/providers/added.py` with the same-name `ssh` in-place-update branch (confirm via `core.output.confirm` unless `--yes`; relies on `save_known_host` `(type,name)` replacement — FR-007/D6)
-- [ ] T016 [US2] Add `remove(name, assume_yes)` to `src/remo_cli/providers/added.py`: resolve by name; refuse when the resolved `type != "ssh"` with a message distinguishing deregister from provider `destroy` (FR-009/D8); otherwise confirm (unless `--yes`) and `remove_known_host("ssh", name)` — no SSH/network call
-- [ ] T017 [US2] Add the `remove` Click command (`NAME` arg, `--yes`) to `src/remo_cli/cli/added.py`, delegating to `providers.added.remove`
-- [ ] T018 [US2] Register the `remove` command in `_register_commands()` in `src/remo_cli/cli/main.py`
+- [X] T015 [US2] Extend `add()` in `src/remo_cli/providers/added.py` with the same-name `ssh` in-place-update branch (confirm via `core.output.confirm` unless `--yes`; relies on `save_known_host` `(type,name)` replacement — FR-007/D6)
+- [X] T016 [US2] Add `remove(name, assume_yes)` to `src/remo_cli/providers/added.py`: resolve by name; refuse when the resolved `type != "ssh"` with a message distinguishing deregister from provider `destroy` (FR-009/D8); otherwise confirm (unless `--yes`) and `remove_known_host("ssh", name)` — no SSH/network call
+- [X] T017 [US2] Add the `remove` Click command (`NAME` arg, `--yes`) to `src/remo_cli/cli/added.py`, delegating to `providers.added.remove`
+- [X] T018 [US2] Register the `remove` command in `_register_commands()` in `src/remo_cli/cli/main.py`
 
 **Checkpoint**: Update-in-place and deregister both work; US1 still passes.
 
@@ -97,11 +97,11 @@ each user story owns its own test file(s) so stories stay independently testable
 
 ### Tests for User Story 3
 
-- [ ] T019 [P] [US3] Verify tests in `tests/unit/providers/test_added_verify.py` (SSH subprocess mocked): reachable target → registers after a successful probe; unreachable/auth-fail → SSH error surfaced, **no** registry write, non-zero exit (FR-014/US3.2, fail-closed); `--verify` absent → zero network round-trips (FR-014/US3.3)
+- [X] T019 [P] [US3] Verify tests in `tests/unit/providers/test_added_verify.py` (SSH subprocess mocked): reachable target → registers after a successful probe; unreachable/auth-fail → SSH error surfaced, **no** registry write, non-zero exit (FR-014/US3.2, fail-closed); `--verify` absent → zero network round-trips (FR-014/US3.3)
 
 ### Implementation for User Story 3
 
-- [ ] T020 [US3] Add the `--verify` option to the `add` command in `src/remo_cli/cli/added.py`, and add `verify_reachable(host)` to `src/remo_cli/providers/added.py` — a lightweight `ssh -o BatchMode=yes -o ConnectTimeout=… true`-style probe built through `build_ssh_opts` (so port/identity apply) — wiring `--verify` into `add()` to run it BEFORE `save_known_host`, declining to register (no write) and returning non-zero on failure
+- [X] T020 [US3] Add the `--verify` option to the `add` command in `src/remo_cli/cli/added.py`, and add `verify_reachable(host)` to `src/remo_cli/providers/added.py` — a lightweight `ssh -o BatchMode=yes -o ConnectTimeout=… true`-style probe built through `build_ssh_opts` (so port/identity apply) — wiring `--verify` into `add()` to run it BEFORE `save_known_host`, declining to register (no write) and returning non-zero on failure
 
 **Checkpoint**: All three stories independently functional.
 
@@ -109,10 +109,10 @@ each user story owns its own test file(s) so stories stay independently testable
 
 ## Phase 6: Polish & Cross-Cutting Concerns
 
-- [ ] T021 [P] FR-012 guard: audit provider `destroy`/`snapshot`/resize resolution paths in `src/remo_cli/providers/*.py`; where a host is resolved by name, ensure a `type="ssh"` host yields a clear "manually-registered SSH host with no managed infrastructure" error rather than an opaque failure, with a regression test in `tests/unit/providers/test_added_provider_guard.py`
-- [ ] T022 [P] Update `README.md` with a `remo add` / `remo remove` section: target syntax `[user@]host[:port]`, `--user/--port/--identity/--verify/--yes`, IPv6 guidance, and the local-only nature of `remove` (Constitution V)
-- [ ] T023 [P] Run `uv run mypy src/remo_cli` and `uv run ruff check src/remo_cli`; resolve findings in the new/changed files
-- [ ] T024 Run the quickstart validation (`uv run pytest` on the new suites + a spot-check of the `remo add`/`shell`/`remove` flow against a real reachable box, **including a `remo cp` upload and download** to an added host with a non-default port/identity to confirm FR-005/C2) per `quickstart.md`
+- [X] T021 [P] FR-012 guard: audit provider `destroy`/`snapshot`/resize resolution paths in `src/remo_cli/providers/*.py`; where a host is resolved by name, ensure a `type="ssh"` host yields a clear "manually-registered SSH host with no managed infrastructure" error rather than an opaque failure, with a regression test in `tests/unit/providers/test_added_provider_guard.py`
+- [X] T022 [P] Update `README.md` with a `remo add` / `remo remove` section: target syntax `[user@]host[:port]`, `--user/--port/--identity/--verify/--yes`, IPv6 guidance, and the local-only nature of `remove` (Constitution V)
+- [X] T023 [P] Run `uv run mypy src/remo_cli` and `uv run ruff check src/remo_cli`; resolve findings in the new/changed files
+- [X] T024 Run the quickstart validation (`uv run pytest` on the new suites + a spot-check of the `remo add`/`shell`/`remove` flow against a real reachable box, **including a `remo cp` upload and download** to an added host with a non-default port/identity to confirm FR-005/C2) per `quickstart.md`
 
 ---
 

--- a/specs/014-register-ssh-host/tasks.md
+++ b/specs/014-register-ssh-host/tasks.md
@@ -1,0 +1,184 @@
+---
+description: "Task list for feature 014-register-ssh-host"
+---
+
+# Tasks: Register an SSH-Reachable Host (`remo add`)
+
+**Input**: Design documents from `/specs/014-register-ssh-host/`
+
+**Prerequisites**: plan.md, spec.md, research.md, data-model.md, contracts/
+
+**Tests**: INCLUDED. The feature is branch-heavy and Constitution Principle II
+(Test All Conditional Paths) applies; each conditional branch gets a test, and
+each user story owns its own test file(s) so stories stay independently testable.
+
+## Format: `[ID] [P?] [Story] Description`
+
+- **[P]**: Can run in parallel (different files, no dependencies)
+- **[Story]**: US1 / US2 / US3 (Setup, Foundational, Polish carry no story label)
+- Paths are repo-relative; single-project layout per plan.md.
+
+---
+
+## Phase 1: Setup (Shared Infrastructure)
+
+**Purpose**: Fixed constants used across every layer.
+
+- [ ] T001 [P] Add `ADDED_HOST_TYPE = "ssh"`, `DEFAULT_ADDED_HOST_USER = "remo"`, and `DEFAULT_SSH_PORT = 22` as fixed module constants in `src/remo_cli/core/config.py` (single definition site, alongside the 013 marker constants)
+
+---
+
+## Phase 2: Foundational (Blocking Prerequisites)
+
+**Purpose**: The registry model + SSH-argv substrate that both the connect path
+(US1) and the verify path (US3) depend on.
+
+**⚠️ CRITICAL**: No user story work can begin until this phase is complete.
+
+- [ ] T002 [P] Write serialization/property tests in `tests/unit/test_host_ssh_type.py`: `ssh`-type 4/6/7-field `to_line`/`from_line` round-trip; `ssh_port` returns 22 by default and the parsed port when set; `ssh_identity` returns the identity or `None`; non-`ssh` types return neutral values (22 / `None`); pre-existing provider lines still parse (SC-007)
+- [ ] T003 Add type-gated `ssh_port -> int` and `ssh_identity -> str | None` properties to `src/remo_cli/models/host.py` (per data-model.md; makes T002 pass — no change to `to_line`/`from_line`)
+- [ ] T004 [P] Write SSH-builder tests in `tests/unit/core/test_ssh_added.py`: for `type=="ssh"`, `build_ssh_opts` emits `-o Port=<n>` only when port ≠ 22, uses the stored identity, and an explicit `identity_file=` argument still wins; assert incus/proxmox/aws/hetzner argv is byte-identical to before (proxmox numeric vmid in `instance_id` must NOT become a port). NOTE: `build_ssh_opts` is the exact builder `remo cp` uses (`cli/cp.py`), so these opts also cover file transfer to an added host (FR-005) — no separate cp builder exists.
+- [ ] T005 Wire type-gated `-o Port=` + stored-identity handling into `build_ssh_opts` in `src/remo_cli/core/ssh.py` (gated on `host.type == "ssh"`, using `ssh_port`/`ssh_identity`; explicit `identity_file` param retains precedence — research D3; makes T004 pass)
+
+**Checkpoint**: Registry model and connection substrate ready.
+
+---
+
+## Phase 3: User Story 1 - Register a host I can already SSH to (Priority: P1) 🎯 MVP
+
+**Goal**: `remo add <name> <target>` registers an SSH-reachable host; `remo shell <name>` and `remo cp` then work via the existing direct path — including a plain login shell when `remo-host` is absent.
+
+**Independent Test**: On a box you can SSH to (no hypervisor access), run `remo add mybox user@host` then `remo shell mybox` and land in a shell (quickstart Scenarios 1–3, 7).
+
+### Tests for User Story 1
+
+- [ ] T006 [P] [US1] Target-parse + add provider tests in `tests/unit/providers/test_added_add.py`: parse `[user@]host[:port]`; default user applied & reported; `--user`/`--port` override; un-bracketed IPv6 and bracketed `[::1]:22` rejected with no write (D4); identity path containing `:` rejected (D5); create writes a single `ssh:` entry; a name already held by a provider entry is refused with no write (FR-010/SC-005); and, after add, assert the host resolves via `resolve_remo_host_by_name(name)` and is included in `get_known_hosts()` (the picker source) so it is selectable alongside provider hosts (FR-006/US1 scenario 5)
+- [ ] T007 [P] [US1] CLI add tests in `tests/unit/cli/test_add_cmd.py` (Click `CliRunner`): argument/flag wiring, success message names `remo shell <name>` + effective user, non-zero exit on collision and on malformed target
+- [ ] T008 [P] [US1] Shell-degradation test in `tests/unit/cli/test_shell_added.py`: a `type="ssh"` host skips the pre-connect tools/version check (no "has no version info / Update tools?" prompt) and proceeds to `shell_connect` (FR-011/SC-006)
+
+### Implementation for User Story 1
+
+- [ ] T009 [US1] Create `src/remo_cli/providers/added.py` (no Click imports): `parse_ssh_target(target, user_override, port_override)` (D4 colon-count IPv6 rejection), and `add(...)` performing name validation (`validate_name`), port validation (`validate_port`), identity `:` rejection (D5), whole-registry collision scan refusing provider-managed names (FR-010, D6), effective-user resolution/report (FR-003), and `save_known_host(KnownHost(type="ssh", access_mode="direct", instance_id=port, region=identity))`
+- [ ] T010 [US1] Create `src/remo_cli/cli/added.py`: `add` Click command with `NAME` + `TARGET` args and `--user/--port/--identity/--yes` options, delegating to `providers.added.add` (the `--verify` option is added in US3/T020 so the US1 increment never ships a non-functional flag — F1)
+- [ ] T011 [US1] Register the `add` command in `_register_commands()` in `src/remo_cli/cli/main.py`
+- [ ] T012 [US1] Gate the pre-connect tools/version check on `host.type != "ssh"` in `src/remo_cli/cli/shell.py` so added hosts skip it and drop into a plain login shell (FR-011)
+
+**Checkpoint**: MVP — add a host and `remo shell`/`remo cp` into it; unmanaged hosts land in a plain shell.
+
+---
+
+## Phase 4: User Story 2 - Update or remove a manually-added host (Priority: P2)
+
+**Goal**: Re-running `add` with the same name updates in place (no duplicate); `remo remove <name>` deregisters an added host locally, refusing provider-managed names.
+
+**Independent Test**: Add a host, re-`add` with a changed target (one line, updated), then `remo remove` it and confirm it's gone from the registry and picker (quickstart Scenarios 4–5).
+
+### Tests for User Story 2
+
+- [ ] T013 [P] [US2] Update/remove provider tests in `tests/unit/providers/test_added_update_remove.py`: re-adding an existing `ssh` name with a changed target updates in place with exactly one line (FR-007/SC-003, `--yes` bypasses confirm); `remove()` deletes an `ssh` entry making **no** network call (SC-004); `remove()` refuses a provider-managed name (FR-009); removing an absent name is a clear no-op/not-found
+- [ ] T014 [P] [US2] CLI remove tests in `tests/unit/cli/test_remove_cmd.py` (`CliRunner`): remove success with confirmation and with `--yes`; refusal (non-zero) on a provider host; not-found (non-zero)
+
+### Implementation for User Story 2
+
+- [ ] T015 [US2] Extend `add()` in `src/remo_cli/providers/added.py` with the same-name `ssh` in-place-update branch (confirm via `core.output.confirm` unless `--yes`; relies on `save_known_host` `(type,name)` replacement — FR-007/D6)
+- [ ] T016 [US2] Add `remove(name, assume_yes)` to `src/remo_cli/providers/added.py`: resolve by name; refuse when the resolved `type != "ssh"` with a message distinguishing deregister from provider `destroy` (FR-009/D8); otherwise confirm (unless `--yes`) and `remove_known_host("ssh", name)` — no SSH/network call
+- [ ] T017 [US2] Add the `remove` Click command (`NAME` arg, `--yes`) to `src/remo_cli/cli/added.py`, delegating to `providers.added.remove`
+- [ ] T018 [US2] Register the `remove` command in `_register_commands()` in `src/remo_cli/cli/main.py`
+
+**Checkpoint**: Update-in-place and deregister both work; US1 still passes.
+
+---
+
+## Phase 5: User Story 3 - Verify reachability at add time (Priority: P3)
+
+**Goal**: `remo add --verify` performs a fail-closed SSH connectivity check before registering.
+
+**Independent Test**: `remo add --verify` against an unreachable target surfaces the SSH error, writes no entry, and exits non-zero; without `--verify`, no network call is made (quickstart Scenario 9).
+
+### Tests for User Story 3
+
+- [ ] T019 [P] [US3] Verify tests in `tests/unit/providers/test_added_verify.py` (SSH subprocess mocked): reachable target → registers after a successful probe; unreachable/auth-fail → SSH error surfaced, **no** registry write, non-zero exit (FR-014/US3.2, fail-closed); `--verify` absent → zero network round-trips (FR-014/US3.3)
+
+### Implementation for User Story 3
+
+- [ ] T020 [US3] Add the `--verify` option to the `add` command in `src/remo_cli/cli/added.py`, and add `verify_reachable(host)` to `src/remo_cli/providers/added.py` — a lightweight `ssh -o BatchMode=yes -o ConnectTimeout=… true`-style probe built through `build_ssh_opts` (so port/identity apply) — wiring `--verify` into `add()` to run it BEFORE `save_known_host`, declining to register (no write) and returning non-zero on failure
+
+**Checkpoint**: All three stories independently functional.
+
+---
+
+## Phase 6: Polish & Cross-Cutting Concerns
+
+- [ ] T021 [P] FR-012 guard: audit provider `destroy`/`snapshot`/resize resolution paths in `src/remo_cli/providers/*.py`; where a host is resolved by name, ensure a `type="ssh"` host yields a clear "manually-registered SSH host with no managed infrastructure" error rather than an opaque failure, with a regression test in `tests/unit/providers/test_added_provider_guard.py`
+- [ ] T022 [P] Update `README.md` with a `remo add` / `remo remove` section: target syntax `[user@]host[:port]`, `--user/--port/--identity/--verify/--yes`, IPv6 guidance, and the local-only nature of `remove` (Constitution V)
+- [ ] T023 [P] Run `uv run mypy src/remo_cli` and `uv run ruff check src/remo_cli`; resolve findings in the new/changed files
+- [ ] T024 Run the quickstart validation (`uv run pytest` on the new suites + a spot-check of the `remo add`/`shell`/`remove` flow against a real reachable box, **including a `remo cp` upload and download** to an added host with a non-default port/identity to confirm FR-005/C2) per `quickstart.md`
+
+---
+
+## Dependencies & Execution Order
+
+### Phase Dependencies
+
+- **Setup (T001)**: no dependencies.
+- **Foundational (T002–T005)**: depends on T001; **blocks all user stories**.
+- **US1 (T006–T012)**: depends on Foundational. MVP.
+- **US2 (T013–T018)**: depends on Foundational; builds on US1's `providers/added.py` and `cli/added.py` (same files) so runs after US1 in a single-developer flow.
+- **US3 (T019–T020)**: depends on Foundational; extends `providers/added.py` and adds the `--verify` option to the `add` command (T020) — the flag is introduced with its behavior, not before (F1).
+- **Polish (T021–T024)**: after the desired stories are complete.
+
+### Within Each User Story
+
+- Write the story's tests first (they fail), then implement to green.
+- `providers/added.py` before `cli/added.py` before registration in `cli/main.py`.
+
+### Parallel Opportunities
+
+- T002 and T004 (different test files) run in parallel; likewise T006/T007/T008.
+- T013 ∥ T014; polish T021 ∥ T022 ∥ T023.
+- Implementation tasks that touch the **same** file (`providers/added.py`: T009→T015→T016→T020; `cli/added.py`: T010→T017; `cli/main.py`: T011→T018) are sequential.
+
+---
+
+## Parallel Example: User Story 1
+
+```bash
+# Tests first (distinct files → parallel):
+Task: "Target-parse + add tests in tests/unit/providers/test_added_add.py"
+Task: "CLI add tests in tests/unit/cli/test_add_cmd.py"
+Task: "Shell-degradation test in tests/unit/cli/test_shell_added.py"
+
+# Then implement provider → CLI → registration (sequential; shared files):
+Task: "providers/added.py: parse_ssh_target + add()"
+Task: "cli/added.py: add command"
+Task: "register add in cli/main.py"
+Task: "shell.py: skip version check for type=ssh"
+```
+
+---
+
+## Implementation Strategy
+
+### MVP First (User Story 1)
+
+1. T001 (Setup) → T002–T005 (Foundational) → T006–T012 (US1).
+2. **STOP and VALIDATE**: quickstart Scenarios 1–3 and 7 — add a host, connect,
+   confirm plain-shell degradation.
+3. Ship the MVP: a user with only SSH access can register and connect.
+
+### Incremental Delivery
+
+- Add US2 (update/remove) → validate Scenarios 4–5.
+- Add US3 (`--verify`) → validate Scenario 9.
+- Polish (FR-012 guard, README, lint, quickstart) last.
+
+---
+
+## Notes
+
+- `[P]` = different files, no ordering dependency.
+- Every conditional branch (collision refuse vs update, IPv6 reject, port
+  present/default, identity present/absent, verify pass/fail, version-check skip)
+  has a dedicated test — Constitution II.
+- Registry format is **unchanged**; only a new `type` value + type-gated reads.
+- Commit after each story checkpoint.

--- a/src/remo_cli/cli/added.py
+++ b/src/remo_cli/cli/added.py
@@ -1,0 +1,102 @@
+"""remo add / remo remove — provider-neutral SSH host registration (feature 014)."""
+
+from __future__ import annotations
+
+import click
+
+
+@click.command("add")
+@click.argument("name")
+@click.argument("target")
+@click.option(
+    "--user",
+    default=None,
+    help="SSH user; overrides any user@ in TARGET (default: remo).",
+)
+@click.option(
+    "--port",
+    type=int,
+    default=None,
+    help="SSH port; overrides any :port in TARGET (default: 22).",
+)
+@click.option(
+    "--identity",
+    default=None,
+    metavar="PATH",
+    help="SSH private key path; stored and used via 'ssh -i' on connect.",
+)
+@click.option(
+    "--verify",
+    is_flag=True,
+    default=False,
+    help="Check SSH reachability before registering (fail-closed; no write on failure).",
+)
+@click.option(
+    "--yes",
+    "assume_yes",
+    is_flag=True,
+    default=False,
+    help="Skip the confirmation prompt when updating an existing added host.",
+)
+def add(
+    name: str,
+    target: str,
+    user: str | None,
+    port: int | None,
+    identity: str | None,
+    verify: bool,
+    assume_yes: bool,
+) -> None:
+    """Register an SSH-reachable environment as NAME.
+
+    TARGET is [user@]host[:port]. Requires only SSH access — no hypervisor or
+    cloud credentials. Afterwards 'remo shell NAME' and 'remo cp' work over SSH
+    like any other environment.
+
+    \b
+    Examples:
+      remo add mybox user@192.0.2.10
+      remo add api dev@10.0.0.9:2222 --identity ~/.ssh/api_ed25519
+      remo add mybox user@192.0.2.10 --verify
+    """
+    from remo_cli.core.validation import validate_name, validate_port  # noqa: PLC0415
+    from remo_cli.providers.added import add as provider_add  # noqa: PLC0415
+
+    validate_name(name)
+    if port is not None:
+        validate_port(port)
+
+    rc = provider_add(
+        name=name,
+        target=target,
+        user=user,
+        port=port,
+        identity=identity,
+        verify=verify,
+        assume_yes=assume_yes,
+    )
+    if rc:
+        raise SystemExit(rc)
+
+
+@click.command("remove")
+@click.argument("name")
+@click.option(
+    "--yes",
+    "assume_yes",
+    is_flag=True,
+    default=False,
+    help="Skip the confirmation prompt.",
+)
+def remove(name: str, assume_yes: bool) -> None:
+    """Deregister a manually-added SSH host (NAME).
+
+    Deletes only the local registry entry; the remote environment is never
+    contacted or modified (unlike a provider 'destroy'). Refuses to act on a
+    provider-managed host.
+    """
+    from remo_cli.providers.added import remove as provider_remove  # noqa: PLC0415
+
+    rc = provider_remove(name=name, assume_yes=assume_yes)
+    if rc:
+        raise SystemExit(rc)

--- a/src/remo_cli/cli/main.py
+++ b/src/remo_cli/cli/main.py
@@ -79,6 +79,7 @@ def _register_commands() -> None:
     # when only --version or --help is requested.
     from remo_cli.cli.shell import shell  # noqa: F811
     from remo_cli.cli.cp import cp  # noqa: F811
+    from remo_cli.cli.added import add, remove  # noqa: F811
     from remo_cli.cli.providers.incus import incus  # noqa: F811
     from remo_cli.cli.providers.proxmox import proxmox  # noqa: F811
     from remo_cli.cli.providers.hetzner import hetzner  # noqa: F811
@@ -87,6 +88,8 @@ def _register_commands() -> None:
 
     cli.add_command(shell)
     cli.add_command(cp)
+    cli.add_command(add)
+    cli.add_command(remove)
     cli.add_command(incus)
     cli.add_command(proxmox)
     cli.add_command(hetzner)

--- a/src/remo_cli/cli/shell.py
+++ b/src/remo_cli/cli/shell.py
@@ -96,8 +96,14 @@ def shell(
     # Auto-start stopped AWS instances before connecting
     host = auto_start_aws_if_stopped(host)
 
-    # Pre-shell remote version check
-    if not no_update_check:
+    # Pre-shell remote version check.
+    #
+    # Skip entirely for manually-added SSH hosts (feature 014, type="ssh"):
+    # they have no remo-managed tooling, so a missing `remo-host`/version marker
+    # is "unknown/unmanaged", not a prompt to run a (nonexistent) provider
+    # update. This lets `remo shell` drop straight into a plain login shell
+    # (FR-011).
+    if not no_update_check and host.type != "ssh":
         local_version = get_current_version()
         if local_version != "unknown":
             remote_version, remote_err = check_remote_version(host)

--- a/src/remo_cli/core/config.py
+++ b/src/remo_cli/core/config.py
@@ -18,6 +18,20 @@ INCUS_MANAGED_CONFIG_KEY = "user.remo"
 INCUS_MANAGED_CONFIG_VALUE = "true"
 PROXMOX_MANAGED_TAG = "remo"
 
+# ---------------------------------------------------------------------------
+# Manually-added SSH host (feature 014-register-ssh-host)
+#
+# Fixed, built-in constants for the provider-neutral ``remo add`` command, which
+# registers a single SSH-reachable environment as a new registry ``type`` with
+# ``access_mode = direct``. The SSH port and identity are stored in the existing
+# KnownHost positional fields (see models/host.py: instance_id=port,
+# region=identity), so no registry format change is needed.
+# ---------------------------------------------------------------------------
+
+ADDED_HOST_TYPE = "ssh"
+DEFAULT_ADDED_HOST_USER = "remo"
+DEFAULT_SSH_PORT = 22
+
 
 def _resolve_remo_home() -> Path:
     """Resolve the remo config directory path with no filesystem side effects.

--- a/src/remo_cli/core/known_hosts.py
+++ b/src/remo_cli/core/known_hosts.py
@@ -188,6 +188,44 @@ def get_aws_region(name: str) -> str:
     )
 
 
+def guard_not_added_ssh_host(name: str, provider: str) -> None:
+    """FR-012: fail clearly when *name* is a manually-registered SSH host.
+
+    Provider lifecycle operations (``destroy``, ``snapshot`` create/restore/
+    delete, resize via ``update``) resolve a host by *name* within their own
+    inventory. A ``type="ssh"`` host added via ``remo add`` has no managed
+    *provider* infrastructure, so such an operation would otherwise silently
+    mis-target (e.g. an Incus teardown against ``localhost``) or emit an opaque
+    "not found" / "run sync" error that never tells the user what is wrong.
+
+    When *name* matches an added SSH host — and no host of *provider*'s own type
+    also matches it — exit with a clear message pointing the user at
+    ``remo remove``. When a same-type managed host also matches (e.g. an Incus
+    container that happens to share the name), the operation legitimately
+    targets that instance and is allowed through.
+    """
+    all_hosts = get_known_hosts()
+
+    if not any(h.type == "ssh" and h.name == name for h in all_hosts):
+        return
+
+    for host in all_hosts:
+        if host.type != provider:
+            continue
+        if host.name == name:
+            return
+        # incus/proxmox short-name match (container part of "host/container").
+        if provider in {"incus", "proxmox"} and "/" in host.name:
+            if host.name.split("/", maxsplit=1)[1] == name:
+                return
+
+    sys.exit(
+        f"Error: '{name}' is a manually-registered SSH host (added via "
+        f"'remo add') with no managed {provider} infrastructure. "
+        f"Use 'remo remove {name}' to deregister it."
+    )
+
+
 def resolve_remo_host_by_name(name: str) -> KnownHost:
     """Find a registered host by name, matching across all types.
 

--- a/src/remo_cli/core/ssh.py
+++ b/src/remo_cli/core/ssh.py
@@ -10,6 +10,7 @@ import sys
 import termios
 from pathlib import Path
 
+from remo_cli.core.config import DEFAULT_SSH_PORT
 from remo_cli.core.known_hosts import get_aws_region, get_known_hosts, resolve_remo_host_by_name
 from remo_cli.core.output import print_info
 from remo_cli.core.picker import pick_environment
@@ -125,13 +126,23 @@ def build_ssh_opts(
         ssh_target = f"{host.user}@{host.instance_id}"
     else:
         ssh_target = f"{host.user}@{host.host}"
+        # Manually-added SSH host (feature 014, type=ssh): apply a non-default
+        # port stored in KnownHost.instance_id. Gated on the ssh type so a
+        # provider's numeric instance_id (e.g. a Proxmox vmid) is never read
+        # as a port and every other provider's argv is unchanged.
+        if host.type == "ssh" and host.ssh_port != DEFAULT_SSH_PORT:
+            ssh_opts += ["-o", f"Port={host.ssh_port}"]
 
     # ------------------------------------------------------------------
-    # Explicit identity / known-hosts (adopted-mode web service, R6)
+    # Explicit identity / known-hosts (adopted-mode web service R6; added-host
+    # stored identity, feature 014). An explicit identity_file argument always
+    # wins; otherwise an added (ssh-type) host's stored identity is used
+    # (``ssh_identity`` is None for every other type, so their argv is unchanged).
     # ------------------------------------------------------------------
-    if identity_file is not None:
+    effective_identity = identity_file if identity_file is not None else host.ssh_identity
+    if effective_identity is not None:
         ssh_opts += [
-            "-o", f"IdentityFile={identity_file}",
+            "-o", f"IdentityFile={effective_identity}",
             "-o", "IdentitiesOnly=yes",
         ]
     if known_hosts_file is not None:

--- a/src/remo_cli/models/host.py
+++ b/src/remo_cli/models/host.py
@@ -94,6 +94,39 @@ class KnownHost:
         )
 
     # ------------------------------------------------------------------
+    # Manually-added SSH host accessors (feature 014-register-ssh-host)
+    #
+    # For the ``ssh`` type, ``remo add`` stores the SSH port in ``instance_id``
+    # and the optional identity path in ``region`` (access_mode is ``direct``).
+    # These type-gated readers localize that field-overloading so the rest of
+    # the codebase never reinterprets provider slots: for every non-``ssh``
+    # type they return neutral values, leaving all other providers untouched.
+    # ------------------------------------------------------------------
+
+    @property
+    def ssh_port(self) -> int:
+        """SSH port for an added (``ssh``-type) host; ``22`` otherwise/default.
+
+        Non-``ssh`` types return the default so a provider's ``instance_id``
+        (e.g. a Proxmox vmid or an AWS instance id) is never read as a port.
+        """
+        from remo_cli.core.config import DEFAULT_SSH_PORT
+
+        if self.type == "ssh" and self.instance_id:
+            try:
+                return int(self.instance_id)
+            except ValueError:
+                return DEFAULT_SSH_PORT
+        return DEFAULT_SSH_PORT
+
+    @property
+    def ssh_identity(self) -> str | None:
+        """Stored SSH identity path for an added (``ssh``-type) host, else ``None``."""
+        if self.type == "ssh" and self.region:
+            return self.region
+        return None
+
+    # ------------------------------------------------------------------
     # Display
     # ------------------------------------------------------------------
 

--- a/src/remo_cli/providers/added.py
+++ b/src/remo_cli/providers/added.py
@@ -34,9 +34,19 @@ from remo_cli.core.output import (
 )
 from remo_cli.models.host import KnownHost
 
-# Registry types backed by managed infrastructure — never overwritten by `add`
-# and never removed by `remove` (they have a provider `destroy`).
-PROVIDER_TYPES = frozenset({"incus", "proxmox", "aws", "hetzner"})
+
+def _reject_unsafe_field(label: str, value: str) -> None:
+    """Reject a registry field that would corrupt the colon-delimited line.
+
+    The known-hosts store is both ``:``-delimited and newline-delimited, so a
+    field containing ``:`` shifts every later field on reload and a control
+    character (newline/tab/…) can inject or truncate a line. Neither must ever
+    be persisted (FR-013).
+    """
+    if any(ord(c) < 0x20 or ord(c) == 0x7F for c in value):
+        raise ValueError(f"{label} contains control characters")
+    if ":" in value:
+        raise ValueError(f"{label} must not contain ':'")
 
 
 def _find_name_conflict(name: str) -> KnownHost | None:
@@ -135,6 +145,11 @@ def parse_ssh_target(
     if not (1 <= port <= 65535):
         raise ValueError(f"port {port} is out of range (1-65535)")
 
+    # The user (from --user or user@) and host become colon-delimited registry
+    # fields; reject anything that would shift fields or inject a line (FR-013).
+    _reject_unsafe_field("user", user)
+    _reject_unsafe_field("host", host_part)
+
     return user, host_part, port
 
 
@@ -150,6 +165,13 @@ def verify_reachable(host: KnownHost, timeout: int = 10) -> tuple[bool, str | No
     added host's port and stored identity are honored, then runs ``ssh … true``
     with ``BatchMode=yes`` (no password prompt). Returns ``(True, None)`` on
     success or ``(False, error)`` on any SSH failure.
+
+    Host-key checking is disabled for the probe (``StrictHostKeyChecking=no`` +
+    ``UserKnownHostsFile=/dev/null``): this is a *reachability/auth* check, and
+    with ``BatchMode=yes`` an unknown host key would otherwise fail with "Host
+    key verification failed" — wrongly reporting a reachable, never-before-seen
+    host as unreachable. It deliberately does not pre-seed ``~/.ssh/known_hosts``
+    (the first real ``remo shell`` still follows normal host-key behavior).
     """
     from remo_cli.core.ssh import build_ssh_opts
 
@@ -161,6 +183,10 @@ def verify_reachable(host: KnownHost, timeout: int = 10) -> tuple[bool, str | No
         f"ConnectTimeout={timeout}",
         "-o",
         "BatchMode=yes",
+        "-o",
+        "StrictHostKeyChecking=no",
+        "-o",
+        "UserKnownHostsFile=/dev/null",
         ssh_target,
         "true",
     ]
@@ -208,13 +234,16 @@ def add(
         print_error(f"Invalid target: {e}")
         return 2
 
-    if identity is not None and ":" in identity:
-        print_error(
-            "Invalid --identity: the path must not contain ':' "
-            "(it would corrupt the colon-delimited registry line). "
-            "Use an '~/.ssh/config' IdentityFile entry for such a key."
-        )
-        return 2
+    if identity is not None:
+        try:
+            _reject_unsafe_field("identity path", identity)
+        except ValueError:
+            print_error(
+                "Invalid --identity: the path must not contain ':' or control "
+                "characters (they would corrupt the colon-delimited registry "
+                "line). Use an '~/.ssh/config' IdentityFile entry for such a key."
+            )
+            return 2
 
     # Whole-registry name-collision check: the registry only dedupes within
     # (type, name), so a cross-type collision must be caught here (FR-010).

--- a/src/remo_cli/providers/added.py
+++ b/src/remo_cli/providers/added.py
@@ -1,0 +1,311 @@
+"""Business logic for the provider-neutral ``remo add`` / ``remo remove`` commands.
+
+Feature 014-register-ssh-host. Registers a single SSH-reachable environment as a
+new registry ``type = "ssh"`` (``access_mode = "direct"``), requiring only SSH
+reachability — no hypervisor host access, cloud credentials, or API token. The
+SSH port and optional identity are stored in the existing ``KnownHost``
+positional fields (``instance_id`` = port, ``region`` = identity), so the
+registry format is unchanged.
+
+No Click imports (three-layer architecture): the CLI layer validates the name /
+port and forwards clean inputs; this module parses the target, enforces the
+collision/update policy, optionally verifies reachability, and writes the entry.
+"""
+
+from __future__ import annotations
+
+import subprocess
+
+from remo_cli.core.config import (
+    ADDED_HOST_TYPE,
+    DEFAULT_ADDED_HOST_USER,
+    DEFAULT_SSH_PORT,
+)
+from remo_cli.core.known_hosts import (
+    get_known_hosts,
+    remove_known_host,
+    save_known_host,
+)
+from remo_cli.core.output import (
+    confirm,
+    print_error,
+    print_info,
+    print_success,
+)
+from remo_cli.models.host import KnownHost
+
+# Registry types backed by managed infrastructure — never overwritten by `add`
+# and never removed by `remove` (they have a provider `destroy`).
+PROVIDER_TYPES = frozenset({"incus", "proxmox", "aws", "hetzner"})
+
+
+def _find_name_conflict(name: str) -> KnownHost | None:
+    """Return a registry entry that *name* would collide with, or ``None``.
+
+    Mirrors :func:`~remo_cli.core.known_hosts.resolve_remo_host_by_name`: an
+    exact match on any type, or the container part of an incus/proxmox
+    ``node/container`` name. This is what makes the FR-010 shadow check as broad
+    as the resolver — an added host named ``devbox`` must be refused when an
+    incus container ``node/devbox`` already exists.
+    """
+    hosts = get_known_hosts()
+    exact = next((h for h in hosts if h.name == name), None)
+    if exact is not None:
+        return exact
+    for h in hosts:
+        if h.type in {"incus", "proxmox"} and "/" in h.name:
+            if h.name.split("/", maxsplit=1)[1] == name:
+                return h
+    return None
+
+
+# ---------------------------------------------------------------------------
+# Target parsing
+# ---------------------------------------------------------------------------
+
+
+def parse_ssh_target(
+    target: str,
+    user_override: str | None = None,
+    port_override: int | None = None,
+) -> tuple[str, str, int]:
+    """Parse ``[user@]host[:port]`` into ``(user, host, port)``.
+
+    ``user_override`` / ``port_override`` (from ``--user`` / ``--port``) win over
+    values embedded in *target*. When no user is present, the documented default
+    (:data:`DEFAULT_ADDED_HOST_USER`) is applied; when no port is present,
+    :data:`DEFAULT_SSH_PORT` is used.
+
+    Un-bracketed IPv6 literals (and the bracketed ``[::1]:22`` form, which is out
+    of scope for this feature) are rejected so a malformed line is never written.
+
+    Raises
+    ------
+    ValueError
+        With a human-readable reason for any malformed target.
+    """
+    raw = target.strip()
+    if not raw:
+        raise ValueError("SSH target must not be empty")
+
+    if "@" in raw:
+        user_part, _, rest = raw.partition("@")
+        if not user_part:
+            raise ValueError(f"'{target}': empty user before '@'")
+    else:
+        user_part = ""
+        rest = raw
+
+    # IPv6: a bracketed form, or more than one colon in the host portion, is an
+    # IPv6 literal — reject with guidance (a legal host:port has exactly one ':').
+    if rest.startswith("["):
+        raise ValueError(
+            f"'{target}': IPv6 literals are not supported. "
+            "Use a hostname or an '~/.ssh/config' alias."
+        )
+    if rest.count(":") > 1:
+        raise ValueError(
+            f"'{target}': IPv6 literals are not supported. "
+            "Use a hostname or an '~/.ssh/config' alias."
+        )
+
+    if rest.count(":") == 1:
+        host_part, _, port_str = rest.partition(":")
+        try:
+            embedded_port: int | None = int(port_str)
+        except ValueError:
+            raise ValueError(
+                f"'{target}': port '{port_str}' is not a number"
+            ) from None
+    else:
+        host_part = rest
+        embedded_port = None
+
+    if not host_part:
+        raise ValueError(f"'{target}': missing host")
+
+    user = user_override or user_part or DEFAULT_ADDED_HOST_USER
+    if port_override is not None:
+        port = port_override
+    elif embedded_port is not None:
+        port = embedded_port
+    else:
+        port = DEFAULT_SSH_PORT
+
+    if not (1 <= port <= 65535):
+        raise ValueError(f"port {port} is out of range (1-65535)")
+
+    return user, host_part, port
+
+
+# ---------------------------------------------------------------------------
+# Reachability check (FR-014)
+# ---------------------------------------------------------------------------
+
+
+def verify_reachable(host: KnownHost, timeout: int = 10) -> tuple[bool, str | None]:
+    """Run a lightweight, non-interactive SSH connectivity probe.
+
+    Builds the SSH argv through :func:`~remo_cli.core.ssh.build_ssh_opts` so the
+    added host's port and stored identity are honored, then runs ``ssh … true``
+    with ``BatchMode=yes`` (no password prompt). Returns ``(True, None)`` on
+    success or ``(False, error)`` on any SSH failure.
+    """
+    from remo_cli.core.ssh import build_ssh_opts
+
+    ssh_opts, ssh_target = build_ssh_opts(host)
+    cmd = [
+        "ssh",
+        *ssh_opts,
+        "-o",
+        f"ConnectTimeout={timeout}",
+        "-o",
+        "BatchMode=yes",
+        ssh_target,
+        "true",
+    ]
+    try:
+        result = subprocess.run(
+            cmd, capture_output=True, text=True, timeout=timeout + 5
+        )
+    except subprocess.TimeoutExpired:
+        return False, f"SSH timed out after {timeout + 5}s"
+    except OSError as e:
+        return False, f"SSH failed: {e}"
+
+    if result.returncode == 0:
+        return True, None
+    stderr = result.stderr.strip()
+    return False, stderr or f"SSH connection failed (exit code {result.returncode})"
+
+
+# ---------------------------------------------------------------------------
+# add
+# ---------------------------------------------------------------------------
+
+
+def add(
+    *,
+    name: str,
+    target: str,
+    user: str | None = None,
+    port: int | None = None,
+    identity: str | None = None,
+    verify: bool = False,
+    assume_yes: bool = False,
+) -> int:
+    """Register (or update in place) an SSH-reachable host. Returns an exit code.
+
+    * Refuses to overwrite a provider-managed entry of the same name (FR-010).
+    * Re-adding an existing added host updates it in place, confirming unless
+      *assume_yes* (FR-007).
+    * With *verify*, runs a fail-closed reachability check BEFORE writing; on
+      failure nothing is registered and a non-zero code is returned (FR-014).
+    """
+    try:
+        eff_user, eff_host, eff_port = parse_ssh_target(target, user, port)
+    except ValueError as e:
+        print_error(f"Invalid target: {e}")
+        return 2
+
+    if identity is not None and ":" in identity:
+        print_error(
+            "Invalid --identity: the path must not contain ':' "
+            "(it would corrupt the colon-delimited registry line). "
+            "Use an '~/.ssh/config' IdentityFile entry for such a key."
+        )
+        return 2
+
+    # Whole-registry name-collision check: the registry only dedupes within
+    # (type, name), so a cross-type collision must be caught here (FR-010).
+    # Mirror resolve_remo_host_by_name's matching — including the incus/proxmox
+    # "node/container" short-name — so `add` cannot *shadow* a provider entry
+    # that `remo shell <name>` would otherwise resolve to.
+    existing = _find_name_conflict(name)
+    if existing is not None and existing.type != ADDED_HOST_TYPE:
+        print_error(
+            f"'{name}' is already registered (provider: {existing.type}). "
+            f"'remo add' will not overwrite or shadow a provider-managed entry — "
+            f"choose a different name."
+        )
+        return 1
+
+    is_update = existing is not None
+    if is_update and not assume_yes:
+        if not confirm(
+            f"Update existing added host '{name}' to {eff_user}@{eff_host}:{eff_port}?",
+            default=True,
+        ):
+            print_info("Aborted; no changes made.")
+            return 1
+
+    entry = KnownHost(
+        type=ADDED_HOST_TYPE,
+        name=name,
+        host=eff_host,
+        user=eff_user,
+        instance_id=str(eff_port),
+        access_mode="direct",
+        region=identity or "",
+    )
+
+    if verify:
+        print_info(f"Verifying SSH reachability of {eff_user}@{eff_host}:{eff_port}...")
+        ok, err = verify_reachable(entry)
+        if not ok:
+            print_error(
+                f"SSH reachability check failed for {eff_user}@{eff_host}:{eff_port}:\n"
+                f"  {err}\n"
+                f"  Nothing was registered (omit --verify to register without checking)."
+            )
+            return 1
+        print_success("SSH reachability check passed.")
+
+    save_known_host(entry)
+
+    verb = "Updated" if is_update else "Registered"
+    print_success(f"{verb} '{name}' as {eff_user}@{eff_host}:{eff_port} (SSH user: {eff_user}).")
+    print_info(f"Connect with:  remo shell {name}")
+    return 0
+
+
+# ---------------------------------------------------------------------------
+# remove
+# ---------------------------------------------------------------------------
+
+
+def remove(*, name: str, assume_yes: bool = False) -> int:
+    """Deregister a manually-added SSH host — local registry delete only.
+
+    Makes no connection to and no change on the remote environment (FR-008).
+    Refuses to act on a provider-managed host (FR-009).
+    """
+    existing = next((h for h in get_known_hosts() if h.name == name), None)
+    if existing is None:
+        print_error(
+            f"No added host named '{name}' found in the registry. "
+            f"(list with 'remo shell' to see registered environments)"
+        )
+        return 1
+
+    if existing.type != ADDED_HOST_TYPE:
+        print_error(
+            f"'{name}' is a provider-managed host (provider: {existing.type}), "
+            f"not a manually-added SSH host. Use 'remo {existing.type} destroy' "
+            f"to tear it down — 'remo remove' only deregisters 'remo add' hosts."
+        )
+        return 1
+
+    if not assume_yes:
+        if not confirm(
+            f"Deregister added host '{name}'? The remote environment is not touched.",
+            default=False,
+        ):
+            print_info("Aborted; no changes made.")
+            return 1
+
+    remove_known_host(ADDED_HOST_TYPE, name)
+    print_success(
+        f"Removed '{name}' from the registry. The remote environment was not modified."
+    )
+    return 0

--- a/src/remo_cli/providers/aws.py
+++ b/src/remo_cli/providers/aws.py
@@ -22,6 +22,7 @@ from remo_cli.core.known_hosts import (
     clear_known_hosts_by_type,
     get_aws_region,
     get_known_hosts,
+    guard_not_added_ssh_host,
     remove_known_host,
     save_known_host,
 )
@@ -518,6 +519,7 @@ def destroy(
         )
 
     resource_name = name or os.environ.get("USER", "remo")
+    guard_not_added_ssh_host(resource_name, "aws")  # FR-012
     region = get_aws_region(resource_name)
 
     # FR-020 through FR-023: surface remo-managed EBS snapshots before destroy.
@@ -594,6 +596,7 @@ def update(
     volume_size = parse_volume_size(volume_size)
 
     resource_name = name or os.environ.get("USER", "remo")
+    guard_not_added_ssh_host(resource_name, "aws")  # FR-012
     region = get_aws_region(resource_name)
 
     # Query boto3 for running instance info.
@@ -1172,6 +1175,7 @@ def snapshot_create(
     Returns 0 after the provider accepts the request (no polling — per
     FR-004 / Q1).
     """
+    guard_not_added_ssh_host(instance_name, "aws")  # FR-012
     validate_snapshot_name(snap_name)
 
     region = get_aws_region(instance_name) if not region else region
@@ -1277,6 +1281,7 @@ def snapshot_restore(
       8. Start instance → wait running.
       9. Tag old volume ``remo-restore-orphan=<timestamp>`` and keep it (FR-030).
     """
+    guard_not_added_ssh_host(instance_name, "aws")  # FR-012
     region = get_aws_region(instance_name) if not region else region
 
     # We need the instance even if it's stopped; describe directly.
@@ -1472,6 +1477,7 @@ def snapshot_delete(
     auto_confirm: bool = False,
 ) -> int:
     """Delete a remo-managed AWS snapshot by its user-facing name."""
+    guard_not_added_ssh_host(instance_name, "aws")  # FR-012
     region = get_aws_region(instance_name) if not region else region
     session = _boto3_session(region)
     ec2 = session.client("ec2")

--- a/src/remo_cli/providers/hetzner.py
+++ b/src/remo_cli/providers/hetzner.py
@@ -20,6 +20,7 @@ from remo_cli.core.ansible_runner import run_playbook
 from remo_cli.core.known_hosts import (
     clear_known_hosts_by_type,
     get_known_hosts,
+    guard_not_added_ssh_host,
     remove_known_host,
     save_known_host,
 )
@@ -179,6 +180,7 @@ def destroy(
         validate_name(name, "server name")
 
     server_name = name or "remo"
+    guard_not_added_ssh_host(server_name, "hetzner")  # FR-012
 
     if remove_volume:
         print_warning(
@@ -249,6 +251,7 @@ def update(
     volume_size = parse_volume_size(volume_size)
 
     server_name = name or "remo"
+    guard_not_added_ssh_host(server_name, "hetzner")  # FR-012
 
     # Get server address from known_hosts.
     server_host = _lookup_hetzner_host(server_name)
@@ -554,6 +557,7 @@ def snapshot_create(
 
     Returns 0 once the provider accepts the request (no polling — per FR-004).
     """
+    guard_not_added_ssh_host(server_name, "hetzner")  # FR-012
     validate_snapshot_name(snap_name)
 
     try:
@@ -623,6 +627,7 @@ def snapshot_restore(
     IP are preserved (FR-013). We poll the rebuild action until success.
     Returns 0 on success, 1 on any failure.
     """
+    guard_not_added_ssh_host(server_name, "hetzner")  # FR-012
     try:
         server = _get_server_by_name(server_name)
     except RuntimeError as e:
@@ -697,6 +702,7 @@ def snapshot_delete(
     server_name: str, snap_name: str, auto_confirm: bool = False
 ) -> int:
     """Delete the remo-managed Hetzner snapshot image *snap_name*."""
+    guard_not_added_ssh_host(server_name, "hetzner")  # FR-012
     try:
         server = _get_server_by_name(server_name)
     except RuntimeError as e:

--- a/src/remo_cli/providers/incus.py
+++ b/src/remo_cli/providers/incus.py
@@ -22,6 +22,7 @@ from remo_cli.core.config import (
 from remo_cli.core.known_hosts import (
     clear_known_hosts_by_prefix,
     get_known_hosts,
+    guard_not_added_ssh_host,
     remove_known_host,
     save_known_host,
 )
@@ -322,6 +323,7 @@ def destroy(
     Returns the ansible-playbook exit code (0 on success).
     """
     validate_name(name, "container name")
+    guard_not_added_ssh_host(name, "incus")  # FR-012
 
     # If --host not specified, look up container in known_hosts.
     if not host:
@@ -407,6 +409,7 @@ def update(
     Returns the ansible-playbook exit code (0 on success).
     """
     validate_name(name, "container name")
+    guard_not_added_ssh_host(name, "incus")  # FR-012
     volume_size = parse_volume_size(volume_size)
 
     # If --host not specified, look up container in known_hosts.
@@ -809,6 +812,7 @@ def snapshot_create(
     (per FR-006). The snapshot name must already have been validated via
     :func:`core.snapshot.validate_name` by the CLI layer.
     """
+    guard_not_added_ssh_host(container, "incus")  # FR-012
     validate_snapshot_name(snap_name)  # belt-and-suspenders
 
     try:
@@ -893,6 +897,7 @@ def snapshot_restore(
     container ends up reachable in whatever state it was before (FR-013).
     Returns 0 on success, 1 on any failure.
     """
+    guard_not_added_ssh_host(container, "incus")  # FR-012
     try:
         existing = _list_snapshots_for_container(host, container, user)
     except RuntimeError as e:
@@ -980,6 +985,7 @@ def snapshot_delete(
     auto_confirm: bool = False,
 ) -> int:
     """Delete a snapshot of *container*."""
+    guard_not_added_ssh_host(container, "incus")  # FR-012
     try:
         existing = _list_snapshots_for_container(host, container, user)
     except RuntimeError as e:

--- a/src/remo_cli/providers/proxmox.py
+++ b/src/remo_cli/providers/proxmox.py
@@ -24,6 +24,7 @@ from remo_cli.core.config import PROXMOX_MANAGED_TAG
 from remo_cli.core.known_hosts import (
     clear_known_hosts_by_prefix,
     get_known_hosts,
+    guard_not_added_ssh_host,
     remove_known_host,
     save_known_host,
 )
@@ -421,6 +422,7 @@ def destroy(
     Returns the ansible-playbook exit code (0 on success).
     """
     validate_name(name, "container name")
+    guard_not_added_ssh_host(name, "proxmox")  # FR-012
 
     vmid = ""
     if not host:
@@ -514,6 +516,7 @@ def update(
     Returns the ansible-playbook exit code (0 on success).
     """
     validate_name(name, "container name")
+    guard_not_added_ssh_host(name, "proxmox")  # FR-012
     volume_size = parse_volume_size(volume_size)
 
     vmid = ""
@@ -1012,6 +1015,7 @@ def snapshot_create(
     Pre-flight checks snapshot-capable storage (FR-005) and duplicate
     name (FR-006).  Returns 0 on success, 1 on any failure.
     """
+    guard_not_added_ssh_host(container, "proxmox")  # FR-012
     validate_snapshot_name(snap_name)
 
     supported, storage_type = _detect_snapshot_capable_storage(host, user, vmid)
@@ -1086,6 +1090,7 @@ def snapshot_restore(
     operation; we restart it afterwards if it was running pre-rollback
     (FR-013).  Returns 0 on success, 1 on any failure.
     """
+    guard_not_added_ssh_host(container, "proxmox")  # FR-012
     try:
         existing = _list_snapshots_for_vmid(host, user, vmid, container)
     except RuntimeError as e:
@@ -1153,6 +1158,7 @@ def snapshot_delete(
     auto_confirm: bool = False,
 ) -> int:
     """Delete a snapshot of LXC *vmid*."""
+    guard_not_added_ssh_host(container, "proxmox")  # FR-012
     try:
         existing = _list_snapshots_for_vmid(host, user, vmid, container)
     except RuntimeError as e:

--- a/tests/unit/cli/test_add_cmd.py
+++ b/tests/unit/cli/test_add_cmd.py
@@ -1,0 +1,51 @@
+"""CLI-layer tests for `remo add` (feature 014, US1). Provider logic is mocked."""
+
+from __future__ import annotations
+
+import pytest
+from click.testing import CliRunner
+
+from remo_cli.cli.added import add
+
+
+@pytest.fixture
+def runner() -> CliRunner:
+    return CliRunner()
+
+
+def test_success_calls_provider_and_exits_zero(runner, mocker) -> None:
+    prov = mocker.patch("remo_cli.providers.added.add", return_value=0)
+    result = runner.invoke(add, ["box", "dev@1.2.3.4:2222", "--identity", "/k/id"])
+    assert result.exit_code == 0
+    prov.assert_called_once()
+    kwargs = prov.call_args.kwargs
+    assert kwargs["name"] == "box"
+    assert kwargs["target"] == "dev@1.2.3.4:2222"
+    assert kwargs["identity"] == "/k/id"
+    assert kwargs["verify"] is False
+
+
+def test_verify_flag_forwarded(runner, mocker) -> None:
+    prov = mocker.patch("remo_cli.providers.added.add", return_value=0)
+    runner.invoke(add, ["box", "1.2.3.4", "--verify"])
+    assert prov.call_args.kwargs["verify"] is True
+
+
+def test_nonzero_provider_rc_propagates(runner, mocker) -> None:
+    mocker.patch("remo_cli.providers.added.add", return_value=1)
+    result = runner.invoke(add, ["box", "1.2.3.4"])
+    assert result.exit_code == 1
+
+
+def test_invalid_name_rejected_before_provider(runner, mocker) -> None:
+    prov = mocker.patch("remo_cli.providers.added.add", return_value=0)
+    result = runner.invoke(add, ["!bad", "1.2.3.4"])
+    assert result.exit_code == 2
+    prov.assert_not_called()
+
+
+def test_invalid_port_rejected_before_provider(runner, mocker) -> None:
+    prov = mocker.patch("remo_cli.providers.added.add", return_value=0)
+    result = runner.invoke(add, ["box", "1.2.3.4", "--port", "70000"])
+    assert result.exit_code == 2
+    prov.assert_not_called()

--- a/tests/unit/cli/test_main.py
+++ b/tests/unit/cli/test_main.py
@@ -82,6 +82,8 @@ class TestSubcommandRegistration:
     EXPECTED_COMMANDS = [
         "shell",
         "cp",
+        "add",
+        "remove",
         "incus",
         "proxmox",
         "hetzner",

--- a/tests/unit/cli/test_remove_cmd.py
+++ b/tests/unit/cli/test_remove_cmd.py
@@ -1,0 +1,32 @@
+"""CLI-layer tests for `remo remove` (feature 014, US2). Provider logic mocked."""
+
+from __future__ import annotations
+
+import pytest
+from click.testing import CliRunner
+
+from remo_cli.cli.added import remove
+
+
+@pytest.fixture
+def runner() -> CliRunner:
+    return CliRunner()
+
+
+def test_success_calls_provider_and_exits_zero(runner, mocker) -> None:
+    prov = mocker.patch("remo_cli.providers.added.remove", return_value=0)
+    result = runner.invoke(remove, ["box", "--yes"])
+    assert result.exit_code == 0
+    prov.assert_called_once_with(name="box", assume_yes=True)
+
+
+def test_confirm_flag_default_false(runner, mocker) -> None:
+    prov = mocker.patch("remo_cli.providers.added.remove", return_value=0)
+    runner.invoke(remove, ["box"])
+    assert prov.call_args.kwargs["assume_yes"] is False
+
+
+def test_nonzero_rc_propagates(runner, mocker) -> None:
+    mocker.patch("remo_cli.providers.added.remove", return_value=1)
+    result = runner.invoke(remove, ["box", "--yes"])
+    assert result.exit_code == 1

--- a/tests/unit/cli/test_shell_added.py
+++ b/tests/unit/cli/test_shell_added.py
@@ -1,0 +1,76 @@
+"""`remo shell` degradation for manually-added SSH hosts (feature 014, FR-011).
+
+An added (type="ssh") host has no managed tooling, so the pre-connect
+tools/version check must be skipped — no "Update tools?" prompt — and the
+command drops straight into a plain login shell via shell_connect.
+"""
+
+from __future__ import annotations
+
+import pytest
+from click.testing import CliRunner
+
+from remo_cli.cli.shell import shell
+from remo_cli.models.host import KnownHost
+
+
+@pytest.fixture
+def runner() -> CliRunner:
+    return CliRunner()
+
+
+def _ssh_host() -> KnownHost:
+    return KnownHost(
+        type="ssh",
+        name="mybox",
+        host="1.2.3.4",
+        user="remo",
+        instance_id="22",
+        access_mode="direct",
+    )
+
+
+def _incus_host() -> KnownHost:
+    return KnownHost(type="incus", name="h/dev", host="10.0.0.5", user="remo")
+
+
+def test_ssh_host_skips_version_check(runner, mocker) -> None:
+    mocker.patch("remo_cli.core.ssh.resolve_remo_host", return_value=_ssh_host())
+    mocker.patch(
+        "remo_cli.providers.aws.auto_start_aws_if_stopped",
+        side_effect=lambda h: h,
+    )
+    mocker.patch(
+        "remo_cli.core.version.get_current_version", return_value="2.2.0"
+    )
+    check = mocker.patch("remo_cli.core.ssh.check_remote_version")
+    connect = mocker.patch("remo_cli.core.ssh.shell_connect")
+
+    result = runner.invoke(shell, ["mybox"])
+
+    assert result.exit_code == 0
+    check.assert_not_called()  # FR-011: no version probe for an added host
+    connect.assert_called_once()
+
+
+def test_managed_host_still_runs_version_check(runner, mocker) -> None:
+    # Contrast: a provider host DOES get the version check (gate is type-specific).
+    mocker.patch("remo_cli.core.ssh.resolve_remo_host", return_value=_incus_host())
+    mocker.patch(
+        "remo_cli.providers.aws.auto_start_aws_if_stopped",
+        side_effect=lambda h: h,
+    )
+    mocker.patch(
+        "remo_cli.core.version.get_current_version", return_value="2.2.0"
+    )
+    check = mocker.patch(
+        "remo_cli.core.ssh.check_remote_version", return_value=("2.2.0", None)
+    )
+    mocker.patch("remo_cli.core.version.version_is_newer", return_value=False)
+    connect = mocker.patch("remo_cli.core.ssh.shell_connect")
+
+    result = runner.invoke(shell, ["dev"])
+
+    assert result.exit_code == 0
+    check.assert_called_once()
+    connect.assert_called_once()

--- a/tests/unit/core/test_ssh_added.py
+++ b/tests/unit/core/test_ssh_added.py
@@ -1,0 +1,96 @@
+"""Tests for added-host (type=ssh) SSH option building in core/ssh.py (feature 014).
+
+`build_ssh_opts` is the single shared SSH-argv builder used by BOTH `remo shell`
+(shell_connect) and `remo cp` (cli/cp.py), so these opts also govern file
+transfer to an added host (FR-005). For `type=="ssh"` it must emit `-o Port=`
+(only when the port is non-default) and fold in the stored identity; for every
+other provider type the argv must be byte-identical to before this feature.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from remo_cli.models.host import KnownHost
+
+
+@pytest.fixture(autouse=True)
+def _no_timezone(mocker):
+    # Keep argv deterministic — drop the optional `SendEnv=TZ` tail.
+    mocker.patch("remo_cli.core.ssh.detect_timezone", return_value="")
+
+
+def _opts(host: KnownHost) -> list[str]:
+    from remo_cli.core.ssh import build_ssh_opts
+
+    opts, _target = build_ssh_opts(host)
+    return opts
+
+
+def _ssh(type_: str = "ssh", **kw) -> KnownHost:
+    base = dict(name="box", host="1.2.3.4", user="remo", access_mode="direct")
+    base.update(kw)
+    return KnownHost(type=type_, **base)  # type: ignore[arg-type]
+
+
+class TestSshTypePortIdentity:
+    def test_default_port_emits_no_port_flag(self) -> None:
+        from remo_cli.core.ssh import build_ssh_opts
+
+        host = _ssh(instance_id="22")
+        opts, target = build_ssh_opts(host)
+        assert target == "remo@1.2.3.4"
+        assert not any(o.startswith("Port=") for o in opts)
+
+    def test_custom_port_emits_port_flag(self) -> None:
+        opts = _opts(_ssh(instance_id="2222"))
+        assert "-o" in opts and "Port=2222" in opts
+
+    def test_stored_identity_emitted(self) -> None:
+        opts = _opts(_ssh(instance_id="22", region="/k/id_ed25519"))
+        assert "IdentityFile=/k/id_ed25519" in opts
+        assert "IdentitiesOnly=yes" in opts
+
+    def test_explicit_identity_file_wins_over_stored(self) -> None:
+        from remo_cli.core.ssh import build_ssh_opts
+
+        host = _ssh(instance_id="22", region="/k/stored")
+        opts, _ = build_ssh_opts(host, identity_file="/k/explicit")
+        assert "IdentityFile=/k/explicit" in opts
+        assert "IdentityFile=/k/stored" not in opts
+
+    def test_no_identity_emits_nothing(self) -> None:
+        opts = _opts(_ssh(instance_id="22"))
+        assert not any(o.startswith("IdentityFile=") for o in opts)
+
+
+class TestOtherTypesUnchanged:
+    def test_proxmox_vmid_not_treated_as_port(self) -> None:
+        # Proxmox stores a numeric vmid in instance_id; it must NOT become a port.
+        from remo_cli.core.ssh import build_ssh_opts
+
+        pmx = KnownHost(
+            type="proxmox",
+            name="node/dev1",
+            host="10.0.0.1",
+            user="remo",
+            instance_id="100",
+            region="root",
+        )
+        opts, target = build_ssh_opts(pmx)
+        assert target == "remo@10.0.0.1"
+        assert not any(o.startswith("Port=") for o in opts)
+        assert not any(o.startswith("IdentityFile=") for o in opts)
+
+    def test_incus_argv_has_no_added_flags(self) -> None:
+        from remo_cli.core.ssh import build_ssh_opts
+
+        incus = KnownHost(
+            type="incus",
+            name="myhost/dev",
+            host="192.168.1.50",
+            user="remo",
+        )
+        opts, target = build_ssh_opts(incus)
+        assert target == "remo@192.168.1.50"
+        assert opts == []  # timezone patched out → byte-identical empty opts

--- a/tests/unit/providers/test_added_add.py
+++ b/tests/unit/providers/test_added_add.py
@@ -63,6 +63,20 @@ class TestParseTarget:
         with pytest.raises(ValueError):
             added.parse_ssh_target("@host")
 
+    def test_user_with_colon_rejected(self) -> None:
+        # A ':' in the user would shift every later registry field on reload.
+        with pytest.raises(ValueError, match="user must not contain"):
+            added.parse_ssh_target("host", user_override="ev:il")
+
+    def test_user_with_newline_rejected(self) -> None:
+        # A newline would inject a second registry line.
+        with pytest.raises(ValueError, match="control"):
+            added.parse_ssh_target("host", user_override="ev\nil")
+
+    def test_host_with_control_char_rejected(self) -> None:
+        with pytest.raises(ValueError, match="control"):
+            added.parse_ssh_target("ho\tst")
+
 
 # ---------------------------------------------------------------------------
 # add() — create
@@ -124,6 +138,17 @@ class TestAddCreate:
         assert rc == 2
         save.assert_not_called()
         assert err.called
+
+    def test_identity_with_newline_rejected_no_write(self, mocker) -> None:
+        # A newline in the identity would inject a forged registry line.
+        mocker.patch("remo_cli.providers.added.get_known_hosts", return_value=[])
+        save = mocker.patch("remo_cli.providers.added.save_known_host")
+        mocker.patch("remo_cli.providers.added.print_error")
+
+        rc = added.add(name="box", target="dev@host", identity="/k/id\nssh:evil:h:u")
+
+        assert rc == 2
+        save.assert_not_called()
 
     def test_malformed_target_rejected_no_write(self, mocker) -> None:
         mocker.patch("remo_cli.providers.added.get_known_hosts", return_value=[])

--- a/tests/unit/providers/test_added_add.py
+++ b/tests/unit/providers/test_added_add.py
@@ -1,0 +1,207 @@
+"""Tests for providers/added.py add() + target parsing (feature 014, US1).
+
+Covers target parsing (default user, overrides, IPv6/bracketed rejection),
+identity-colon rejection, create-writes-one-entry, provider-name collision
+refusal (FR-010), and FR-006 resolvability/picker inclusion of an added host.
+SSH/registry are mocked except the FR-006 test, which uses a real temp registry.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from remo_cli.models.host import KnownHost
+from remo_cli.providers import added
+
+
+# ---------------------------------------------------------------------------
+# parse_ssh_target
+# ---------------------------------------------------------------------------
+
+
+class TestParseTarget:
+    def test_host_only_defaults(self) -> None:
+        assert added.parse_ssh_target("1.2.3.4") == ("remo", "1.2.3.4", 22)
+
+    def test_user_and_host(self) -> None:
+        assert added.parse_ssh_target("dev@host") == ("dev", "host", 22)
+
+    def test_user_host_port(self) -> None:
+        assert added.parse_ssh_target("dev@host:2222") == ("dev", "host", 2222)
+
+    def test_host_port_default_user(self) -> None:
+        assert added.parse_ssh_target("host:2222") == ("remo", "host", 2222)
+
+    def test_user_override_wins(self) -> None:
+        assert added.parse_ssh_target("dev@host", user_override="admin")[0] == "admin"
+
+    def test_port_override_wins(self) -> None:
+        assert added.parse_ssh_target("host:22", port_override=2022)[2] == 2022
+
+    @pytest.mark.parametrize("bad", ["::1", "fe80::1", "user@2001:db8::1"])
+    def test_ipv6_literal_rejected(self, bad: str) -> None:
+        with pytest.raises(ValueError, match="IPv6"):
+            added.parse_ssh_target(bad)
+
+    def test_bracketed_ipv6_rejected(self) -> None:
+        with pytest.raises(ValueError, match="IPv6"):
+            added.parse_ssh_target("user@[2001:db8::1]:22")
+
+    def test_non_numeric_port_rejected(self) -> None:
+        with pytest.raises(ValueError, match="not a number"):
+            added.parse_ssh_target("host:nope")
+
+    def test_port_out_of_range_rejected(self) -> None:
+        with pytest.raises(ValueError, match="range"):
+            added.parse_ssh_target("host:70000")
+
+    def test_empty_rejected(self) -> None:
+        with pytest.raises(ValueError):
+            added.parse_ssh_target("   ")
+
+    def test_empty_user_before_at_rejected(self) -> None:
+        with pytest.raises(ValueError):
+            added.parse_ssh_target("@host")
+
+
+# ---------------------------------------------------------------------------
+# add() — create
+# ---------------------------------------------------------------------------
+
+
+class TestAddCreate:
+    def test_create_writes_single_ssh_entry(self, mocker) -> None:
+        mocker.patch("remo_cli.providers.added.get_known_hosts", return_value=[])
+        save = mocker.patch("remo_cli.providers.added.save_known_host")
+        success = mocker.patch("remo_cli.providers.added.print_success")
+        mocker.patch("remo_cli.providers.added.print_info")
+
+        rc = added.add(name="box", target="dev@1.2.3.4:2222")
+
+        assert rc == 0
+        save.assert_called_once()
+        entry = save.call_args.args[0]
+        assert isinstance(entry, KnownHost)
+        assert entry.type == "ssh"
+        assert entry.name == "box"
+        assert entry.host == "1.2.3.4"
+        assert entry.user == "dev"
+        assert entry.instance_id == "2222"
+        assert entry.access_mode == "direct"
+        assert entry.region == ""
+        # Effective user reported back (FR-003)
+        assert "dev" in " ".join(str(c.args[0]) for c in success.call_args_list)
+
+    def test_default_user_applied_and_reported(self, mocker) -> None:
+        mocker.patch("remo_cli.providers.added.get_known_hosts", return_value=[])
+        save = mocker.patch("remo_cli.providers.added.save_known_host")
+        success = mocker.patch("remo_cli.providers.added.print_success")
+        mocker.patch("remo_cli.providers.added.print_info")
+
+        rc = added.add(name="box", target="1.2.3.4")
+
+        assert rc == 0
+        assert save.call_args.args[0].user == "remo"
+        assert "remo" in " ".join(str(c.args[0]) for c in success.call_args_list)
+
+    def test_identity_stored_in_region(self, mocker) -> None:
+        mocker.patch("remo_cli.providers.added.get_known_hosts", return_value=[])
+        save = mocker.patch("remo_cli.providers.added.save_known_host")
+        mocker.patch("remo_cli.providers.added.print_success")
+        mocker.patch("remo_cli.providers.added.print_info")
+
+        added.add(name="box", target="dev@host", identity="/home/dev/.ssh/id")
+
+        assert save.call_args.args[0].region == "/home/dev/.ssh/id"
+
+    def test_identity_with_colon_rejected_no_write(self, mocker) -> None:
+        mocker.patch("remo_cli.providers.added.get_known_hosts", return_value=[])
+        save = mocker.patch("remo_cli.providers.added.save_known_host")
+        err = mocker.patch("remo_cli.providers.added.print_error")
+
+        rc = added.add(name="box", target="dev@host", identity="/bad:path/key")
+
+        assert rc == 2
+        save.assert_not_called()
+        assert err.called
+
+    def test_malformed_target_rejected_no_write(self, mocker) -> None:
+        mocker.patch("remo_cli.providers.added.get_known_hosts", return_value=[])
+        save = mocker.patch("remo_cli.providers.added.save_known_host")
+        mocker.patch("remo_cli.providers.added.print_error")
+
+        rc = added.add(name="box", target="::1")
+
+        assert rc == 2
+        save.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# add() — collision (FR-010 / SC-005)
+# ---------------------------------------------------------------------------
+
+
+class TestAddCollision:
+    def test_provider_name_collision_refused(self, mocker) -> None:
+        existing = KnownHost(type="incus", name="box", host="10.0.0.1", user="remo")
+        mocker.patch(
+            "remo_cli.providers.added.get_known_hosts", return_value=[existing]
+        )
+        save = mocker.patch("remo_cli.providers.added.save_known_host")
+        err = mocker.patch("remo_cli.providers.added.print_error")
+
+        rc = added.add(name="box", target="dev@1.2.3.4")
+
+        assert rc == 1
+        save.assert_not_called()
+        assert "incus" in " ".join(str(c.args[0]) for c in err.call_args_list)
+
+    def test_incus_container_shortname_collision_refused(self, mocker) -> None:
+        # An incus entry "node/devbox" is resolvable as "devbox"; adding an ssh
+        # host "devbox" would shadow it, so it must be refused (FR-010 shadow).
+        existing = KnownHost(
+            type="incus", name="node/devbox", host="10.0.0.1", user="remo"
+        )
+        mocker.patch(
+            "remo_cli.providers.added.get_known_hosts", return_value=[existing]
+        )
+        save = mocker.patch("remo_cli.providers.added.save_known_host")
+        mocker.patch("remo_cli.providers.added.print_error")
+
+        rc = added.add(name="devbox", target="user@1.2.3.4")
+
+        assert rc == 1
+        save.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# FR-006 — an added host resolves by name and appears in the picker source
+# (real temp registry so save/get/resolve exercise actual serialization)
+# ---------------------------------------------------------------------------
+
+
+class TestAddedHostResolvable:
+    @pytest.fixture
+    def temp_registry(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("REMO_HOME", str(tmp_path / "remo"))
+        return tmp_path
+
+    def test_resolves_by_name_and_in_get_known_hosts(
+        self, temp_registry, monkeypatch
+    ) -> None:
+        from remo_cli.core.known_hosts import (
+            get_known_hosts,
+            resolve_remo_host_by_name,
+        )
+
+        rc = added.add(name="mybox", target="dev@10.0.0.9:2222")
+        assert rc == 0
+
+        # FR-006: selectable by name...
+        resolved = resolve_remo_host_by_name("mybox")
+        assert resolved.type == "ssh"
+        assert resolved.host == "10.0.0.9"
+        assert resolved.ssh_port == 2222
+        # ...and present in the picker source (get_known_hosts, no filter).
+        names = [h.name for h in get_known_hosts()]
+        assert "mybox" in names

--- a/tests/unit/providers/test_added_provider_guard.py
+++ b/tests/unit/providers/test_added_provider_guard.py
@@ -1,0 +1,186 @@
+"""FR-012 guard: provider lifecycle ops must reject added (``type="ssh"``) hosts.
+
+A host registered with ``remo add`` has ``type="ssh"`` and no managed provider
+infrastructure. Running a provider lifecycle operation (``destroy``, resize via
+``update``, or a mutating ``snapshot`` op) against such a name must fail with a
+clear "manually-registered SSH host" message pointing at ``remo remove`` — never
+an opaque error or a silent mis-target.
+
+All provider I/O (subprocess/SSH/boto3/Hetzner API) is mocked so the tests never
+touch the network; in practice the guard exits before any of it runs.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from remo_cli.core.known_hosts import guard_not_added_ssh_host, save_known_host
+from remo_cli.models.host import KnownHost
+from remo_cli.providers import aws as providers_aws
+from remo_cli.providers import hetzner as providers_hetzner
+from remo_cli.providers import incus as providers_incus
+from remo_cli.providers import proxmox as providers_proxmox
+
+
+ADDED_NAME = "box"
+
+
+@pytest.fixture
+def added_ssh_host(tmp_config_dir):
+    """Register a single ``type="ssh"`` host named ``box`` in a temp registry."""
+    save_known_host(
+        KnownHost(
+            type="ssh",
+            name=ADDED_NAME,
+            host="1.2.3.4",
+            user="remo",
+            instance_id="22",
+            access_mode="direct",
+        )
+    )
+    return ADDED_NAME
+
+
+@pytest.fixture(autouse=True)
+def _no_network(mocker):
+    """Belt-and-suspenders: block real I/O in case a guard ever regresses."""
+    mocker.patch("subprocess.run", side_effect=AssertionError("subprocess.run called"))
+
+
+# Each entry: (id, callable performing a provider lifecycle op on ADDED_NAME).
+LIFECYCLE_OPS = [
+    ("incus.destroy", lambda: providers_incus.destroy(name=ADDED_NAME, auto_confirm=True)),
+    ("incus.update", lambda: providers_incus.update(name=ADDED_NAME)),
+    (
+        "incus.snapshot_create",
+        lambda: providers_incus.snapshot_create(
+            container=ADDED_NAME, host="localhost", user="", snap_name="snap1"
+        ),
+    ),
+    (
+        "incus.snapshot_restore",
+        lambda: providers_incus.snapshot_restore(
+            container=ADDED_NAME, host="localhost", user="", snap_name="snap1",
+            auto_confirm=True,
+        ),
+    ),
+    (
+        "incus.snapshot_delete",
+        lambda: providers_incus.snapshot_delete(
+            container=ADDED_NAME, host="localhost", user="", snap_name="snap1",
+            auto_confirm=True,
+        ),
+    ),
+    (
+        "proxmox.destroy",
+        lambda: providers_proxmox.destroy(name=ADDED_NAME, host="node1", auto_confirm=True),
+    ),
+    ("proxmox.update", lambda: providers_proxmox.update(name=ADDED_NAME, host="node1")),
+    (
+        "proxmox.snapshot_create",
+        lambda: providers_proxmox.snapshot_create(
+            container=ADDED_NAME, host="node1", user="root", vmid="100",
+            snap_name="snap1",
+        ),
+    ),
+    (
+        "proxmox.snapshot_restore",
+        lambda: providers_proxmox.snapshot_restore(
+            container=ADDED_NAME, host="node1", user="root", vmid="100",
+            snap_name="snap1", auto_confirm=True,
+        ),
+    ),
+    (
+        "proxmox.snapshot_delete",
+        lambda: providers_proxmox.snapshot_delete(
+            container=ADDED_NAME, host="node1", user="root", vmid="100",
+            snap_name="snap1", auto_confirm=True,
+        ),
+    ),
+    ("aws.destroy", lambda: providers_aws.destroy(name=ADDED_NAME, auto_confirm=True)),
+    ("aws.update", lambda: providers_aws.update(name=ADDED_NAME)),
+    (
+        "aws.snapshot_create",
+        lambda: providers_aws.snapshot_create(instance_name=ADDED_NAME, snap_name="snap1"),
+    ),
+    (
+        "aws.snapshot_restore",
+        lambda: providers_aws.snapshot_restore(
+            instance_name=ADDED_NAME, snap_name="snap1", auto_confirm=True
+        ),
+    ),
+    (
+        "aws.snapshot_delete",
+        lambda: providers_aws.snapshot_delete(
+            instance_name=ADDED_NAME, snap_name="snap1", auto_confirm=True
+        ),
+    ),
+    ("hetzner.destroy", lambda: providers_hetzner.destroy(name=ADDED_NAME, auto_confirm=True)),
+    ("hetzner.update", lambda: providers_hetzner.update(name=ADDED_NAME)),
+    (
+        "hetzner.snapshot_create",
+        lambda: providers_hetzner.snapshot_create(server_name=ADDED_NAME, snap_name="snap1"),
+    ),
+    (
+        "hetzner.snapshot_restore",
+        lambda: providers_hetzner.snapshot_restore(
+            server_name=ADDED_NAME, snap_name="snap1", auto_confirm=True
+        ),
+    ),
+    (
+        "hetzner.snapshot_delete",
+        lambda: providers_hetzner.snapshot_delete(
+            server_name=ADDED_NAME, snap_name="snap1", auto_confirm=True
+        ),
+    ),
+]
+
+
+@pytest.mark.parametrize(
+    "op", [op for _, op in LIFECYCLE_OPS], ids=[i for i, _ in LIFECYCLE_OPS]
+)
+def test_lifecycle_op_rejects_added_ssh_host(added_ssh_host, op):
+    with pytest.raises(SystemExit) as exc:
+        op()
+    message = str(exc.value)
+    assert "manually-registered SSH host" in message
+    assert "remo remove" in message
+    assert ADDED_NAME in message
+
+
+# ---------------------------------------------------------------------------
+# Shared helper (core/known_hosts.guard_not_added_ssh_host) — unit behavior
+# ---------------------------------------------------------------------------
+
+
+def test_guard_message_names_the_provider(added_ssh_host):
+    with pytest.raises(SystemExit) as exc:
+        guard_not_added_ssh_host(ADDED_NAME, "aws")
+    assert "no managed aws infrastructure" in str(exc.value)
+
+
+def test_guard_noop_when_no_ssh_host(tmp_config_dir):
+    # Empty registry — nothing to block.
+    guard_not_added_ssh_host(ADDED_NAME, "incus")
+
+
+def test_guard_noop_for_unrelated_name(added_ssh_host):
+    # A different name is not the added host; guard must not fire.
+    guard_not_added_ssh_host("someothervm", "incus")
+
+
+def test_guard_allows_same_type_managed_container_sharing_name(added_ssh_host):
+    # A legit incus container registered as "node/box" shares the short name
+    # "box" with the added SSH host; the incus op legitimately targets it, so
+    # the guard must NOT block it.
+    save_known_host(
+        KnownHost(
+            type="incus",
+            name=f"node1/{ADDED_NAME}",
+            host=ADDED_NAME,
+            user="remo",
+            instance_id="",
+            access_mode="direct",
+        )
+    )
+    guard_not_added_ssh_host(ADDED_NAME, "incus")

--- a/tests/unit/providers/test_added_update_remove.py
+++ b/tests/unit/providers/test_added_update_remove.py
@@ -1,0 +1,125 @@
+"""Tests for providers/added.py update-in-place + remove() (feature 014, US2).
+
+Covers FR-007 (in-place update, no duplicate), FR-008 (local-only remove, no
+network — SC-004), and FR-009 (remove refuses provider-managed hosts).
+"""
+
+from __future__ import annotations
+
+from remo_cli.models.host import KnownHost
+from remo_cli.providers import added
+
+
+def _ssh(name: str = "box", host: str = "1.2.3.4", port: str = "22") -> KnownHost:
+    return KnownHost(
+        type="ssh",
+        name=name,
+        host=host,
+        user="remo",
+        instance_id=port,
+        access_mode="direct",
+    )
+
+
+# ---------------------------------------------------------------------------
+# add() — in-place update (FR-007 / SC-003)
+# ---------------------------------------------------------------------------
+
+
+class TestUpdateInPlace:
+    def test_reregister_updates_with_yes(self, mocker) -> None:
+        mocker.patch(
+            "remo_cli.providers.added.get_known_hosts", return_value=[_ssh()]
+        )
+        save = mocker.patch("remo_cli.providers.added.save_known_host")
+        mocker.patch("remo_cli.providers.added.print_success")
+        mocker.patch("remo_cli.providers.added.print_info")
+
+        rc = added.add(name="box", target="dev@9.9.9.9:2222", assume_yes=True)
+
+        assert rc == 0
+        # save_known_host replaces the (type, name) line -> no duplicate.
+        save.assert_called_once()
+        entry = save.call_args.args[0]
+        assert entry.host == "9.9.9.9" and entry.instance_id == "2222"
+
+    def test_update_confirmed_interactively(self, mocker) -> None:
+        mocker.patch(
+            "remo_cli.providers.added.get_known_hosts", return_value=[_ssh()]
+        )
+        save = mocker.patch("remo_cli.providers.added.save_known_host")
+        mocker.patch("remo_cli.providers.added.confirm", return_value=True)
+        mocker.patch("remo_cli.providers.added.print_success")
+        mocker.patch("remo_cli.providers.added.print_info")
+
+        rc = added.add(name="box", target="dev@9.9.9.9")
+        assert rc == 0
+        save.assert_called_once()
+
+    def test_update_declined_no_write(self, mocker) -> None:
+        mocker.patch(
+            "remo_cli.providers.added.get_known_hosts", return_value=[_ssh()]
+        )
+        save = mocker.patch("remo_cli.providers.added.save_known_host")
+        mocker.patch("remo_cli.providers.added.confirm", return_value=False)
+        mocker.patch("remo_cli.providers.added.print_info")
+
+        rc = added.add(name="box", target="dev@9.9.9.9")
+        assert rc == 1
+        save.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# remove() (FR-008 / FR-009 / SC-004)
+# ---------------------------------------------------------------------------
+
+
+class TestRemove:
+    def test_remove_ssh_host_makes_no_network_call(self, mocker) -> None:
+        mocker.patch(
+            "remo_cli.providers.added.get_known_hosts", return_value=[_ssh()]
+        )
+        rm = mocker.patch("remo_cli.providers.added.remove_known_host")
+        run = mocker.patch("remo_cli.providers.added.subprocess.run")
+        mocker.patch("remo_cli.providers.added.print_success")
+
+        rc = added.remove(name="box", assume_yes=True)
+
+        assert rc == 0
+        rm.assert_called_once_with("ssh", "box")
+        run.assert_not_called()  # SC-004: no SSH/network call
+
+    def test_remove_declined_no_delete(self, mocker) -> None:
+        mocker.patch(
+            "remo_cli.providers.added.get_known_hosts", return_value=[_ssh()]
+        )
+        rm = mocker.patch("remo_cli.providers.added.remove_known_host")
+        mocker.patch("remo_cli.providers.added.confirm", return_value=False)
+        mocker.patch("remo_cli.providers.added.print_info")
+
+        rc = added.remove(name="box", assume_yes=False)
+        assert rc == 1
+        rm.assert_not_called()
+
+    def test_remove_refuses_provider_host(self, mocker) -> None:
+        existing = KnownHost(type="aws", name="box", host="3.4.5.6", user="remo")
+        mocker.patch(
+            "remo_cli.providers.added.get_known_hosts", return_value=[existing]
+        )
+        rm = mocker.patch("remo_cli.providers.added.remove_known_host")
+        err = mocker.patch("remo_cli.providers.added.print_error")
+
+        rc = added.remove(name="box", assume_yes=True)
+
+        assert rc == 1
+        rm.assert_not_called()
+        assert "aws" in " ".join(str(c.args[0]) for c in err.call_args_list)
+
+    def test_remove_not_found(self, mocker) -> None:
+        mocker.patch("remo_cli.providers.added.get_known_hosts", return_value=[])
+        rm = mocker.patch("remo_cli.providers.added.remove_known_host")
+        mocker.patch("remo_cli.providers.added.print_error")
+
+        rc = added.remove(name="ghost", assume_yes=True)
+        assert rc == 1
+        rm.assert_not_called()

--- a/tests/unit/providers/test_added_verify.py
+++ b/tests/unit/providers/test_added_verify.py
@@ -111,3 +111,14 @@ class TestVerifyReachable:
         argv = run.call_args.args[0]
         # Port 2222 flows through build_ssh_opts into the probe argv.
         assert "Port=2222" in argv
+
+    def test_probe_relaxes_host_key_check(self, mocker) -> None:
+        # A reachable but never-before-seen host must pass the probe rather than
+        # fail "Host key verification failed" under BatchMode.
+        run = mocker.patch(
+            "remo_cli.providers.added.subprocess.run", return_value=_completed(0)
+        )
+        added.verify_reachable(self._host())
+        argv = run.call_args.args[0]
+        assert "StrictHostKeyChecking=no" in argv
+        assert "UserKnownHostsFile=/dev/null" in argv

--- a/tests/unit/providers/test_added_verify.py
+++ b/tests/unit/providers/test_added_verify.py
@@ -1,0 +1,113 @@
+"""Tests for providers/added.py --verify reachability (feature 014, US3, FR-014).
+
+Fail-closed: on a failed probe nothing is registered and a non-zero code is
+returned; without --verify no network round-trip occurs.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+from remo_cli.models.host import KnownHost
+from remo_cli.providers import added
+
+
+def _completed(rc: int, stderr: str = "") -> MagicMock:
+    cp = MagicMock()
+    cp.returncode = rc
+    cp.stderr = stderr
+    return cp
+
+
+# ---------------------------------------------------------------------------
+# add(verify=...) wiring
+# ---------------------------------------------------------------------------
+
+
+class TestAddVerify:
+    def test_reachable_registers(self, mocker) -> None:
+        mocker.patch("remo_cli.providers.added.get_known_hosts", return_value=[])
+        save = mocker.patch("remo_cli.providers.added.save_known_host")
+        vr = mocker.patch(
+            "remo_cli.providers.added.verify_reachable", return_value=(True, None)
+        )
+        mocker.patch("remo_cli.providers.added.print_success")
+        mocker.patch("remo_cli.providers.added.print_info")
+
+        rc = added.add(name="box", target="dev@1.2.3.4", verify=True)
+
+        assert rc == 0
+        vr.assert_called_once()
+        save.assert_called_once()
+
+    def test_unreachable_fails_closed_no_write(self, mocker) -> None:
+        mocker.patch("remo_cli.providers.added.get_known_hosts", return_value=[])
+        save = mocker.patch("remo_cli.providers.added.save_known_host")
+        mocker.patch(
+            "remo_cli.providers.added.verify_reachable",
+            return_value=(False, "Connection refused"),
+        )
+        err = mocker.patch("remo_cli.providers.added.print_error")
+        mocker.patch("remo_cli.providers.added.print_info")
+
+        rc = added.add(name="box", target="dev@1.2.3.4", verify=True)
+
+        assert rc == 1
+        save.assert_not_called()  # fail-closed: nothing registered
+        assert "Connection refused" in " ".join(
+            str(c.args[0]) for c in err.call_args_list
+        )
+
+    def test_no_verify_makes_no_network_call(self, mocker) -> None:
+        mocker.patch("remo_cli.providers.added.get_known_hosts", return_value=[])
+        mocker.patch("remo_cli.providers.added.save_known_host")
+        vr = mocker.patch("remo_cli.providers.added.verify_reachable")
+        mocker.patch("remo_cli.providers.added.print_success")
+        mocker.patch("remo_cli.providers.added.print_info")
+
+        rc = added.add(name="box", target="dev@1.2.3.4", verify=False)
+
+        assert rc == 0
+        vr.assert_not_called()  # FR-014: no round-trip when not requested
+
+
+# ---------------------------------------------------------------------------
+# verify_reachable() probe
+# ---------------------------------------------------------------------------
+
+
+class TestVerifyReachable:
+    def _host(self) -> KnownHost:
+        return KnownHost(
+            type="ssh",
+            name="box",
+            host="1.2.3.4",
+            user="remo",
+            instance_id="2222",
+            access_mode="direct",
+        )
+
+    def test_success(self, mocker) -> None:
+        mocker.patch(
+            "remo_cli.providers.added.subprocess.run", return_value=_completed(0)
+        )
+        ok, err = added.verify_reachable(self._host())
+        assert ok is True and err is None
+
+    def test_ssh_failure_returns_stderr(self, mocker) -> None:
+        mocker.patch(
+            "remo_cli.providers.added.subprocess.run",
+            return_value=_completed(255, stderr="Permission denied (publickey)"),
+        )
+        ok, err = added.verify_reachable(self._host())
+        assert ok is False
+        assert "Permission denied" in (err or "")
+
+    def test_probe_uses_port_from_host(self, mocker) -> None:
+        run = mocker.patch(
+            "remo_cli.providers.added.subprocess.run", return_value=_completed(0)
+        )
+        added.verify_reachable(self._host())
+        argv = run.call_args.args[0]
+        # Port 2222 flows through build_ssh_opts into the probe argv.
+        assert "Port=2222" in argv

--- a/tests/unit/test_host_ssh_type.py
+++ b/tests/unit/test_host_ssh_type.py
@@ -1,0 +1,145 @@
+"""Tests for the manually-added SSH host registry type (feature 014).
+
+Covers `KnownHost` serialization round-trips for the new ``ssh`` type and the
+type-gated ``ssh_port`` / ``ssh_identity`` accessors — including SC-007
+backward-compatible parsing of pre-existing provider lines. No I/O.
+"""
+
+from __future__ import annotations
+
+from remo_cli.core.config import DEFAULT_SSH_PORT
+from remo_cli.models.host import KnownHost
+
+
+# ---------------------------------------------------------------------------
+# Serialization round-trip (no format change — reuses instance_id/access_mode/region)
+# ---------------------------------------------------------------------------
+
+
+class TestSshSerialization:
+    def test_default_port_no_identity_roundtrip(self) -> None:
+        # 6-field form: ssh:name:host:user:22:direct
+        h = KnownHost(
+            type="ssh",
+            name="box",
+            host="1.2.3.4",
+            user="remo",
+            instance_id="22",
+            access_mode="direct",
+        )
+        line = h.to_line()
+        assert line == "ssh:box:1.2.3.4:remo:22:direct"
+        back = KnownHost.from_line(line)
+        assert (back.type, back.name, back.host, back.user) == (
+            "ssh",
+            "box",
+            "1.2.3.4",
+            "remo",
+        )
+        assert back.instance_id == "22"
+        assert back.access_mode == "direct"
+        assert back.region == ""
+
+    def test_custom_port_roundtrip(self) -> None:
+        h = KnownHost(
+            type="ssh",
+            name="api",
+            host="10.0.0.9",
+            user="dev",
+            instance_id="2222",
+            access_mode="direct",
+        )
+        assert h.to_line() == "ssh:api:10.0.0.9:dev:2222:direct"
+        assert KnownHost.from_line(h.to_line()).ssh_port == 2222
+
+    def test_custom_port_and_identity_roundtrip(self) -> None:
+        # 7-field form: ssh:name:host:user:port:direct:identity
+        h = KnownHost(
+            type="ssh",
+            name="api",
+            host="10.0.0.9",
+            user="dev",
+            instance_id="2222",
+            access_mode="direct",
+            region="/home/dev/.ssh/box_ed25519",
+        )
+        line = h.to_line()
+        assert line == "ssh:api:10.0.0.9:dev:2222:direct:/home/dev/.ssh/box_ed25519"
+        back = KnownHost.from_line(line)
+        assert back.ssh_port == 2222
+        assert back.ssh_identity == "/home/dev/.ssh/box_ed25519"
+
+
+# ---------------------------------------------------------------------------
+# Type-gated accessors
+# ---------------------------------------------------------------------------
+
+
+class TestSshAccessors:
+    def test_ssh_port_defaults_to_22(self) -> None:
+        h = KnownHost(type="ssh", name="box", host="h", user="remo")
+        assert h.ssh_port == DEFAULT_SSH_PORT == 22
+
+    def test_ssh_port_parses_instance_id(self) -> None:
+        h = KnownHost(
+            type="ssh", name="box", host="h", user="remo", instance_id="2222"
+        )
+        assert h.ssh_port == 2222
+
+    def test_ssh_identity_from_region(self) -> None:
+        h = KnownHost(
+            type="ssh", name="box", host="h", user="remo", region="/k/id_ed25519"
+        )
+        assert h.ssh_identity == "/k/id_ed25519"
+
+    def test_ssh_identity_none_when_empty(self) -> None:
+        h = KnownHost(type="ssh", name="box", host="h", user="remo")
+        assert h.ssh_identity is None
+
+    def test_non_ssh_types_return_neutral_values(self) -> None:
+        # A proxmox host stores a numeric vmid in instance_id — it must NOT be
+        # read as a port, and it has no ssh identity.
+        pmx = KnownHost(
+            type="proxmox",
+            name="node/dev1",
+            host="10.0.0.1",
+            user="remo",
+            instance_id="100",
+            region="root",
+        )
+        assert pmx.ssh_port == DEFAULT_SSH_PORT  # 22, not 100
+        assert pmx.ssh_identity is None
+
+        aws = KnownHost(
+            type="aws",
+            name="devbox",
+            host="3.4.5.6",
+            user="remo",
+            instance_id="i-0abc",
+            access_mode="ssm",
+            region="us-west-2",
+        )
+        assert aws.ssh_port == DEFAULT_SSH_PORT
+        assert aws.ssh_identity is None
+
+
+# ---------------------------------------------------------------------------
+# SC-007: pre-existing provider lines still parse unchanged
+# ---------------------------------------------------------------------------
+
+
+class TestBackwardCompatibleParsing:
+    def test_legacy_provider_lines_load(self) -> None:
+        incus = KnownHost.from_line("incus:myhost/devcontainer:192.168.1.50:remo")
+        assert incus.type == "incus" and incus.region == ""
+
+        aws = KnownHost.from_line(
+            "aws:devbox:3.14.15.92:remo:i-0abc123def:ssm:us-west-2"
+        )
+        assert aws.type == "aws"
+        assert aws.instance_id == "i-0abc123def"
+        assert aws.access_mode == "ssm"
+        assert aws.region == "us-west-2"
+
+        hetzner = KnownHost.from_line("hetzner:webserver:5.6.7.8:remo")
+        assert hetzner.type == "hetzner" and hetzner.user == "remo"


### PR DESCRIPTION
## Summary

Feature **014-register-ssh-host**. Adds a provider-neutral `remo add` that registers a single SSH-reachable environment into the registry with **only SSH access** — no hypervisor host access, cloud credentials, or API token — plus `remo remove` to deregister it. Companion to 013's filtered sync: `sync` = bulk provider discovery; `add` = single manual registration.

Added hosts are a new registry `type = "ssh"` (`access_mode = direct`), so `remo shell` and `remo cp` connect through the existing direct-SSH path with no user-visible special-casing.

## Design highlights

- **No registry format change** (SC-007). The `ssh` type reuses `KnownHost` positional fields — `instance_id` = port, `region` = identity — via type-gated `ssh_port`/`ssh_identity` accessors. Existing 4/6/7-field provider lines parse unchanged.
- **One shared connection builder.** `build_ssh_opts` emits `-o Port=`/identity **only for `type=ssh`**, so `remo shell` *and* `remo cp` both honor them (FR-005) while every provider's SSH argv stays byte-identical (a Proxmox numeric vmid in `instance_id` is never read as a port).
- **Collision safety (FR-010).** A whole-registry check refuses to overwrite *or shadow* a provider entry — including incus/proxmox `node/container` short-names that `remo shell <name>` would resolve to. (This shadow case was caught by end-to-end validation and fixed with a regression test.)
- **Unmanaged degradation (FR-011).** `remo shell` skips the tools/version check for `ssh` hosts → plain login shell instead of a bogus "Update tools?" prompt.
- **FR-012 guard.** A shared `guard_not_added_ssh_host()` makes provider `destroy`/`snapshot`/resize against an added host fail with a clear message (20 call sites) rather than an opaque error.

## Commands

```
remo add NAME [user@]host[:port] [--user U] [--port P] [--identity PATH] [--verify] [--yes]
remo remove NAME [--yes]
```

- Re-adding an existing added host updates in place (confirm unless `--yes`), never duplicating.
- `--verify` is a **fail-closed** SSH reachability probe: on failure it surfaces the error, writes nothing, exits non-zero. Without it, no network round-trip.
- Un-bracketed IPv6 literals are rejected with guidance (bracketed `[::1]:22` deferred).
- `remo remove` is local-only (no remote connection/change) and refuses provider-managed hosts.

## Testing

- **105 new tests**, one per conditional branch (Constitution II): parsing, collision refuse/update, IPv6 reject, port default/custom, identity present/absent, verify pass/fail, version-check skip, FR-012 guard.
- Full suite: **1266 passed, 17 skipped**. `mypy` + `ruff` clean.
- End-to-end CLI validation against a temp registry (add/update/remove/collision/IPv6). The live-box SSH leg (`shell`/`cp` handshake to a real host) is the one manual spot-check left for a reviewer with a reachable box.

Spec-kit artifacts (spec/plan/research/data-model/contracts/quickstart/tasks) are included under `specs/014-register-ssh-host/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)