### PR TITLE
fix(ci): release-please falls back to GITHUB_TOKEN (works without the PAT)

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -29,13 +29,15 @@ jobs:
       # here because the SHA can't be resolved offline.
       - uses: googleapis/release-please-action@v4
         with:
-          # IMPORTANT: a PAT with `contents` + `pull-requests` write is required
-          # so the tag release-please creates on merge is authored by a real
-          # token and therefore triggers the tag-driven `release.yml` (the PyPI +
-          # Docker publish). A tag created with the default GITHUB_TOKEN does NOT
-          # fire `on: push: tags`, so without this secret the release PR and tag
-          # are still created but nothing publishes until a maintainer re-pushes
-          # the tag. Store the PAT as the `RELEASE_PLEASE_TOKEN` repo secret.
-          token: ${{ secrets.RELEASE_PLEASE_TOKEN }}
+          # Prefer a PAT (`RELEASE_PLEASE_TOKEN`, `contents` + `pull-requests`
+          # write); fall back to GITHUB_TOKEN so release-please still opens and
+          # maintains the release PR out of the box.
+          #
+          # The PAT matters only for the *publish chain*: a tag created with the
+          # default GITHUB_TOKEN does NOT fire `on: push: tags`, so with the
+          # fallback the release PR and tag are still created, but `release.yml`
+          # (PyPI + Docker) won't run until a maintainer re-pushes the tag. Set
+          # the `RELEASE_PLEASE_TOKEN` secret to make merge-to-publish automatic.
+          token: ${{ secrets.RELEASE_PLEASE_TOKEN || secrets.GITHUB_TOKEN }}
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json


### PR DESCRIPTION
The first release-please runs on `main` failed with `Input required and not supplied: token` because `RELEASE_PLEASE_TOKEN` isn't set, so it couldn't open its release PR at all.

Fall back to `GITHUB_TOKEN` (`secrets.RELEASE_PLEASE_TOKEN || secrets.GITHUB_TOKEN`). The workflow already grants `contents: write` + `pull-requests: write`, so with the fallback release-please opens/maintains the release PR out of the box. The PAT now only governs whether the created tag **auto-triggers** `release.yml` (PyPI + Docker) — the previously-documented caveat (a `GITHUB_TOKEN`-created tag doesn't fire `on: push: tags`).

`actionlint` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)