### PR TITLE
fix(ci): scope release-please to pyproject.toml (stop bumping __init__.py sentinel)

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -2,13 +2,20 @@
   "$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json",
   "packages": {
     ".": {
-      "release-type": "python",
+      "release-type": "simple",
       "package-name": "remo-cli",
       "changelog-path": "CHANGELOG.md",
       "include-component-in-tag": false,
       "bump-minor-pre-major": false,
       "draft": false,
-      "prerelease": false
+      "prerelease": false,
+      "extra-files": [
+        {
+          "type": "toml",
+          "path": "pyproject.toml",
+          "jsonpath": "$.project.version"
+        }
+      ]
     }
   }
 }


### PR DESCRIPTION
## Problem

The first release PR (#81) showed the `python` release-type rewriting the fallback sentinel in `src/remo_cli/__init__.py`:

```python
except PackageNotFoundError:
-    __version__ = "0.0.0-dev"
+    __version__ = "2.3.0"
```

That line is the *"package not installed"* sentinel — the real version comes from `importlib.metadata` (per CLAUDE.md). Bumping it means an un-installed source checkout would falsely report the last-released version, and it'd drift on every release.

## Fix

Switch `release-type: python → simple` and add an explicit `extra-files` entry so release-please bumps **only** `[project].version` in `pyproject.toml`:

```json
"release-type": "simple",
"extra-files": [{ "type": "toml", "path": "pyproject.toml", "jsonpath": "$.project.version" }]
```

release-please now updates `pyproject.toml` + `CHANGELOG.md` + the manifest, and never touches `__init__.py`. After this merges, release-please regenerates the open release PR (#81) with the corrected file set — all pre-merge and reviewable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)