### PR TITLE
feat(sync): shared reconcile engine across all four providers (016)

### DIFF
--- a/.specify/feature.json
+++ b/.specify/feature.json
@@ -1,3 +1,3 @@
 {
-  "feature_directory": "specs/015-registry-v2"
+  "feature_directory": "specs/016-sync-reconcile"
 }

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,6 +1,6 @@
 # remo Development Guidelines
 
-Auto-generated from all feature plans. Last updated: 2026-07-25
+Auto-generated from all feature plans. Last updated: 2026-07-26
 
 ## Constitution
 
@@ -15,6 +15,7 @@ See `.specify/memory/constitution.md` for project principles and non-negotiable 
 - FastAPI/Uvicorn + WebSockets (backend, optional `web` extra), TypeScript/Vite/React + ghostty-web (frontend), Bash (`remo-host` host command templated by Ansible) (010-web-session-interface)
 - Stdlib `urllib.request` CLI setup client + token-gated `/api/v1/setup/*` FastAPI surface; service state in flat files under the writable `REMO_HOME` volume (`web-identity/` keypair + service known_hosts, `~/.config/remo/web-service.json` saved credentials, `cache_version: 2`) (011-web-adopt; payload versioning updated by 015-registry-v2)
 - `core/registry.py`: stdlib `json` (format), `fcntl` (advisory locking via a `registry.lock` sidecar), `os.replace` (atomic writes). No new runtime deps. Setup API mirror payload moved to v2 (`contracts/mirror-payload-v2.md`) with a `payload_versions` capability handshake; an upgraded service still accepts v1 payloads. (015-registry-v2)
+- `core/reconcile.py`: provider-agnostic sync-reconcile engine (`SyncScope`, `DiscoveredHost`, `ProbeResult`, `build_plan` (pure), `render_plan`, the consent gate, `apply_plan` via the existing `mutate_registry()`, and the `run_sync` driver). No new runtime deps — stdlib only, built on `core/registry.py`/`core/output.py` as-is. (016-sync-reconcile)
 
 - Ansible 2.14+ / YAML + `ansible.builtin`, `community.general` (for zypper module) (001-bootstrap-incus-host)
 
@@ -190,6 +191,7 @@ Provider SDKs (boto3, hcloud) are lazy-imported with clear error messages if mis
 - Ansible 2.14+ / YAML: Follow standard conventions plus Constitution principles
 
 ## Recent Changes
+- 016-sync-reconcile: Replaced all four providers' hand-rolled clear-then-repopulate `sync` with one shared reconcile engine (`core/reconcile.py`): each provider now contributes only a read-only probe (every host in scope, marked and unmarked alike, plus a `complete` enumeration-completeness flag), and the engine diffs against the in-scope registry slice, prints a scope-first plan, gates removals behind a `--yes`/interactive/`--dry-run`-aware consent gate, and writes exactly once via the existing `mutate_registry()` (aborting with a conflict error, no auto-retry, if the in-scope slice moved between plan and write). Fixes three data-loss bugs: Hetzner's `sync` wiped its entire registry slice on every run (the `remo` label it filtered on was never applied by anything — now applied at create and backfillable via `update`), a bare `remo aws sync` destroyed every other region's entries, and `remo aws stop` followed by any sync destroyed the stopped instance's own entry. The managed marker now gates only *addition* (`--all` widens it, per-provider — unrestricted for Incus/Proxmox/Hetzner, narrowed to `remo-*`-named instances for AWS); provider presence alone protects an existing entry from removal. New `--yes`/`--dry-run` on all four providers' `sync`, new `--all` on AWS/Hetzner. No registry schema change.
 - 015-registry-v2: Replaced the colon-delimited `known_hosts` registry with a versioned JSON `registry.json` (format v2, named per-type fields, no positional overloading) via a single new accessor `core/registry.py` (parse/serialize/validate/advisory-lock/migrate) shared by the CLI, providers, and web service; lazy, lossless, idempotent CLI migration (`known_hosts` → `known_hosts.v1.bak`); `core/known_hosts.py` slimmed to thin delegates; the setup API's adoption mirror moved to payload v2 with a `payload_versions` capability handshake (an upgraded service still accepts v1 payloads); push delta-cache bumped to `cache_version: 2`.
 - 011-web-adopt: Added CLI-to-web adoption — unconfigured boot with service-scoped ed25519 identity, token-gated `/api/v1/setup/*` (REMO_WEB_API_TOKEN, fail-closed), `remo web adopt`/`remo web push` (registry mirror + workstation-verified host keys + idempotent `remo-web@<id>` authorized_keys entries), AwaitingAdoption SPA page.
 - 010-web-session-interface: Added remo-web Docker service (FastAPI + React/ghostty-web) brokering browser terminal sessions across all Remo-managed instances via a new remo-host SSH command; web extra + remo web {serve,check} CLI group.

--- a/README.md
+++ b/README.md
@@ -288,7 +288,10 @@ remo remove NAME [--yes]            # Deregister an added host (local-only)
 remo hetzner create                 # Provision VM
 remo hetzner list                   # List registered VMs
 remo hetzner info [--name N]        # Show type, cores, memory, volume size
-remo hetzner sync                   # Discover existing VMs
+remo hetzner sync                   # Reconcile registry with existing VMs
+remo hetzner sync --all             # Also adopt unlabelled VMs
+remo hetzner sync --yes             # Skip the removal confirmation
+remo hetzner sync --dry-run         # Preview the plan, change nothing
 remo hetzner update                 # Update dev tools
 remo hetzner update --volume-size 100   # Grow persistent volume + FS
 remo hetzner destroy [--yes]        # Tear down (keeps volume)
@@ -297,7 +300,10 @@ remo hetzner destroy [--yes]        # Tear down (keeps volume)
 remo aws create                     # Provision EC2 via SSM
 remo aws create --spot              # Use spot instance (~70% savings)
 remo aws list                       # List registered instances
-remo aws sync                       # Discover existing instances
+remo aws sync                       # Reconcile registry with existing instances
+remo aws sync --all                 # Also adopt untagged remo-* named instances
+remo aws sync --yes                 # Skip the removal confirmation
+remo aws sync --dry-run             # Preview the plan, change nothing
 remo aws update                     # Update dev tools
 remo aws update --volume-size 100   # Grow EBS volume + FS in place
 remo aws stop [--yes]               # Stop instance (pause billing)
@@ -310,8 +316,10 @@ remo aws info [--name N]            # Show type, cores, memory, EBS size
 remo incus create --name <n> [--host H]  # Create container
 remo incus list                     # List registered containers
 remo incus info --name <n>          # Show cores, memory, root size
-remo incus sync [--host H]          # Discover remo-managed containers
+remo incus sync [--host H]          # Reconcile registry with remo-managed containers
 remo incus sync [--host H] --all    # Also adopt non-remo containers on the host
+remo incus sync [--host H] --yes    # Skip the removal confirmation
+remo incus sync [--host H] --dry-run   # Preview the plan, change nothing
 remo incus update --name <n>        # Update dev tools (also marks as remo-managed)
 remo incus update --name <n> --volume-size 40 --cores 4 --memory 4096
 remo incus destroy --name <n> [--yes]    # Destroy container
@@ -321,8 +329,10 @@ remo incus bootstrap                # Initialize Incus on host
 remo proxmox create --name <n> --host <node>  # Create LXC container
 remo proxmox list                   # List registered containers
 remo proxmox info --name <n>        # Show cores, memory, rootfs size
-remo proxmox sync --host <node>     # Discover remo-managed containers
+remo proxmox sync --host <node>     # Reconcile registry with remo-managed containers
 remo proxmox sync --host <node> --all   # Also adopt non-remo containers on the node
+remo proxmox sync --host <node> --yes   # Skip the removal confirmation
+remo proxmox sync --host <node> --dry-run   # Preview the plan, change nothing
 remo proxmox update --name <n>      # Update dev tools (also marks as remo-managed)
 remo proxmox update --name <n> --volume-size 40 --cores 4 --memory 4096
 remo proxmox destroy --name <n> [--yes] [--purge]   # Destroy container
@@ -408,20 +418,31 @@ discovery states, terminal limits, troubleshooting, and upgrade notes:
 
 **Installed remo on a new machine with existing instances?**
 ```bash
-remo aws sync                          # Discover AWS instances with 'remo' tag
-remo hetzner sync                      # Discover Hetzner VMs with 'remo' label
-remo incus sync                        # Discover remo-managed Incus containers
-remo proxmox sync --host <node>        # Discover remo-managed Proxmox LXC containers
+remo aws sync                          # Reconcile registry with AWS instances tagged 'remo'
+remo hetzner sync                      # Reconcile registry with Hetzner VMs labelled 'remo'
+remo incus sync                        # Reconcile registry with remo-managed Incus containers
+remo proxmox sync --host <node>        # Reconcile registry with remo-managed Proxmox LXC containers
 ```
 
-All four providers now filter `sync` to the containers/instances **remo created**.
-On Incus/Proxmox, `remo`-created containers are marked at provision time (an Incus
-`user.remo=true` config key or a Proxmox `remo` guest tag), and a default `sync`
-registers only those. To adopt containers `remo` did not create, use
-`sync --all` (a one-time, unmarked adoption) or `remo <provider> update <name>`
-(permanently marks one). Containers created before this feature are unmarked;
-the first default `sync` after upgrading names them and prints both remedies
-rather than silently dropping or re-marking them.
+`sync` reconciles the registry against what a provider actually has within one
+bounded scope (an Incus/Proxmox host, an AWS region, or — for Hetzner — the
+whole project): additions and updates apply immediately, but removing a
+registry entry that's genuinely gone always requires confirmation first,
+either interactively or with `--yes`. `--dry-run` prints the plan — what
+would be added, updated, removed, and why — without changing anything or
+prompting.
+
+A default `sync` only *adds* containers/instances that carry the `remo`
+managed marker (an Incus `user.remo=true` config key, a Proxmox `remo` guest
+tag, an AWS `tag:remo=true`, or a Hetzner `remo` label) — but an existing
+registry entry is never removed just because it lacks that marker; presence
+at the provider is what protects it, independently of the marker. To adopt
+unmarked containers/instances into the registry, use `sync --all` (per-run,
+prints what it widened to) or `remo <provider> update <name>` (marks one
+permanently, and for Hetzner also backfills the label on the server itself).
+Containers/instances that predate this marker convention are unmarked; a
+default `sync` retains them, names them, and prints both remedies rather than
+dropping or silently re-marking them.
 
 **SSH connection fails?**
 ```bash

--- a/ansible/roles/hetzner_server/tasks/main.yml
+++ b/ansible/roles/hetzner_server/tasks/main.yml
@@ -65,6 +65,8 @@
       - "{{ hetzner_ssh_key_name }}"
     firewalls:
       - "{{ hetzner_server_name }}-firewall"
+    labels:
+      remo: "true"
     state: present
   register: hetzner_server_result
 

--- a/docs/aws.md
+++ b/docs/aws.md
@@ -215,7 +215,8 @@ The principal `remo` uses (your local IAM user, SSO session, or assumed role) ne
 |---|---|
 | `create` | `RunInstances`, `DescribeInstances`, `DescribeImages`, `DescribeVolumes`, `CreateTags`, `CreateVolume`, `DescribeSecurityGroups`, `CreateSecurityGroup`, `AuthorizeSecurityGroupIngress`, `CreateKeyPair`, `ImportKeyPair`, `DescribeKeyPairs`, `RunInstances`, `iam:PassRole`, `iam:GetRole`, `iam:CreateRole`, `iam:AttachRolePolicy`, `iam:GetInstanceProfile`, `iam:CreateInstanceProfile`, `iam:AddRoleToInstanceProfile` |
 | `destroy` | `DescribeInstances`, `TerminateInstances`, `DescribeVolumes`, `DeleteVolume`, `DescribeSecurityGroups`, `DeleteSecurityGroup`, `DescribeKeyPairs`, `DeleteKeyPair`, plus the IAM cleanup mirror of `create` |
-| `update`, `info`, `list`, `sync` | `DescribeInstances`, `DescribeVolumes` (+ `ModifyVolume` and `DescribeVolumesModifications` for `update --volume-size`) |
+| `update`, `info`, `list` | `DescribeInstances`, `DescribeVolumes` (+ `ModifyVolume` and `DescribeVolumesModifications` for `update --volume-size`) |
+| `sync` | `DescribeInstances` — describes every non-terminal instance in the region (paginated; not filtered by the `remo` tag) and reads each instance's tags to determine its registry name and managed-marker state. No new action beyond what `update`/`info`/`list` already require. |
 | `stop`, `start`, `reboot` | `DescribeInstances`, `StopInstances` / `StartInstances` / `RebootInstances` |
 | `snapshot create` | `DescribeInstances`, `DescribeVolumes`, `DescribeSnapshots`, `CreateSnapshot`, `CreateTags` |
 | `snapshot list` | `DescribeInstances`, `DescribeVolumes`, `DescribeSnapshots` |

--- a/docs/hetzner.md
+++ b/docs/hetzner.md
@@ -93,6 +93,45 @@ Available tools: `docker`, `user_setup`, `nodejs`, `devcontainers`, `github_cli`
 | `--yes`, `-y` | Skip confirmation prompt |
 | `--remove-volume` | Also delete the persistent volume (destroys all data) |
 
+### Sync
+
+```bash
+# Reconcile the registry with every server in the Hetzner Cloud project
+remo hetzner sync
+
+# Also adopt servers without the remo label
+remo hetzner sync --all
+
+# Skip the removal confirmation prompt
+remo hetzner sync --yes
+
+# Preview the plan without changing the registry or prompting
+remo hetzner sync --dry-run
+```
+
+`sync` reconciles the registry against every server in the project (Hetzner
+has no per-node/per-region boundary to scope to). Servers still present in
+the project are never removed just because they lack the `remo` label —
+only a server that has genuinely disappeared, in a fully-paginated listing,
+is proposed for removal, and that removal always requires confirmation (or
+`--yes`) first. `--dry-run` prints the same plan without prompting or
+changing anything, and always exits `0`.
+
+By default only servers carrying the `remo` label are *added*; `--all`
+widens that to every server in the project for this run only — Hetzner has
+no naming convention to narrow to, so `--all` here is deliberately broad.
+
+The `remo` label is applied automatically at `create` time. A server created
+before this label existed (or one whose label was somehow lost) can be
+backfilled permanently — without disturbing any of its other labels — by
+running `remo hetzner update`.
+
+| Option | Description |
+|--------|-------------|
+| `--all` | Also register servers without the managed label (this run only) |
+| `--yes`, `-y` | Skip the removal confirmation prompt |
+| `--dry-run` | Show what would change without writing to the registry |
+
 ## Features
 
 | Feature | Description |

--- a/docs/incus.md
+++ b/docs/incus.md
@@ -105,6 +105,47 @@ Available tools: `docker`, `user_setup`, `nodejs`, `devcontainers`, `github_cli`
 | `--host <host>` | Incus host |
 | `--user <user>` | SSH user for host |
 
+### Sync
+
+```bash
+# Reconcile the registry with what's actually on the host (default project only)
+remo incus sync --host myserver --user paul
+
+# Also adopt containers without the remo managed marker
+remo incus sync --host myserver --user paul --all
+
+# Skip the removal confirmation prompt
+remo incus sync --host myserver --user paul --yes
+
+# Preview the plan without changing the registry or prompting
+remo incus sync --host myserver --user paul --dry-run
+```
+
+`sync` reconciles the registry against every container on the given host's
+**default project** (`--all-projects` is deliberately not queried, so
+containers in other projects are outside this run's scope and are never
+read, matched, or touched). Containers and instances still present at the
+provider are never removed just because they lack the marker — only a
+container that has genuinely disappeared, in a fully-enumerated scope, is
+proposed for removal, and that removal always requires confirmation (or
+`--yes`) before it's written. `--dry-run` prints the same plan — additions,
+updates, removals, and any unmarked containers skipped or retained — without
+prompting or changing anything, and always exits `0`.
+
+By default only containers carrying the `user.remo=true` managed marker are
+*added*; `--all` widens that to every container on the host for this run
+only. To mark one permanently instead, use `remo incus update --name <n>
+--host <h>`.
+
+| Option | Description |
+|--------|-------------|
+| `--host <host>` | Incus host (default: `localhost`) |
+| `--user <user>` | SSH user for remote Incus host |
+| `--use-ip` | Store each container's resolved IP instead of its name |
+| `--all` | Also register containers without the managed marker (this run only) |
+| `--yes`, `-y` | Skip the removal confirmation prompt |
+| `--dry-run` | Show what would change without writing to the registry |
+
 ## Features
 
 | Feature | Description |

--- a/docs/proxmox.md
+++ b/docs/proxmox.md
@@ -61,8 +61,15 @@ remo proxmox update --name dev1 --volume-size 40
 # Live-tune CPU and/or memory limits (cgroup v2)
 remo proxmox update --name dev1 --cores 4 --memory 4096
 
-# Sync remo's registry with the node (rebuild known_hosts entries)
+# Reconcile the registry with the node (this node's LXC containers only —
+# other nodes' entries are never read, matched, or touched)
 remo proxmox sync --host prox01 --user root
+
+# Also adopt containers without the remo tag, skip the removal prompt, or
+# preview the plan without changing anything
+remo proxmox sync --host prox01 --user root --all
+remo proxmox sync --host prox01 --user root --yes
+remo proxmox sync --host prox01 --user root --dry-run
 
 # Destroy a container (rootfs is removed regardless)
 remo proxmox destroy --name dev1 --yes

--- a/specs/016-sync-reconcile/checklists/requirements.md
+++ b/specs/016-sync-reconcile/checklists/requirements.md
@@ -1,0 +1,44 @@
+# Specification Quality Checklist: Unified Sync Reconcile
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-07-25
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+- **Iteration 1**: 3 [NEEDS CLARIFICATION] markers raised (Hetzner label gap, instance-state persistence, adopted-entry re-sync). All three affected scope, so they were presented to the user rather than defaulted.
+- **Iteration 2**: All three resolved and recorded in the Clarifications section with their downstream FR/SC references. Spec updated: FR-021–FR-024 (marker gates addition, not removal), FR-019 + SC-011 (state is display-only, no schema change), FR-031–FR-035 (Hetzner label applied at create, backfilled via update). Stale cross-references corrected after renumbering; FR-001–FR-038 and SC-001–SC-011 verified contiguous with no gaps or duplicates.
+- **Iteration 3 (`/speckit-clarify`)**: 5 further ambiguities identified and resolved — entry↔host matching key (FR-039), enumeration completeness under pagination (FR-040, SC-014), field ownership on update (FR-041), `--dry-run` preview (FR-042, SC-012), and the exit-code contract (FR-043, SC-013). Checklist re-validated against the updated spec: 16/16 → 16/16, no state changes and no regressions. FR-001–FR-043 and SC-001–SC-014 verified contiguous.
+- **Iteration 4 (post-planning `/speckit-clarify`)**: 3 further gaps resolved — all latent contradictions rather than open choices. FR-044 (the query must not filter on the managed marker; a server-side marker filter made FR-022 unenforceable on AWS and Hetzner), FR-045 (the scope line must name the enumeration boundary, since a container moved between Incus projects or Proxmox nodes reads as absent), and FR-046 (a same-scope registry change between plan and write aborts the write, no auto-retry). Added SC-015 and SC-016. Checklist re-validated: 16/16 → 16/16, no state changes and no regressions. FR-001–FR-046 and SC-001–SC-016 verified contiguous.
+- CLI command and flag names (`remo aws sync`, `--all`, `--use-ip`, `--yes`, `--dry-run`) are retained deliberately: for a CLI tool these are the user-facing contract, not implementation detail. No internal module, class, or language references appear in the spec.
+- Scope notes for `/speckit-plan`:
+  - The Hetzner clarification extends this feature beyond the CLI/registry layer into the Hetzner provisioning path (Ansible role).
+  - FR-040 requires the desired-hosts query to report enumeration completeness, so the provider contract is a host set *plus a completeness signal*, not a bare list. AWS and Hetzner listings are paginated today; neither is currently paginated to exhaustion.
+  - FR-043 introduces a three-value exit-code contract scoped to sync, departing from the codebase's uniform exit-1 convention.
+
+**Status: all 16 items pass — ready for `/speckit-plan`.**

--- a/specs/016-sync-reconcile/contracts/cli-sync.md
+++ b/specs/016-sync-reconcile/contracts/cli-sync.md
@@ -1,0 +1,113 @@
+# Contract: `remo <provider> sync` CLI surface
+
+**Feature**: `016-sync-reconcile`
+
+The user-facing contract. All four providers conform (FR-001).
+
+## Command shapes
+
+```
+remo incus   sync [--host H] [--user U] [--use-ip] [--all] [--yes|-y] [--dry-run]
+remo proxmox sync  --host H  [--user U] [--use-ip] [--all] [--yes|-y] [--dry-run]
+remo aws     sync [--region R]                     [--all] [--yes|-y] [--dry-run]
+remo hetzner sync                                  [--all] [--yes|-y] [--dry-run]
+```
+
+New on every provider: `--yes/-y`, `--dry-run`.
+New on AWS and Hetzner: `--all`.
+Hetzner gains its first flags at all.
+
+### Flag semantics
+
+| Flag | Meaning |
+|---|---|
+| `--all` | Widen additions to hosts lacking the managed marker (FR-028). Does **not** affect removals, and does **not** change what the provider query enumerates — the query always sees unmarked hosts (FR-044). |
+| `--yes`, `-y` | Skip the removal confirmation (FR-012). Does not suppress the removal report. |
+| `--dry-run` | Print the plan, change nothing, prompt for nothing, exit 0 (FR-042). Takes precedence over `--yes`. |
+| `--use-ip` | Incus/Proxmox only, unchanged (FR-025). |
+| `--host` / `--user` | Incus/Proxmox only, unchanged. `--host` required for Proxmox. |
+| `--region` | AWS only. Absent → the existing default-region resolution (`_effective_region`). |
+
+### Click wiring
+
+Follow the AWS explicit-destination style so the provider kwarg needs no renaming:
+
+```python
+@click.option("--yes", "-y", "auto_confirm", is_flag=True, default=False,
+              help="Skip the removal confirmation prompt.")
+@click.option("--dry-run", "dry_run", is_flag=True, default=False,
+              help="Show what would change without writing to the registry.")
+@click.option("--all", "include_all", is_flag=True,
+              help="Also register instances that lack the remo managed marker.")
+```
+
+Each wrapper must `sys.exit(rc)` — today none of the four does, which is why sync always exits 0 (R9).
+
+## Exit codes (FR-043)
+
+| Code | Meaning |
+|---|---|
+| `0` | Plan applied, or nothing to do, or `--dry-run` completed |
+| `1` | Failure: provider query failed, write failed, or the plan was refused (ambiguous / conflicted) |
+| `2` | **Reserved** — argument/usage errors, owned by Click and `remo shell`. Never emitted by sync. |
+| `3` | Aborted with no change: confirmation declined, or removals needed consent with no TTY and no `--yes` |
+
+## Output contract
+
+Ordered sections. Empty sections are omitted; `--dry-run` prefixes the header.
+
+```
+Reconciling aws region us-west-2...
+
+  + added      2   devbox, buildbox
+  ~ updated    1   webhost
+  = unchanged  3   alpha, beta, gamma (stopped)
+  - removed    1   oldbox
+
+The following 1 entry will be REMOVED from the registry:
+  - oldbox (i-0abc123, us-west-2)
+
+Remove it? [y/N]
+```
+
+Rules:
+
+1. **Scope line first** (FR-003), before any change is described.
+2. Every non-empty category names its entries (FR-007). Counts reflect what is actually written — not the pre-filter result count, which is what two providers report today.
+3. **No-op** prints `Nothing to reconcile — registry already matches <scope>.` and exits 0 (FR-007, user story 4 scenario 4).
+4. **Non-running state** is annotated inline on the entry, e.g. `beta (stopped)` (FR-019). Never persisted.
+5. **Removals** are listed individually before the prompt (FR-010), with enough identifying detail to recognise them.
+6. **Unmarked retained entries** get a note plus the permanent-marking hint (FR-024):
+   `2 retained entries are not remo-marked: legacy1, legacy2` / `Mark permanently: remo incus update --name <n> --host <h>`
+7. **Skipped unmarked hosts** name themselves and both remedies (FR-029):
+   `Skipped 3 unmarked instance(s): a, b, c` / `Adopt this run: … --all` / `Mark permanently: … update …`
+8. **Adoption criteria** are stated whenever `--all` is set (FR-030), e.g.
+   `--all: also matching instances named remo-* without the remo tag` (AWS) or
+   `--all: every server in this Hetzner project` (Hetzner).
+9. **Suppressed removals** warn explicitly (FR-040):
+   `Removals skipped: the provider listing was incomplete (<reason>). Additions and updates were applied.`
+10. Errors go through `print_error` (stderr); everything else through `print_info`/`print_success`/`print_warning` (stdout), matching `core/output.py`.
+
+## Behavioural guarantees
+
+| # | Guarantee | FR |
+|---|---|---|
+| C1 | Entries outside the scope are never read as removal candidates, modified, or counted | FR-004 |
+| C2 | Exactly one registry write per run; none at all on dry-run, decline, or failure | FR-006, SC-006 |
+| C3 | A failed provider query leaves the registry untouched and exits 1 | FR-009 |
+| C4 | Removals always require consent; additions and updates never prompt | FR-010, FR-011 |
+| C5 | Declining changes nothing — not the additions either | FR-013 |
+| C6 | No provider-side state is mutated | FR-008 |
+| C7 | Re-running against an unchanged provider is a no-op and does not prompt | FR-036, SC-007 |
+| C8 | An unmarked host that still exists is never removed | FR-022 |
+| C9 | Removals require a provably complete enumeration | FR-040 |
+| C10 | The query is never narrowed by the managed marker | FR-044 |
+| C11 | The scope line names the boundary actually enumerated | FR-045 |
+| C12 | A same-scope registry change between plan and write aborts the write | FR-046 |
+
+## Compatibility notes
+
+- Additive for incus/proxmox: existing invocations keep working. The `--all` warning text changes — the claim that "a later default `sync` will drop those unmarked one(s) again" is now false and must be deleted (FR-026).
+- Behaviour change for AWS: bare `remo aws sync` no longer touches other regions, and stopped instances are retained.
+- Behaviour change for Hetzner: `sync()` gains parameters; it previously took none.
+- `sync` return type changes from `None` to `int` in all four providers, breaking `tests/unit/cli/providers/test_incus_sync_all.py` and `test_proxmox_sync_all.py` (they assert exit 0 against a `None`-returning mock).

--- a/specs/016-sync-reconcile/contracts/provider-probe.md
+++ b/specs/016-sync-reconcile/contracts/provider-probe.md
@@ -1,0 +1,96 @@
+# Contract: provider probe interface
+
+**Feature**: `016-sync-reconcile`
+
+The internal seam between `core/reconcile.py` and the four providers. A provider's *only* contribution to sync is one function conforming to this contract (FR-002, SC-005).
+
+## Signature
+
+```python
+ProbeFn = Callable[[], ProbeResult]
+```
+
+The driver receives a zero-argument thunk; each provider closes over its own scope and flags:
+
+```python
+def sync(host="localhost", user="", use_ip=False, include_all=False,
+         auto_confirm=False, dry_run=False) -> int:
+    scope = SyncScope(type="incus", host=host)
+    return run_sync(
+        scope,
+        lambda: _probe(scope, user=user, use_ip=use_ip, include_all=include_all),
+        auto_confirm=auto_confirm,
+        dry_run=dry_run,
+    )
+```
+
+That is the entire body of each provider's `sync`. All reporting, diffing, consent, and writing lives in `run_sync`.
+
+## Obligations
+
+A conforming probe **MUST**:
+
+1. **Return every host it can see in scope** — marked and unmarked alike. Filtering unmarked hosts out of the result is the bug this feature removes: presence is what protects an existing entry from removal (FR-022), independently of eligibility for addition (FR-021).
+   **The marker must not narrow the query itself** (FR-044). Only conditions establishing genuine non-existence — a terminated instance — may be pushed server-side. A marker-filtered query cannot distinguish "deleted" from "lost its tag", so it would propose deleting a host that is sitting right there.
+2. **Set `marked` per host** from the provider's managed marker: `user.remo=true` (Incus), the `remo` tag (Proxmox), `tag:remo=true` (AWS), the `remo` label (Hetzner).
+3. **Report `complete` honestly** (FR-040). `True` only if the enumeration is provably exhaustive. Anything less sets `False` with an `incomplete_reason`, and the reconcile layer then produces no removals at all.
+4. **Raise `ProbeError` when it could not ask** (FR-009). Never return an empty `ProbeResult` to mean "the query failed." A probe that cannot distinguish these two must report `complete=False`.
+5. **Mutate nothing at the provider** (FR-008) — no create, destroy, start, stop, tag, label, or reconfigure. Markers are written only by `create` and `update`.
+6. **Build `entry` in the same shape the provider's `create` writes**, so create and sync agree and a freshly created host reconciles as `unchanged`.
+7. **Degrade softly on per-host problems.** One container's IP lookup failing must append to `warnings` and leave `entry.host` empty, so `merge_entry` preserves the previously recorded address. It must not abort the run and must not drop the host from `hosts` — dropping it would turn a transient failure into a proposed deletion.
+8. **Set `state`** to the observed provider state when the provider has one, `""` otherwise. Reported, never persisted (FR-019).
+9. **Set `adoption_criteria`** to a human-readable description of what `include_all` widened to (FR-030).
+
+A conforming probe **MUST NOT** call `save_known_host`, `remove_known_host`, `clear_known_hosts_*`, `mutate_registry`, or `replace_registry`. Registry writes belong exclusively to the reconcile driver.
+
+## Per-provider implementation notes
+
+### Incus — `providers/incus.py`
+
+- Source: `_list_containers_with_marker(host, user)` (`incus.py:156-180`), one `incus list -f csv -c n,user.remo`. This already enumerates every container and evaluates the marker locally, so it satisfies FR-044 as written.
+- `complete = True` — `incus list` does not paginate. Default project only; `--all-projects` is deliberately not added (FR-045), so the scope description must name the boundary: `incus host <h> (default project)`.
+- Existing `RuntimeError` on non-zero return code maps to `ProbeError`.
+- `--use-ip`: `_resolve_container_ip` must be changed to return `""` on SSH failure instead of `sys.exit(1)` (`incus.py:113,117`), appending to `warnings`. Also catch `FileNotFoundError` from the SSH helper.
+- Entry: `name=f"{host}/{c}"`, `host=ip or c`, `user="remo"`, `instance_id=<node ssh user>`, `access_mode="direct"`.
+
+### Proxmox — `providers/proxmox.py`
+
+- Sources: `pct list` (`proxmox.py:756-780`) and `_read_tags_by_vmid` (`proxmox.py:145-180`).
+- **Must add a return-code check to `_read_tags_by_vmid`.** It currently ignores `returncode`, so an SSH failure silently yields an empty tag map, every container reads unmarked, and a default sync registers zero. Under reconcile that would propose deleting the node's entire fleet. Non-zero → `ProbeError`.
+- `complete = True` — neither source paginates. Addressed node only; the scope description must say so (FR-045): `proxmox node <h> (this node only)`.
+- Entry: `name=f"{host}/{hostname}"`, `instance_id=vmid`, `access_mode="direct"`, `region=user or "root"`.
+
+### AWS — `providers/aws.py`
+
+- Replace the single-shot `describe_instances` (`aws.py:721-731`) with `ec2.get_paginator("describe_instances").paginate(...)`.
+- **Filter on state only** — never on `tag:remo` (FR-044). Enumerate every non-terminal instance in the region and set `marked` from `tags.get("remo") == "true"` locally. This is one broader paginated call rather than several narrow ones, and it is the only way an untagged-but-live instance can be retained instead of deleted.
+- `include_all` widens **eligibility for addition** to instances whose `tag:Name` matches `remo-*`. It does not change the query.
+- **States**: `pending`, `running`, `stopping`, `stopped` (FR-017) — matching the `states=` list every other AWS command already passes to `_find_remo_instance` (`aws.py:783,837,928,977`). Exclude `shutting-down` and `terminated`.
+- `complete = True` only if the paginator ran to exhaustion. A mid-iteration exception returns the pages gathered so far with `complete=False` — additions still apply, removals are suppressed.
+- Name: prefer the `remo_resource_name` tag; fall back to `Name` minus `remo-` (R8). Skip an instance that yields an empty name.
+- Entry: `host=<public ip>` or `""` when absent (**not** the instance id — the merge preserves the prior address, FR-018), `instance_id=<id>`, `access_mode=tags.get("remo_access_mode", "ssm")`, `region=<scope region>`.
+- `state = instance["State"]["Name"]`.
+
+### Hetzner — `providers/hetzner.py`
+
+- Route through `_hetzner_api` (`hetzner.py:446-485`), not the inline `urllib` block at `:396-407`.
+- **Must paginate.** `GET /v1/servers` defaults to `per_page=25`; today's sync silently truncates there. Add `_hetzner_api_paged(path, key)` looping on `meta.pagination.next_page` with `per_page=50`. `complete=False` if the loop terminates early.
+- **Never use `?label_selector=remo`** (FR-044). Always `GET /v1/servers` unfiltered and set `marked` from the presence of the `remo` label locally. The existing selector is precisely what makes an unlabelled-but-live server look absent.
+- `include_all` widens **eligibility for addition** to every server in the project — Hetzner has no naming convention to match on (research R7). It does not change the query.
+- `complete = True` only when pagination ran to exhaustion.
+- Entry: `name=<server name>`, `host=<public IPv4>`, `user="remo"`, others empty — matching what `create` writes (`hetzner.py:141-148`).
+- A server with no IPv4 still belongs in `hosts` with `entry.host=""`; the merge preserves the prior address rather than dropping the entry.
+- `state = server["status"]`.
+
+## Test seam
+
+Each probe is independently testable by patching one symbol:
+
+| Provider | Patch target |
+|---|---|
+| Incus | `remo_cli.providers.incus._ssh_run_on_incus_host` |
+| Proxmox | `remo_cli.providers.proxmox._run_on_node` |
+| AWS | the `ec2` client fixture (must now stub `get_paginator`) |
+| Hetzner | `remo_cli.providers.hetzner._hetzner_api` |
+
+`build_plan` is pure, so the whole classification matrix is testable with no provider at all.

--- a/specs/016-sync-reconcile/data-model.md
+++ b/specs/016-sync-reconcile/data-model.md
@@ -1,0 +1,167 @@
+# Phase 1 Data Model: Unified Sync Reconcile
+
+**Feature**: `016-sync-reconcile` | **Date**: 2026-07-25
+
+No persisted schema changes. The registry format stays at v2 and no migration is introduced (SC-011). Everything below is in-memory, living in a new provider-agnostic module `src/remo_cli/core/reconcile.py`.
+
+## Existing entity (unchanged)
+
+### `KnownHost` — `src/remo_cli/models/host.py:8-29`
+
+```python
+type: str; name: str; host: str; user: str
+instance_id: str = ""; access_mode: str = ""; region: str = ""
+```
+
+Identity is `(type, name)`, enforced by `validate_hosts` (`core/registry.py:344-359`). Per-type slot meanings are unchanged:
+
+| type | `name` | `host` | `instance_id` | `access_mode` | `region` |
+|---|---|---|---|---|---|
+| incus | `<node>/<container>` | container name or IP | node SSH user | `direct` | — |
+| proxmox | `<node>/<hostname>` | hostname or IP | vmid | `direct` | node SSH user |
+| aws | resource name | public IP or instance id | instance id | `ssm`\|`direct` | AWS region |
+| hetzner | server name | public IPv4 | — | — | — |
+
+## New entities
+
+### `SyncScope`
+
+The bounded slice of the registry one sync run may change (FR-003, FR-004).
+
+| Field | Type | Notes |
+|---|---|---|
+| `type` | `str` | `incus` \| `proxmox` \| `aws` \| `hetzner` |
+| `host` | `str` | Incus/Proxmox node; `""` otherwise |
+| `region` | `str` | AWS region; `""` otherwise |
+
+**Two membership predicates, deliberately asymmetric:**
+
+- `in_update_scope(entry) -> bool` — may be matched and refreshed.
+- `in_removal_scope(entry) -> bool` — may be proposed for removal when absent.
+
+| type | `in_update_scope` | `in_removal_scope` |
+|---|---|---|
+| incus, proxmox | `e.type == type and e.name.startswith(f"{host}/")` | same |
+| hetzner | `e.type == "hetzner"` | same |
+| aws | `e.type == "aws" and e.region in (region, "")` | `e.type == "aws" and e.region == region` |
+
+**Why AWS differs**: a legacy AWS entry with no recorded region cannot be attributed to any region, so FR-023 ("cannot determine → retain") forbids ever removing it. But if the queried region turns out to contain a host of that name, matching it lets the reconcile *stamp* the region — the entry self-heals into a normal scoped entry on first sync. Removal remains impossible until it does.
+
+**Validation**: `host` required non-empty for incus/proxmox; `region` required non-empty for aws; both empty for hetzner.
+
+`describe() -> str` renders the scope line required by FR-003 and must name the enumeration boundary required by FR-045, e.g. `aws region us-west-2`, `incus host prox01 (default project)`, `proxmox node pve1 (this node only)`, `hetzner (all servers in project)`.
+
+### `DiscoveredHost`
+
+One host as the provider currently sees it.
+
+| Field | Type | Notes |
+|---|---|---|
+| `entry` | `KnownHost` | desired registry shape for this host |
+| `marked` | `bool` | carries the managed marker (FR-021) |
+| `state` | `str` | observed provider state; `""` when N/A. Never persisted (FR-019) |
+| `adopted` | `bool` | included only because the adoption flag was set (FR-030) |
+
+`entry.name` is the matching key (FR-039). Provider identifiers inside `entry` are attributes, not identity.
+
+### `ProbeResult`
+
+A provider's complete answer for one scope, at one moment.
+
+| Field | Type | Notes |
+|---|---|---|
+| `hosts` | `list[DiscoveredHost]` | every host found in scope, marked or not |
+| `complete` | `bool` | enumeration exhaustive? (FR-040) |
+| `incomplete_reason` | `str` | shown when `complete` is `False` |
+| `adoption_criteria` | `str` | human-readable, printed when adoption is on (FR-030) |
+| `warnings` | `list[str]` | non-fatal problems, e.g. one container's IP lookup failed |
+
+**Invariant**: `hosts` contains every host the provider can see in scope — *including unmarked ones*. The marker only gates whether a host is eligible for addition; presence in this list is what protects an existing entry from removal (FR-022). Collapsing these two into one filtered list is precisely the bug being fixed.
+
+**Corollary (FR-044)**: the marker must not appear in the query's filter either. AWS's `tag:remo=true` and Hetzner's `label_selector=remo` must be dropped and evaluated locally — a server-side marker filter makes an unmarked-but-live host indistinguishable from a deleted one, so the entry would be proposed for removal. Only terminal-state exclusion may be pushed server-side, because that genuinely establishes non-existence.
+
+**Failure signalling** (FR-009): a probe that cannot ask the provider raises `ProbeError`; it never returns an empty `ProbeResult`. `complete=False` means "asked, but the answer may be partial."
+
+### `ReconcilePlan`
+
+The computed difference. Pure data — building it performs no I/O.
+
+| Field | Type | Notes |
+|---|---|---|
+| `scope` | `SyncScope` | |
+| `added` | `list[KnownHost]` | eligible at provider, not in registry |
+| `updated` | `list[tuple[KnownHost, KnownHost]]` | `(before, after)` |
+| `unchanged` | `list[KnownHost]` | |
+| `removed` | `list[KnownHost]` | in registry, confirmed absent |
+| `skipped_unmarked` | `list[str]` | present, unmarked, not adopted → not added (FR-029) |
+| `retained_unmarked` | `list[str]` | in registry, present, unmarked → kept (FR-024) |
+| `states` | `dict[str, str]` | name → observed state, non-running only (FR-019) |
+| `removals_suppressed` | `bool` | enumeration incomplete (FR-040) |
+| `baseline` | `tuple[KnownHost, ...]` | in-scope entries the plan was built from (R2 conflict check) |
+| `warnings` | `list[str]` | carried from the probe |
+
+Derived: `has_removals`, `is_noop` (`added`, `updated`, `removed` all empty).
+
+**Classification rules** (FR-005), keyed by `entry.name` over the `in_update_scope` slice:
+
+| Registry | Provider | Marker | → |
+|---|---|---|---|
+| absent | present | marked, or adoption on | **added** |
+| absent | present | unmarked, adoption off | *skipped* (reported, not added) |
+| present | present | any | **updated** if merge differs, else **unchanged**; also **retained_unmarked** if unmarked |
+| present | absent | — | **removed**, but only if `in_removal_scope` **and** `complete` |
+| present | absent | — | **unchanged** if `complete` is `False` (FR-040) or not `in_removal_scope` (FR-023) |
+
+### `MergedEntry` rule (FR-041)
+
+Not a type — the function `merge_entry(existing, discovered) -> KnownHost`:
+
+- `type`, `name` — identity, never change.
+- `host`, `access_mode`, `instance_id`, `region` — take the discovered value **when non-empty**, else keep the existing one.
+- `user` — always preserved from `existing`. Every provider hardcodes `"remo"`, so the provider observes nothing here; preserving it respects hand-edits.
+
+The "when non-empty" clause is what implements FR-018: a stopped AWS instance reports no `PublicIpAddress`, so `host` falls through to the last known address instead of being blanked or replaced by the instance id.
+
+### `ConsentOutcome`
+
+Result of the confirmation gate (FR-011 – FR-014).
+
+`APPLY` · `DECLINED` · `NON_INTERACTIVE` · `NOT_REQUIRED`
+
+`NOT_REQUIRED` covers both a no-removal plan and `--yes`. `DECLINED` and `NON_INTERACTIVE` both map to exit 3 with different messages.
+
+## Errors
+
+| Exception | Raised when | Exit |
+|---|---|---|
+| `ProbeError` | provider query failed (FR-009) | 1 |
+| `ReconcileConflictError` | in-scope registry moved between plan and write (R2) | 1 |
+| `AmbiguousPlanError` | two provider hosts resolve to one registry name (FR-037) | 1 |
+| `ScopeError` | malformed scope (e.g. AWS scope with no region) | 1 |
+
+None of these escape the provider layer: `run_sync` catches them, prints via `print_error`, and returns the code. `core/registry.py`'s no-`SystemExit` rule is preserved — the new module raises and returns, never exits; only the thin CLI wrapper calls `sys.exit(rc)`.
+
+## Lifecycle
+
+```
+scope ──► probe(scope, include_all, use_ip) ──► ProbeResult      [network/SSH, no lock]
+                                                    │
+                       read_registry() ─────────────┤
+                                                    ▼
+                                            build_plan(...)      [pure, no I/O]
+                                                    │
+                                            render_plan(...)     [stdout]
+                                                    │
+                        ┌───────── dry-run? ────────┴─── yes ──► exit 0
+                        │ no
+                        ▼
+                     consent gate                               [isatty + confirm()]
+                        │ APPLY / NOT_REQUIRED
+                        ▼
+                mutate_registry(apply)                          [locked, ~microseconds]
+                   └─ re-derive in-scope slice
+                   └─ compare against plan.baseline ──► differ? ReconcileConflictError
+                   └─ return out-of-scope + reconciled in-scope
+```
+
+Discovery and prompting sit entirely outside the lock; the locked critical section is a list comparison and a splice.

--- a/specs/016-sync-reconcile/plan.md
+++ b/specs/016-sync-reconcile/plan.md
@@ -1,0 +1,157 @@
+# Implementation Plan: Unified Sync Reconcile
+
+**Branch**: `016-sync-reconcile` | **Date**: 2026-07-25 | **Spec**: [spec.md](./spec.md)
+
+**Input**: Feature specification from `/specs/016-sync-reconcile/spec.md`
+
+## Summary
+
+Replace four hand-rolled clear-then-repopulate `sync` implementations with one shared reconcile primitive. Each provider contributes a single *probe* — "for this scope, what hosts exist, which carry the managed marker, and was my enumeration complete?" — and a new provider-agnostic `core/reconcile.py` does everything else: diff against the in-scope registry slice, render the plan, gate removals behind consent, and commit via one atomic write.
+
+The technical approach rests on three findings from Phase 0:
+
+1. **No new registry write path is needed.** `mutate_registry()` (`core/registry.py:794-807`) already runs an arbitrary mutator inside the `fcntl` lock with validation and `os.replace`. The reconcile layer sits above it.
+2. **The prompt cannot live inside the lock**, so consent is optimistic: the plan records the in-scope baseline it was built from, and the mutator aborts with `ReconcileConflictError` if that slice moved. This satisfies the concurrency edge case instead of papering over it.
+3. **Removals require a provably complete enumeration.** Hetzner truncates at 25 servers today and AWS paginates nowhere — under the old semantics that silently lost entries; under reconcile it would silently propose deleting them. Completeness becomes an explicit part of the probe contract.
+4. **The query must not filter on the managed marker** (FR-044, added post-planning). AWS's `tag:remo=true` and Hetzner's `label_selector=remo` are server-side filters, so an existing-but-unmarked host is invisible to them and reads as absent — which would have made FR-022 unenforceable on exactly the two providers it matters most for. Both must enumerate broadly and evaluate the marker locally, as Incus and Proxmox already do.
+
+Beyond the three named bugs, the spec's clarifications extend scope to the Hetzner provisioning path (the `remo` label sync queries for is never applied by anything) and change marker semantics so the marker gates *addition* while provider presence gates *removal*.
+
+## Technical Context
+
+**Language/Version**: Python 3.11+ (`requires-python = ">=3.11"`), `from __future__ import annotations`, full type hints
+
+**Primary Dependencies**: Click 8.1+ (CLI), boto3 (AWS), stdlib `urllib`/`json`/`fcntl` (Hetzner API, registry). Ansible 2.14+ / `hetzner.hcloud >= 6.7.0` collection for the Hetzner label work. **No new runtime dependencies.**
+
+**Storage**: Existing JSON registry at `~/.config/remo/registry.json`, format v2. **No schema change, no migration** (SC-011). Instance state is reported, never stored.
+
+**Testing**: pytest + pytest-mock. Existing `tmp_config_dir` fixture (`tests/conftest.py:10-21`) provides a real temporary registry via `REMO_HOME`. `build_plan` is pure, so the classification matrix needs no fixtures at all.
+
+**Target Platform**: Linux/macOS developer workstations (CLI)
+
+**Project Type**: Single-project CLI, three-layer (`cli/` → `providers/` → `core/`)
+
+**Performance Goals**: Exactly one registry write per sync run, down from N+1 today (SC-006). Registry lock held for a list comparison and splice only — all network/SSH work and all prompting happen outside it.
+
+**Constraints**:
+- The registry lock is **not reentrant** — the mutator must be pure list-in/list-out and must not call any other registry function.
+- `core/registry.py` must never raise `SystemExit` (its module docstring, lines 8-9). The new core module inherits that: it raises and returns codes; only the thin CLI wrapper exits.
+- Exit code `2` is reserved for Click/usage errors and must not be emitted by sync.
+- `sync` must not mutate provider-side state (FR-008), including during adoption.
+
+**Scale/Scope**: 4 providers · 43 functional requirements · 1 new core module · ~6 existing modules touched · 1 Ansible role task · README + 4 provider docs
+
+## Constitution Check
+
+*GATE: evaluated before Phase 0 and re-evaluated after Phase 1 design.*
+
+| Principle | Assessment | Verdict |
+|---|---|---|
+| **I. Defensive Variable Access (Ansible)** | The only Ansible change is adding a `labels:` key to an existing `hetzner.hcloud.server` task (`ansible/roles/hetzner_server/tasks/main.yml:55-69`). It registers no new variable and adds no `when:`/`register:`. The existing `hetzner_server_result` registration is untouched. Pre-commit grep for `.rc ==` / `.stdout` without `\| default()` still applies. | **PASS** |
+| **II. Test All Conditional Paths** | This is the binding gate. The consent gate has five outcomes (no removals · `--yes` · confirmed · declined · non-interactive); `complete` and `marked` each branch two ways; `--dry-run` and `--all` compose with all of them. Two providers currently have **zero** sync tests, and where sync is tested the destructive step is mocked out — so the existing suite would not have caught either AWS bug. SC-008 makes closing this explicit, and Phase 2 tasks must enumerate the branches rather than sampling them. | **PASS with obligation** |
+| **III. Idempotent by Default** | FR-036 requires a second run to be a no-op that does not prompt (verified in quickstart Scenario 4). FR-033 requires the Hetzner label write to report no change when already present. Destructive operations gain an explicit safeguard where none existed: today's sync deletes registry entries with no confirmation at all. | **PASS — strengthens** |
+| **IV. Fail Fast with Clear Messages** | FR-009 requires a failed probe to abort with the registry untouched. Phase 0 found three silent failures that this converts to loud ones — most importantly `_read_tags_by_vmid` (`proxmox.py:145-180`) ignoring its return code, which today turns an SSH failure into "zero containers are marked" and wipes the node. Error messages must name what failed, the scope, and the remedy. | **PASS — strengthens** |
+| **V. Documentation Reflects Reality** | FR-038 is a blocking requirement. `README.md:405-424` currently documents the old marker semantics and states that a later default sync drops `--all`-adopted entries — false after this change. `docs/proxmox.md:64-65` describes sync as "rebuild known_hosts entries", which is the behaviour being removed. `docs/incus.md` and `docs/hetzner.md` have no sync section at all. | **PASS with obligation** |
+
+**Violations requiring justification**: none. The Complexity Tracking section is therefore omitted.
+
+**Post-Phase-1 re-evaluation**: The design adds exactly one new module and no new dependency, layer, or abstraction beyond the probe seam the spec explicitly asks for. Provider code shrinks — four bespoke sync bodies become four probes plus a two-line delegation. No gate moved from PASS.
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/016-sync-reconcile/
+├── plan.md                      # This file
+├── research.md                  # Phase 0: 12 findings with file:line evidence
+├── data-model.md                # Phase 1: in-memory entities, classification matrix
+├── quickstart.md                # Phase 1: validation scenarios
+├── contracts/
+│   ├── cli-sync.md              # User-facing CLI surface, output, exit codes
+│   └── provider-probe.md        # Internal provider seam
+├── checklists/requirements.md   # Spec quality checklist (16/16)
+└── tasks.md                     # Phase 2 output — NOT created by /speckit-plan
+```
+
+### Source Code (repository root)
+
+```text
+src/remo_cli/
+├── core/
+│   ├── reconcile.py             # NEW — SyncScope, DiscoveredHost, ProbeResult,
+│   │                            #   ReconcilePlan, merge_entry, build_plan (pure),
+│   │                            #   render_plan, consent gate, apply, run_sync driver,
+│   │                            #   exit-code constants, ProbeError/ReconcileConflictError
+│   ├── registry.py              # UNCHANGED — mutate_registry() used as-is
+│   ├── known_hosts.py           # UNCHANGED — clear_* helpers stay for other callers
+│   └── output.py                # UNCHANGED — confirm()/print_* reused
+├── providers/
+│   ├── incus.py                 # sync -> probe + run_sync; _resolve_container_ip
+│   │                            #   soft-fails instead of sys.exit(1)
+│   ├── proxmox.py               # sync -> probe + run_sync; _read_tags_by_vmid gains
+│   │                            #   a return-code check (silent-failure fix)
+│   ├── aws.py                   # sync -> probe + run_sync; paginate; retain non-terminal
+│   │                            #   states; region-scoped; prefer remo_resource_name tag
+│   └── hetzner.py               # sync -> probe + run_sync; _hetzner_api_paged;
+│                                #   _apply_managed_label (read-merge) called from update
+└── cli/providers/
+    ├── incus.py, proxmox.py     # + --yes, --dry-run; sys.exit(rc)
+    ├── aws.py                   # + --yes, --dry-run, --all; sys.exit(rc)
+    └── hetzner.py               # + --yes, --dry-run, --all; sys.exit(rc)
+
+ansible/roles/hetzner_server/tasks/main.yml    # + labels: {remo: "true"} on the server task
+
+tests/
+├── unit/core/test_reconcile.py                # NEW — pure plan logic, full matrix
+├── unit/providers/test_{incus,proxmox,aws,hetzner}_sync.py   # NEW — per-provider probes
+├── unit/cli/providers/                        # flags, exit codes; 2 existing files updated
+├── integration/test_sync_reconcile.py         # NEW — real temp registry, one-write assertion
+└── unit/providers/test_provider_registry_entries.py   # UPDATED — pinned shapes move
+
+README.md · docs/{aws,hetzner,incus,proxmox}.md            # FR-038
+```
+
+**Structure Decision**: Single-project CLI following the existing three-layer split. `reconcile.py` belongs in `core/` because it must have no provider knowledge — that is precisely what SC-005 measures ("adding a fifth provider requires supplying only a desired-hosts query"). Provider modules keep their business logic and gain a probe; the `cli/` layer stays parsing-only, gaining flags and the `sys.exit(rc)` that all four sync wrappers are missing today.
+
+## Implementation Phases
+
+Sequenced so each phase is independently valuable and testable, mirroring the spec's user-story priorities.
+
+### Phase A — Reconcile core (blocks everything)
+
+`core/reconcile.py` plus `tests/unit/core/test_reconcile.py`. `build_plan` is pure, so the entire classification matrix, `merge_entry` semantics, and scope predicates are testable before any provider is touched. Delivers no user-visible change on its own.
+
+### Phase B — One provider end-to-end (US1, P1)
+
+Wire Incus first: smallest probe, existing test scaffolding, and `--all`/`--use-ip` already present to prove they survive. Proves the whole pipeline — scope, plan, consent, single atomic write, exit codes — against a real temp registry. This is the MVP slice: the empty-result wipe is fixed for one provider.
+
+### Phase C — AWS correctness (US2 + US3, P1)
+
+Region scoping, pagination, non-terminal states, address preservation, and the `remo_resource_name` name fix. Highest bug density; depends on Phase A/B having settled the contract.
+
+### Phase D — Proxmox and Hetzner probes (US4, P2)
+
+Proxmox brings the `_read_tags_by_vmid` silent-failure fix. Hetzner brings `_hetzner_api_paged` and its first-ever sync tests. Completes uniform behaviour across all four.
+
+### Phase E — Adoption parity and the Hetzner label (US5, P3)
+
+`--all` for AWS and Hetzner with stated criteria; the Ansible label at create; the read-merge backfill in `hetzner update`. Independently deferrable behind the P1 fixes.
+
+### Phase F — Documentation (FR-038, blocking)
+
+README command reference and troubleshooting prose, the four provider docs, and removal of the now-false "a later default sync will drop those unmarked one(s) again" warning from source.
+
+## Risks
+
+| Risk | Mitigation |
+|---|---|
+| Hetzner's API replaces the label map wholesale, so a naive backfill drops a user's own labels (violates FR-034) | Read-merge in Python via `_hetzner_api`, mirroring `_apply_managed_marker`'s `(ok, err)` contract. Explicit test in quickstart Scenario 7. |
+| Changing `sync`'s return type to `int` breaks existing CLI tests | Known and enumerated (research R11): two sync-flag tests plus the AWS `ec2` stubs. Update, don't delete. |
+| `test_provider_registry_entries.py` pins exact registry shapes | The probe must build entries identically to each provider's `create`, so create and sync agree. Where a shape legitimately changes (AWS `host` no longer falls back to the instance id), update the pin deliberately. |
+| The optimistic-concurrency check could false-positive under normal use | The baseline compares only the *in-scope* slice, so concurrent syncs of different scopes never collide. A genuine collision is rare and fails loudly with a re-run instruction, which is the required behaviour. |
+| Adoption on Hetzner means "every server in the project" — blunter than AWS's `remo-*` | FR-030 requires printing the criteria. Making the bluntness visible is the mitigation; there is no naming convention to infer from (research R7). |
+
+## Out of scope
+
+Found during research, deliberately excluded — see research.md R12 for detail: the stale `boto3`/`hcloud` extras documented in `CLAUDE.md`, the unused `hcloud` dependency, the `cx23`/`cx22` group_vars-vs-role-defaults mismatch, the ignored `--yes` on incus/proxmox `create`, the hardcoded `access_mode="ssm"` in `aws update`, and the other unpaginated AWS calls (`describe_snapshots`, `describe_volumes`, IAM listings).

--- a/specs/016-sync-reconcile/quickstart.md
+++ b/specs/016-sync-reconcile/quickstart.md
@@ -1,0 +1,129 @@
+# Quickstart: validating Unified Sync Reconcile
+
+**Feature**: `016-sync-reconcile`
+
+How to prove the feature works. Scenarios are ordered by user-story priority; each maps to acceptance criteria in [spec.md](./spec.md). Interfaces referenced here are defined in [contracts/cli-sync.md](./contracts/cli-sync.md) and [contracts/provider-probe.md](./contracts/provider-probe.md).
+
+## Prerequisites
+
+```bash
+uv sync --all-extras
+uv run pytest                       # baseline: everything green before you start
+uv run mypy src/remo_cli
+uv run ruff check src/remo_cli
+```
+
+Known-failing-by-design once implementation lands (see research R11) — these must be *updated*, not deleted:
+
+- `tests/unit/providers/test_provider_registry_entries.py` — pins the exact `KnownHost` shape each provider writes.
+- `tests/unit/cli/providers/test_incus_sync_all.py`, `test_proxmox_sync_all.py` — assert `exit_code == 0` against a `None`-returning `sync` mock.
+- `tests/unit/providers/test_aws_snapshot.py` — its `ec2` stub needs `get_paginator`.
+
+## Automated validation
+
+```bash
+uv run pytest tests/unit/core/test_reconcile.py -v          # pure plan logic
+uv run pytest tests/unit/providers -k sync -v               # per-provider probes
+uv run pytest tests/unit/cli/providers -k sync -v           # flags and exit codes
+uv run pytest tests/integration -k reconcile -v             # real temp registry
+```
+
+The pure-logic suite is the centre of gravity: `build_plan` performs no I/O, so the entire classification matrix in [data-model.md](./data-model.md) is testable without a provider, a registry, or a mock.
+
+## Scenario 1 — Empty result no longer wipes the registry (P1, SC-001)
+
+The headline bug. Uses a real temp registry via the `tmp_config_dir` fixture (`tests/conftest.py:10-21`).
+
+**Setup**: seed three in-scope entries with `write_v2_registry`; stub the probe to return zero hosts, `complete=True`.
+
+| Run | Expect |
+|---|---|
+| decline the prompt | registry byte-identical; output says nothing was changed; exit **3** |
+| `--yes` | all three removed and each named in the output; exit **0** |
+| probe raises `ProbeError` | registry unchanged; error on stderr; exit **1** |
+| no TTY, no `--yes` | registry unchanged; message names `--yes`; exit **3** |
+| `--dry-run` | plan printed; registry unchanged; no prompt; exit **0** |
+
+The decline case is the one to check byte-for-byte — FR-013 requires that additions and updates are abandoned too, not just the removals.
+
+## Scenario 2 — AWS region isolation (P1, SC-002)
+
+**Setup**: registry holds `devbox` (`us-west-2`) and `eubox` (`eu-central-1`). Stub the paginator to return only `eubox`.
+
+```bash
+remo aws sync --region eu-central-1 --dry-run
+```
+
+- `devbox` appears in **no** category — not added, removed, or unchanged. It is out of scope, and `--dry-run` makes that checkable without touching anything.
+- Apply for real: `devbox` retains its recorded region.
+- Regression guard: an entry with an **empty** region must never be proposed for removal in any region, but must be matched and stamped if a same-named host is found (data-model, `in_update_scope` vs `in_removal_scope`).
+
+## Scenario 3 — Stopped instances survive (P1, SC-003)
+
+**Setup**: a registry entry for `parked` with a recorded public IP; the stub returns that instance with `State.Name == "stopped"` and **no** `PublicIpAddress` key — the shape AWS actually returns.
+
+- Entry retained, classified `unchanged`, annotated `(stopped)` in the report.
+- Recorded IP preserved — not blanked, not replaced by the instance id (FR-018 via `merge_entry`).
+- Recorded region intact, so `remo aws start parked` resolves correctly afterwards.
+- Nothing about the state reaches `registry.json` (FR-019). Assert on the file contents, not just the in-memory entry.
+- Contrast: a `terminated` instance is excluded from the probe, so it appears under removals and needs consent.
+
+## Scenario 4 — Uniform report and idempotency (P2, SC-004, SC-007)
+
+For each of the four providers, with a mixed plan:
+
+1. Scope line comes first.
+2. Every non-empty category names its entries; counts equal what was written.
+3. A changed address is reported `updated`, never `removed` + `added`, and does not prompt.
+4. Run twice against an unchanged provider: the second run reports no changes, prompts for nothing, exits 0.
+
+Then assert the write count: **one** registry write per run, zero on dry-run/decline/failure (SC-006). Spying on `mutate_registry` is the cheapest check, and it directly catches a regression to the old N+1-write shape.
+
+## Scenario 5 — Enumeration completeness (SC-014)
+
+The subtlest guarantee, and the easiest to regress.
+
+- **Hetzner**: stub `_hetzner_api` to return a first page whose `meta.pagination.next_page` is `2`, then fail the second page. Expect: additions/updates applied, **zero** removals, explicit warning naming the incomplete listing. Without the fix this silently proposes deleting every server past the 25th.
+- **AWS**: stub `get_paginator` to raise mid-iteration. Same expectation.
+- **Happy path**: two full pages, `next_page: null` → `complete=True`, removals allowed.
+
+## Scenario 6 — Adoption and marker semantics (P3, SC-010)
+
+- Unmarked host present, no `--all` → not added; output names it and gives both remedies.
+- With `--all` → added, warned as not remo-created, and the adoption criteria are printed.
+- **Durability**: after adopting, run a plain sync with no flags. The entry is retained, reported unmarked, and **no prompt appears** (FR-022). This is the regression test for the semantics change — under the old marker-gates-removal behaviour it would be proposed for deletion on every run.
+- Verify the stale warning is gone: `grep -rn "will drop those unmarked" src/` must return nothing (FR-026).
+
+## Scenario 7 — Hetzner label gap (SC-009)
+
+- `remo hetzner sync` against a stub containing a labelled server → discovered with no `--all`.
+- `remo hetzner update` against an unlabelled server → label applied; re-running reports no change (FR-033).
+- **Merge check**: an existing server carrying an unrelated label (`env: prod`) keeps it after backfill (FR-034). Hetzner's API replaces the label map wholesale, so a naive `PUT` fails this and it is the single most likely implementation slip.
+- Ansible side: `grep -n "labels" ansible/roles/hetzner_server/tasks/main.yml` shows the new key; assert it sits on the server task only, not the shared SSH key (research R6).
+
+## Manual smoke test
+
+Only meaningful against real infrastructure. `--dry-run` makes the first three steps risk-free.
+
+```bash
+remo aws sync --dry-run                    # inspect the plan, nothing is written
+remo aws sync --region eu-central-1 --dry-run
+remo hetzner sync --dry-run
+cp ~/.config/remo/registry.json /tmp/registry.backup.json
+remo aws sync                              # answer 'n' at any prompt
+diff ~/.config/remo/registry.json /tmp/registry.backup.json   # must be empty
+```
+
+Then confirm the exit-code contract:
+
+```bash
+remo aws sync --dry-run;  echo "expect 0: $?"
+remo aws sync --nonsense; echo "expect 2: $?"      # Click usage error, untouched
+echo -n | remo aws sync;  echo "expect 3 if removals pending: $?"
+```
+
+## Constitution checkpoints
+
+- **II. Test All Conditional Paths** — the consent gate alone has five outcomes (no removals · `--yes` · confirmed · declined · non-interactive) and each must be covered. Same for `complete` True/False and `marked` True/False.
+- **III. Idempotent by Default** — Scenario 4's double-run, plus the Hetzner label no-op in Scenario 7.
+- **V. Documentation Reflects Reality** — before calling this done, update `README.md:291,300,313-314,324-325` (command reference) and `:405-424` (the troubleshooting prose that the marker-semantics change invalidates), `docs/proxmox.md:64-65` ("rebuild known_hosts entries" describes the behaviour being replaced), `docs/aws.md:218` (IAM table), and add sync sections to `docs/incus.md` and `docs/hetzner.md`, which have none.

--- a/specs/016-sync-reconcile/research.md
+++ b/specs/016-sync-reconcile/research.md
@@ -1,0 +1,164 @@
+# Phase 0 Research: Unified Sync Reconcile
+
+**Feature**: `016-sync-reconcile` | **Date**: 2026-07-25
+
+All findings below were verified against the working tree. File:line references are current as of branch `016-sync-reconcile`.
+
+## R1: Can the existing registry API express a single atomic reconcile?
+
+**Decision**: Yes — reuse `mutate_registry()` unchanged. No new core write path.
+
+**Rationale**: `core/registry.py:794-807` already provides exactly the primitive the spec's FR-006 needs:
+
+```python
+def mutate_registry(mutator: Callable[[list[KnownHost]], list[KnownHost]]) -> RegistryView:
+    with registry_lock():
+        _migrate_locked()
+        current = _current_document_locked()
+        new_hosts = mutator(list(current.hosts))
+        validate_hosts(new_hosts)
+        _write_v2_file(get_registry_path(), new_hosts, current.unknown_raw)
+```
+
+The mutator runs *inside* the `fcntl` exclusive lock (`registry.py:629-666`, sidecar `registry.lock`, 5s timeout → `RegistryBusyError`), receives the state read under that same lock, and its return value is validated before `_atomic_write_text` does `os.replace` (`registry.py:495-505`). Unknown-type entries are preserved verbatim. That satisfies "one atomic registry rewrite" with zero core changes.
+
+**Constraints this imposes on the design** (all load-bearing):
+
+1. **The lock is not reentrant.** A mutator that calls `read_registry`, `save_known_host`, `remove_known_host`, or `replace_registry` will block on itself for 5s and then raise `RegistryBusyError`. The reconcile mutator must be pure list-in/list-out.
+2. **Nothing slow may happen inside the mutator.** Concurrent `remo` commands time out after 5s, and the web service's setup-apply path takes the same lock (`web/api/setup.py:344`). All discovery and all prompting must happen outside.
+3. **The mutator cannot return side-channel data** — `mutate_registry` returns only a `RegistryView`. The applied plan is therefore computed before the call and closed over.
+
+**Alternatives considered**:
+- *`replace_registry(hosts, allow_empty=...)`* — rejected. It writes a whole-registry snapshot, so an out-of-scope entry added by a concurrent process between our read and our write would be silently destroyed. That is the very class of bug this feature exists to remove.
+- *A new `reconcile_registry()` in `core/registry.py`* — rejected as unnecessary. The scope/diff logic belongs in a provider-agnostic layer above the registry, not inside the format accessor. `core/registry.py`'s docstring (lines 8-9) also forbids it raising `SystemExit`, and keeping reconcile out of it preserves that boundary.
+
+## R2: How to prompt outside the lock without applying a stale plan
+
+**Decision**: Snapshot → plan → render → prompt → `mutate_registry` with a mutator that **re-derives the in-scope slice from its own fresh snapshot and aborts if it moved**.
+
+**Rationale**: The spec's concurrency edge case requires that "the plan a user confirmed must be the plan that gets written, or the write must fail loudly." Since the prompt cannot be held inside the lock (R1 constraint 2), the only correct construction is optimistic concurrency: record the exact in-scope entry set the plan was built from, and inside the mutator compare it against what is actually there. If they differ, raise `ReconcileConflictError` — the write does not happen, and the user is told to re-run.
+
+Out-of-scope entries are deliberately *excluded* from the conflict check: a concurrent `remo aws sync --region eu-central-1` must not invalidate an in-flight `--region us-west-2` reconcile. This is what makes scoping more than cosmetic.
+
+**Alternatives considered**:
+- *Prompt inside the lock* — rejected; a user who walks away from the prompt bricks every other `remo` invocation for the duration.
+- *Last-write-wins* — rejected; silently applies a plan the user never saw.
+
+## R3: Enumeration completeness (FR-040)
+
+**Decision**: The provider probe returns an explicit `complete: bool`. Removals are computed only when it is `True`.
+
+**Rationale**: This is the sharpest latent bug in the reconcile design, and it is already live in one provider:
+
+- **Hetzner truncates at 25 servers today.** `providers/hetzner.py:396` builds `https://api.hetzner.cloud/v1/servers?label_selector=remo` by hand with no `page`/`per_page`. Hetzner's `GET /v1/servers` defaults to `per_page=25` (max 50) and reports `meta.pagination.next_page`. Nothing in the file reads `meta`. Under clear-then-repopulate this silently lost entries; under reconcile it would silently propose deleting them.
+- **AWS paginates nowhere.** `providers/aws.py:721-731` (sync), `:185-204` (`_get_running_instance`), `:664-680` (`_find_remo_instance`) each issue a single `describe_instances`. The default page size is 1000, so this is latent rather than live — but it is the same defect.
+- **Incus and Proxmox are complete by construction.** `incus list -f csv` and `pct list` have no pagination.
+
+**Design consequence**: completeness is *reported by the provider*, never inferred by the reconcile layer. A provider that cannot prove completeness reports `False` and therefore can never produce a removal. Incus/Proxmox hardcode `True`; AWS and Hetzner set it from whether the paginator ran to exhaustion.
+
+**Chosen idioms**:
+- AWS: `ec2.get_paginator("describe_instances").paginate(Filters=...)`. A mid-iteration exception yields the pages collected so far with `complete=False` rather than aborting — additions still apply, removals are suppressed.
+- Hetzner: a new `_hetzner_api_paged(path, key)` looping on `meta.pagination.next_page` with `per_page=50`.
+
+## R4: Migrating Hetzner onto the existing API helper
+
+**Decision**: Route the new probe through `_hetzner_api()` (`providers/hetzner.py:446-485`), extending it with the paged wrapper.
+
+**Rationale**: The Hetzner provider has two parallel HTTP implementations. `_hetzner_api()` — added with the snapshot feature — does proper `HTTPError`/`URLError` handling and raises `RuntimeError` with a useful message. The older inline `urllib.request` blocks in `sync()` (`:396-407`), `info()` (`:327-365`) and `_query_hetzner_server_ip()` (`:44-75`) duplicate it badly; `_query_hetzner_server_ip` swallows every error and returns `""`.
+
+Consolidating also unlocks testing: `tests/unit/providers/test_hetzner_snapshot.py` already has an `api` fixture that patches `_hetzner_api`, which becomes the seam for the first-ever Hetzner sync tests.
+
+**Scope boundary**: migrate `sync`'s probe now (required). `info()` and `_query_hetzner_server_ip()` are opportunistic and out of scope unless free.
+
+## R5: Silent failure modes that must become loud (FR-009)
+
+**Decision**: Every probe path must distinguish "provider says there is nothing" from "we failed to ask."
+
+Three concrete offenders found:
+
+1. **Proxmox tag reads never check the return code.** `providers/proxmox.py:145-180` (`_read_tags_by_vmid`) runs a remote `cat` loop and parses `result.stdout` without inspecting `result.returncode`. An SSH failure yields an empty tag map → every container reads unmarked → a default sync registers **zero** containers, prints "Skipped N unmarked container(s)", and (today) has already wiped the node's entries. This is a false negative masquerading as a successful sync.
+2. **Incus IP resolution hard-exits mid-loop.** `providers/incus.py:113,117` — `_resolve_container_ip` calls `sys.exit(1)` on SSH failure. During a `--use-ip` sync this fires *after* `clear_known_hosts_by_prefix` at `:627`, leaving a partially-populated registry and no error recovery. Under the new design it must return `""` softly so FR-041's merge preserves the previously recorded address.
+3. **Neither incus SSH helper catches `FileNotFoundError`** for a missing `ssh`/`bash` binary in `_ssh_run_on_incus_host` (`incus.py:718-738`) — it escapes as an uncaught traceback.
+
+**Rationale**: Under clear-then-repopulate these produced wrong-but-quiet output. Under reconcile they produce *proposed deletions*, so they graduate from cosmetic to dangerous. The probe contract makes the distinction explicit: raise `ProbeError` (→ exit 1, registry untouched) or return `complete=False` (→ removals suppressed).
+
+## R6: Hetzner label application — Ansible vs. Python
+
+**Decision**: Apply the label in **Ansible at create time**, and backfill in **Python at update time**. Label the server only.
+
+**Rationale**: `grep -rn "labels" ansible/` returns zero hits, confirming the spec's core finding — `sync()`'s `label_selector=remo` matches nothing remo creates.
+
+For **create**, the label belongs in the existing task at `ansible/roles/hetzner_server/tasks/main.yml:55-69`, as a sibling key of `state: present`. `hetzner.hcloud.server` (pinned `>=6.7.0` in `ansible/requirements.yml`) diffs labels and issues a `PUT` when they differ, so it is idempotent — satisfying FR-033.
+
+For **backfill**, `hetzner.hcloud.server` and the raw `PUT /v1/servers/{id}` both treat the supplied label map as **authoritative and replace it wholesale**. That directly violates FR-034 ("without disturbing any other labels"). So backfill must read-merge: `_get_server_by_name` → merge `{"remo": "true"}` into the existing map → `PUT`. This also matches the established `_apply_managed_marker` precedent (`incus.py:137-153`, `proxmox.py:115-142`): return `(ok, err)`, never raise, never exit, and the caller warns-and-continues (`incus.py:421-428`).
+
+A further reason to keep backfill in Python: `ansible/hetzner_configure.yml:17-20` is a `hosts: all` play over SSH with no `localhost` tasks, so an Ansible backfill would require a new prepended play.
+
+**Scope decision — label the server only.** Not the volume, firewall, or SSH key:
+- `hetzner.hcloud.ssh_key` (`main.yml:28-36`) is **shared across servers** (default `remote-coding-key`, `defaults/main.yml:7`), so a per-server label is meaningless.
+- `ansible/hetzner_resize.yml:60-66` re-asserts the volume with `state: present` and no `labels:` key. If volumes were labeled, a resize could strip the label. Avoiding that trap is worth more than the marginal benefit.
+- `sync`'s selector only ever needs the server label.
+
+**Label chosen**: `remo: "true"`, matching the existing `label_selector=remo` query and the snapshot code's `remo` key (`hetzner.py:580-585`). Note the codebase is inconsistent about separators — snapshot labels use hyphens (`remo-snapshot-name`), AWS tags use underscores (`remo_resource_name`) — so a single-key `remo` label sidesteps the question entirely.
+
+## R7: Adoption criteria per provider (FR-030)
+
+**Decision**:
+
+| Provider | Default membership | `--all` widens to |
+|---|---|---|
+| Incus | `user.remo=true` config key | every container on the host |
+| Proxmox | `remo` tag | every container on the node |
+| AWS | `tag:remo=true` | additionally `tag:Name` matching `remo-*` |
+| Hetzner | `remo` label | every server in the project |
+
+**Rationale**: AWS has a real naming convention to lean on — `aws_instance_name: "remo-{{ aws_resource_name }}"` (`ansible/roles/aws_server/defaults/main.yml:5`), already queried as an exact filter at `aws.py:671`. `Values` supports `*` wildcards, so `remo-*` is a legitimate server-side filter.
+
+Hetzner has **no** prefix convention — `hetzner_server_name` defaults to the literal `"remo"` (`defaults/main.yml:3`) and `--name alice` produces a server named `alice`. There is nothing to pattern-match, so Hetzner's `--all` must mean "every server in the project." FR-030 requires stating this in the output, which makes the bluntness visible rather than surprising.
+
+**Alternatives considered**: inferring Hetzner membership from a paired `<name>-home` volume or `<name>-firewall` — rejected; costs two extra API calls and infers management from a naming coincidence.
+
+## R8: AWS name derivation
+
+**Decision**: Prefer the `remo_resource_name` tag; fall back to `Name` minus the `remo-` prefix.
+
+**Rationale**: `aws.py:740-751` currently reverse-engineers the registry name by string-stripping the `Name` tag, ignoring `remo_resource_name` — which the Ansible role *does* set authoritatively (`ansible/roles/aws_server/tasks/ec2.yml:80,122`). The current approach misbehaves on an instance tagged `remo=true` whose `Name` lacks the prefix: `removeprefix` is a no-op, so it is registered under its full `Name`. Reading the authoritative tag first is strictly better and costs nothing — the tag is already in the response.
+
+This matters more under reconcile than before, because the derived name is now the **matching key** (FR-039). An unstable name derivation would manifest as spurious remove-plus-add pairs.
+
+## R9: Exit codes
+
+**Decision**: `0` applied/no-op · `1` failure · `3` aborted without change. `2` is reserved.
+
+**Rationale**: Click exits `2` for usage errors, and `cli/shell.py:78,81,88` already follows that convention. Reusing `2` for "user declined" would make a mistyped flag indistinguishable from a deliberate refusal, defeating SC-013. Confirmed with the user; FR-043 was amended accordingly.
+
+**Plumbing consequence**: all four `sync()` functions currently return `None` (`incus.py:600`, `proxmox.py:731`, `hetzner.py:383`, `aws.py:707`) and none of the four CLI wrappers calls `sys.exit` (`cli/providers/incus.py:203`, `proxmox.py:230`, `hetzner.py:129-134`, `aws.py:125-131`) — so sync always exits 0 today unless a provider hard-exits. They must return `int` and the wrappers must `sys.exit(rc)`, matching the established pattern already used by create/destroy/update (`cli/providers/incus.py:157-168`).
+
+## R10: Non-interactive detection
+
+**Decision**: `sys.stdin.isatty()`, checked by the reconcile driver.
+
+**Rationale**: `core/output.py:38-56`'s `confirm()` has no TTY awareness — under closed stdin it hits `EOFError` and returns `default` (i.e. `False`), which is safe but indistinguishable from a deliberate "no". FR-014 requires a *specific* message and exit code for the non-interactive case, so the check must happen before prompting. The established convention is `sys.stdin.isatty() and not assume_yes`, used at `core/web_adopt.py:1117,1232`.
+
+## R11: Test seams
+
+**Decision**: Build on `tmp_config_dir` and the existing per-module patch points.
+
+- `tests/conftest.py:10-21` — `tmp_config_dir` sets `REMO_HOME` and yields the dir; `registry.json` and `registry.lock` land inside it. This is what makes SC-008's "real temporary registry" testable, replacing today's practice of mocking the destructive step out entirely.
+- Companion helpers in the same file: `build_v2_host_entry` (`:86`), `write_v2_registry` (`:105`).
+- Patch points, by convention on the *provider module's* symbol: `remo_cli.providers.incus._ssh_run_on_incus_host` (`tests/unit/providers/test_incus_marker.py:26-30`), `remo_cli.providers.proxmox._run_on_node`, `remo_cli.providers.hetzner._hetzner_api` (`test_hetzner_snapshot.py`), and the `ec2` client fixture in `test_aws_snapshot.py`.
+
+**Known breakage to budget for**:
+- `tests/unit/providers/test_provider_registry_entries.py` pins exact `KnownHost` shapes per provider (e.g. `"aws:buildbox:203.0.113.7:remo:i-abc:ssm"` at `:217`). Any change to what sync writes breaks it.
+- `tests/unit/cli/providers/test_incus_sync_all.py:21` and `test_proxmox_sync_all.py` assert `exit_code == 0` against a `return_value=None` mock; changing `sync` to return `int` breaks them.
+- Switching AWS to `get_paginator` requires every `ec2` stub in `tests/unit/providers/test_aws_snapshot.py` to grow a `get_paginator` stub.
+
+## R12: Out-of-scope observations
+
+Recorded because they were found during research, **not** proposed for this feature:
+
+- `pyproject.toml:12-19` lists `boto3` and `hcloud` as unconditional core dependencies, but `CLAUDE.md:152-153,185` documents `--extra aws` / `--extra hetzner` extras and lazy SDK imports that no longer exist. Also, `hcloud` is imported nowhere in `src/remo_cli/` — the Hetzner provider uses raw `urllib`.
+- `ansible/group_vars/all.yml:5` sets `hetzner_server_type: "cx23"` while `roles/hetzner_server/defaults/main.yml:4` says `"cx22"` and the CLI summary prints `cx22` (`hetzner.py:157`). group_vars wins, so the printed summary is wrong. Same pattern for volume size (20 vs 10).
+- `remo incus create` and `remo proxmox create` declare `--yes` but never pass it through (`cli/providers/incus.py:55`, `proxmox.py:62`) — an accepted-and-ignored flag.
+- `aws.py:614-624` (`update`) hardcodes `access_mode="ssm"` when rewriting the registry entry, ignoring the instance's actual `remo_access_mode` tag.
+- Several other unpaginated AWS calls exist (`describe_snapshots` at `aws.py:1132`, `describe_volumes` at `:1018`, IAM listings at `:245,256`). `describe_snapshots` with `OwnerIds=["self"]` is the one most likely to exceed a page in practice.

--- a/specs/016-sync-reconcile/spec.md
+++ b/specs/016-sync-reconcile/spec.md
@@ -1,0 +1,290 @@
+# Feature Specification: Unified Sync Reconcile
+
+**Feature Branch**: `016-sync-reconcile`
+
+**Created**: 2026-07-25
+
+**Status**: Draft
+
+**Input**: User description: "Rework `remo <provider> sync` from four hand-rolled clear-then-repopulate implementations into one shared reconcile primitive with identical semantics across incus, hetzner, aws, and proxmox. Each provider contributes only a 'desired hosts' query returning the set of KnownHost entries for a stated scope (provider type, type+region for AWS, or type+host for incus/proxmox); shared core code diffs desired vs. current registry entries within that scope and applies the result as one atomic registry rewrite, reporting added / removed / unchanged. This must fix three concrete bugs: (1) AWS region wipe; (2) AWS stopped-instance wipe; (3) empty-result wipe. Preserve existing behaviors: sync never mutates provider-side state; managed-marker semantics still determine membership; incus/proxmox `--all` adoption and `--use-ip` still work. Where practical, close the marker asymmetry so hetzner/aws can also adopt matching-but-unlabeled instances behind an explicit flag."
+
+## Overview
+
+`remo <provider> sync` reconciles the local host registry with what actually exists at a provider. Today each of the four providers implements this independently as *clear the registry, then re-add whatever the query returned*. That shape is destructive by construction: the clear is unconditional, it is often broader than the query that repopulates it, and it happens before anyone knows whether the query returned anything useful.
+
+This feature replaces the four implementations with a single reconcile behavior. A provider's only job becomes answering one question — *"for this scope, what hosts should be in the registry?"* — and shared logic does the rest: compute a plan against the current registry, show the user what will change, get consent for anything destructive, and commit the result in one atomic write.
+
+It also separates two questions the current code conflates. The managed marker decides what sync *pulls in*; whether a host still exists at the provider decides what sync *drops*. Treating an unmarked host as a deletion candidate is what makes today's `--all` adoptions evaporate on the next run, and it is why an unlabeled fleet reads as an empty one.
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - Sync never silently deletes registry entries (Priority: P1)
+
+A user runs `sync` in a situation where the provider query comes back empty or partial — wrong credentials, wrong region, a provider outage, a host that is temporarily unreachable, or instances that were never marked as remo-managed. Today the registry is emptied for that provider before the user is told anything, and the only message they see is a cheerful "no instances found". The user loses the record of every environment they can reach, with no undo.
+
+Under this feature, sync always computes a plan first. If the plan removes nothing, it applies silently. If the plan would remove any entry, sync names each entry it intends to remove, asks for explicit confirmation, and makes no change at all if the user declines.
+
+**Why this priority**: This is the data-loss guard that makes every other change safe. It is also the only fix that protects users from failure modes nobody has enumerated yet — a query that returns partial results for any reason is caught by the same gate.
+
+**Independent Test**: Populate a registry, force a provider query to return zero results, run sync, decline the prompt, and verify the registry is byte-identical to its prior state. Repeat with `--yes` and verify the removals are applied and reported.
+
+**Acceptance Scenarios**:
+
+1. **Given** a registry with three entries in scope and a provider query returning zero hosts, **When** the user runs sync and declines the prompt, **Then** all three entries remain and the command reports that no changes were made.
+2. **Given** the same situation, **When** the user runs sync with `--yes`, **Then** the three entries are removed and each removed entry is named in the output.
+3. **Given** a provider query that fails with an error, **When** the user runs sync, **Then** the registry is unchanged, the error is reported, and the command exits non-zero.
+4. **Given** a plan that only adds and updates entries, **When** the user runs sync, **Then** no confirmation is requested and the changes are applied.
+5. **Given** a plan containing removals and a session with no interactive terminal and no `--yes`, **When** the user runs sync, **Then** nothing is removed, the command explains that `--yes` is required for non-interactive removal, and it exits with the aborted code.
+6. **Given** any plan, **When** the user runs sync with `--dry-run`, **Then** the full plan is printed, no confirmation is requested, the registry is unchanged, and the command exits zero.
+7. **Given** a provider listing that cannot be enumerated completely, **When** the user runs sync, **Then** additions and updates are applied, no entry is removed, and the output warns that removals were skipped because the listing was incomplete.
+
+---
+
+### User Story 2 - AWS sync respects region boundaries (Priority: P1)
+
+A user runs remo instances in more than one AWS region. Today, syncing one region deletes the registry entries for every region and re-adds only the region that was queried, silently destroying the record of instances elsewhere. Under this feature, an AWS sync only ever considers entries belonging to the region it queried; entries in other regions are outside the scope and are neither examined nor touched.
+
+**Why this priority**: This is silent, unprompted destruction of correct data during a routine, non-destructive-sounding command. It is trivially reachable by anyone who passes `--region`.
+
+**Independent Test**: Register instances in two regions, sync one region, and verify the other region's entries survive untouched and are not counted in the sync report.
+
+**Acceptance Scenarios**:
+
+1. **Given** registry entries for `us-west-2` and `eu-central-1`, **When** the user runs `remo aws sync --region eu-central-1`, **Then** the `us-west-2` entries are unchanged and are reported as neither added, removed, nor unchanged — they are out of scope.
+2. **Given** the same registry, **When** an `eu-central-1` instance no longer exists at the provider, **Then** the removal prompt lists only that entry and never mentions `us-west-2` entries.
+3. **Given** a registry entry whose region is recorded and an `aws sync` for a different region, **When** the sync completes, **Then** the out-of-scope entry retains its recorded region.
+
+---
+
+### User Story 3 - Stopped instances survive sync (Priority: P1)
+
+Stopping an instance is a first-class, intentional remo operation — it is how a user parks an environment without paying for it. Today, `sync` filters to running instances only, so any sync while an instance is stopped deletes it from the registry. The user then cannot start it by name, and the recorded region is gone too, so recovery may require knowing which region to look in.
+
+Under this feature, sync retains instances in any non-terminal state and reports their state so the user can see at a glance which environments are parked. The state is shown, never stored — it is read fresh from the provider on every sync, so it cannot go stale after an out-of-band start or stop.
+
+**Why this priority**: The bug directly contradicts a supported workflow — `remo aws stop` followed by any `sync` destroys the thing that was stopped.
+
+**Independent Test**: Register an instance, stop it, run sync, and verify the entry survives with its recorded region intact and is reported as stopped.
+
+**Acceptance Scenarios**:
+
+1. **Given** a remo-managed instance in a stopped state, **When** the user runs sync for its region, **Then** the entry is retained, reported as unchanged, and annotated with its stopped state.
+2. **Given** a stopped instance whose public address is no longer published by the provider, **When** the user runs sync, **Then** the entry keeps its last recorded connection address rather than losing it or having it replaced with a placeholder.
+3. **Given** an instance that has been terminated at the provider, **When** the user runs sync, **Then** it appears in the removal list and is removed only after confirmation.
+4. **Given** a mix of running and stopped instances, **When** the user runs sync, **Then** the report distinguishes them.
+
+---
+
+### User Story 4 - One consistent sync report across providers (Priority: P2)
+
+A user who works across incus, proxmox, AWS, and Hetzner currently gets four different sync experiences: different flags, different messages, different amounts of detail, and different counts (two providers report a total that includes instances they did not actually register). Under this feature, every provider's sync states its scope, then reports the same four outcomes — added, updated, unchanged, removed — with the affected names, and the counts always reflect what was actually written.
+
+**Why this priority**: Consistency is what makes the safety guarantees legible. A user who has learned to trust `sync` on one provider should be able to trust it identically on the next. It is lower priority than the three correctness fixes because it improves comprehension rather than preventing loss.
+
+**Independent Test**: Run sync against each of the four providers with a mixed plan and verify the output structure, wording, and counts follow one template.
+
+**Acceptance Scenarios**:
+
+1. **Given** any provider, **When** sync runs, **Then** the output first states the scope being reconciled.
+2. **Given** a plan with additions, updates, unchanged entries, and removals, **When** sync completes, **Then** each category is reported with an accurate count, and non-empty categories name their entries.
+3. **Given** a host whose connection address changed at the provider, **When** sync runs, **Then** it is reported as updated rather than as removed-and-added, and no confirmation is requested.
+4. **Given** a plan that changes nothing, **When** sync completes, **Then** it says so explicitly rather than printing an empty report.
+
+---
+
+### User Story 5 - Adoption parity across providers (Priority: P3)
+
+Incus and Proxmox let a user pull in containers that lack the remo managed marker via `--all`. Hetzner and AWS have no equivalent, so a user with instances created outside remo — or created before markers existed — has no path to bring them under management short of hand-editing. This feature gives Hetzner and AWS an explicit opt-in adoption flag with the same shape and the same warning, so the four providers behave alike.
+
+It also closes the Hetzner marker gap at its source: Hetzner servers created by remo will carry the `remo` label that sync already looks for, and an existing unlabeled server can be backfilled through `remo hetzner update` the same way Incus and Proxmox already backfill their markers. Adoption becomes the escape hatch for genuinely foreign infrastructure rather than the only way to see your own fleet.
+
+**Why this priority**: This closes a real asymmetry and is explicitly requested, but it adds capability rather than fixing loss. It is safely deferrable behind the three P1 fixes.
+
+**Independent Test**: With an unmarked instance present at a Hetzner or AWS provider, run sync without the flag and verify it is skipped with a hint; run with the flag and verify it is adopted with a warning.
+
+**Acceptance Scenarios**:
+
+1. **Given** an unmarked instance at any of the four providers, **When** the user runs sync without the adoption flag, **Then** the instance is not registered, and the output names it and states how to adopt it for this run or mark it permanently.
+2. **Given** the same instance, **When** the user runs sync with the adoption flag, **Then** it is registered and the output warns that it is not remo-created.
+3. **Given** an unmarked instance that cannot be reliably distinguished from unrelated infrastructure at a provider, **When** the user runs sync with the adoption flag, **Then** the provider's adoption criteria are stated in the output so the user can see what was matched.
+4. **Given** an instance adopted via the flag on a previous run, **When** the user runs a plain sync with no adoption flag, **Then** the entry is retained, reported as unchanged and unmarked, and no confirmation is requested.
+5. **Given** a Hetzner server created by remo after this feature ships, **When** the user runs a plain `remo hetzner sync`, **Then** the server is discovered and registered without any adoption flag.
+6. **Given** an unlabeled Hetzner server created before this feature, **When** the user runs `remo hetzner update` against it and then syncs, **Then** the label is applied, the server is discovered by the plain sync, and re-running `update` reports no change.
+
+---
+
+### Edge Cases
+
+- **Hetzner's marker is never applied.** Hetzner sync selects servers by a `remo` label, but nothing in remo's provisioning path ever applies that label. Every Hetzner sync therefore matches zero servers and, under today's behavior, wipes the entire Hetzner registry. Two independent changes address this: entries are no longer dropped merely for lacking a marker (FR-022), and creation now applies the label so the fleet is discoverable at all (FR-031).
+- **A Hetzner server created before this feature.** It carries no label and will not be added by a default sync until it is backfilled via `remo hetzner update`. It is not removed either, because it still exists at the provider. Sync must make the unmarked state visible so the user knows a backfill is available.
+- **A host exists in scope at the provider and in the registry, but its recorded details differ** (address changed, access mode changed, region tag corrected). This is an update, not a remove-plus-add, and must not trigger a confirmation prompt.
+- **A host is destroyed and rebuilt under the same name.** Its provider-side identifier changes, but its registry identity does not. This is an update — the new identifier is recorded, and no removal is proposed (FR-039).
+- **The provider's listing is paginated and only the first page is retrieved.** Under clear-then-repopulate this silently lost entries; under reconcile it would silently propose deleting them. Enumeration must be exhaustive, and an incomplete listing must suppress removals rather than act on them (FR-040).
+- **The registry entry was hand-edited** — a customized login user, for example. Sync must refresh only what it observes at the provider and leave everything else intact (FR-041).
+- **Two providers claim the same registry name.** Registry identity is provider type plus name, so this cannot collide across providers — but two instances within one provider scope resolving to the same name can. Sync must detect this and refuse to write an ambiguous result rather than silently letting one win.
+- **The registry file does not exist yet.** Sync against an empty or absent registry is a pure-addition plan and must apply without prompting.
+- **A provider query partially succeeds** — for example, per-container address resolution fails for one container while the listing succeeded. The affected host must not be dropped from the desired set on that basis alone; it should retain its prior recorded address if one exists, or be reported as a problem rather than silently omitted (which would turn a transient failure into a proposed deletion).
+- **Concurrent sync runs.** Two syncs for different scopes running at once must not interleave into a lost update; the plan a user confirmed must be the plan that gets written, or the write must fail loudly (FR-046). Syncs of *different* scopes must not obstruct each other — only a change within the same scope invalidates a plan.
+- **A host still exists but has lost its managed marker** — its tag or label was removed by hand, or by another tool. It must be retained and reported as unmarked, never removed. This is only possible if the query enumerated it despite the missing marker (FR-044); a marker-filtered query would report it as absent and propose deleting it.
+- **A container is moved to another Incus project, or to another Proxmox node.** It leaves the enumerated boundary and therefore looks absent. Sync will propose removing it, so the output must name the boundary it examined (FR-045) and the confirmation gate must be what stands between that and data loss.
+- **A stopped instance is adopted or first discovered while stopped.** It has no published address; the entry must be creatable in a usable form or reported as needing a start before it can be reached.
+- **Incus/Proxmox host is unreachable.** The listing fails, so there is no desired set — sync must abort without touching the registry rather than treating "unreachable" as "empty".
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+#### Shared reconcile behavior
+
+- **FR-001**: Sync MUST behave identically across incus, hetzner, aws, and proxmox with respect to scoping, planning, confirmation, atomicity, and reporting. Provider-specific behavior MUST be limited to how the desired host set is obtained.
+- **FR-002**: Each provider MUST contribute only a *desired hosts* query: given a scope, it returns the complete set of registry entries that should exist within that scope. Providers MUST NOT clear, add, or otherwise mutate registry entries directly.
+- **FR-003**: Scope MUST be explicit and MUST be one of: provider type (Hetzner), provider type plus region (AWS), or provider type plus host (Incus, Proxmox). The scope in effect MUST be stated in the sync output before any change is described.
+- **FR-004**: Registry entries outside the stated scope MUST NOT be read as candidates for removal, modified, or reported in the sync summary.
+- **FR-005**: Sync MUST classify every in-scope registry entry and every host the provider reports into exactly one of: **added** (eligible at the provider, not yet in the registry), **updated** (in the registry, still present at the provider, recorded details differ), **unchanged** (in the registry, still present at the provider, recorded details identical), **removed** (in the registry, confirmed absent from the provider).
+- **FR-006**: The computed plan MUST be applied as a single atomic registry write. A partially applied plan MUST NOT be observable, and an interrupted or failed write MUST leave the registry in its pre-sync state.
+- **FR-007**: Sync MUST report each of the four categories with a count that reflects what was actually written, and MUST name the entries in every non-empty category. A plan with no changes MUST say so explicitly.
+- **FR-008**: Sync MUST NOT mutate provider-side state. It MUST NOT create, destroy, start, stop, tag, label, or reconfigure anything at the provider, including applying managed markers to instances that lack them. Applying markers remains the responsibility of the `create` and `update` commands (FR-031, FR-032).
+- **FR-009**: If the desired-hosts query fails, sync MUST abort with a clear error, leave the registry unchanged, and exit with the failure code (FR-043). A failed query MUST NOT be treated as an empty result.
+- **FR-039**: Correspondence between a registry entry and a provider-side host MUST be determined by the registry name within the scope. Provider-side identifiers such as an instance id or vmid are recorded details subject to update, never identity — a host destroyed and rebuilt under the same name MUST be classified as **updated**, not as a removal plus an addition.
+- **FR-040**: Before classifying any entry as **removed**, sync MUST have enumerated the provider's hosts for the scope exhaustively, following pagination to exhaustion. If enumeration cannot be completed, sync MUST apply only additions and updates, suppress every removal, and warn that removals were skipped because the provider listing was incomplete.
+- **FR-041**: On update, sync MUST refresh only the fields it observes from the provider — connection address, access mode, provider identifiers, and region. Any field the provider does not determine, or reports as unknown, MUST be preserved from the existing entry rather than overwritten or blanked.
+- **FR-044**: The provider query MUST enumerate every host in scope, whether or not it carries the managed marker. The marker MUST NOT be used to narrow the query itself; it MUST be evaluated per host after enumeration. Only conditions that establish genuine non-existence — such as an instance being terminated — may narrow the query. A query narrowed by the marker cannot distinguish "this host was deleted" from "this host lost its marker", which would make FR-022 unenforceable.
+- **FR-045**: Where a provider's enumeration covers less than the whole scope a user might reasonably assume — the default Incus project rather than all projects, or a single Proxmox node rather than a cluster — the sync output MUST name the boundary actually examined, so an entry proposed for removal can be recognised as one that merely moved outside it.
+- **FR-046**: If the in-scope registry entries change between the moment the plan is computed and the moment it is written, sync MUST abandon the write, report that the registry changed underneath it, instruct the user to re-run, and exit with the failure code. It MUST NOT retry automatically and MUST NOT apply a plan the user did not see.
+
+#### Destructive-change consent
+
+- **FR-010**: Any plan containing one or more removals MUST list every entry it intends to remove, by name, before requesting confirmation.
+- **FR-011**: Sync MUST require explicit confirmation before applying a plan containing removals. Additions, updates, and unchanged entries MUST NOT trigger a prompt.
+- **FR-012**: A `--yes` flag MUST be available on every provider's sync command to bypass the confirmation prompt for scripted use. It MUST NOT suppress the report of what was removed.
+- **FR-013**: Declining the confirmation MUST result in no registry change whatsoever — not the additions, not the updates, not the removals — and MUST be reported as an abort.
+- **FR-014**: When removals are planned, no interactive terminal is available, and `--yes` was not supplied, sync MUST make no change, explain that `--yes` is required for non-interactive removal, and exit with the aborted code (FR-043).
+- **FR-015**: A desired-hosts query returning zero hosts MUST flow through the same planning and confirmation path as any other result. The registry MUST NOT be cleared before the outcome is reported.
+- **FR-042**: Every provider's sync MUST accept a `--dry-run` flag that computes and prints the complete plan, makes no registry change, requests no confirmation, and exits zero. If both `--dry-run` and `--yes` are supplied, `--dry-run` MUST take precedence and nothing is written.
+- **FR-043**: Sync MUST use a consistent exit-code contract: **0** when the plan was applied or there was nothing to do (including a successful `--dry-run`); **1** when it failed (query error, write error, or a plan it refused to write); **3** when it aborted without changing anything because consent was declined or was unavailable non-interactively. Code **2** MUST NOT be used, as it is reserved for argument/usage errors by the CLI framework and by existing commands.
+
+#### AWS correctness
+
+- **FR-016**: `remo aws sync` MUST scope reconciliation to a single region. Only entries recorded as belonging to that region are in scope; entries for other regions MUST survive untouched.
+- **FR-017**: `remo aws sync` MUST include instances in all non-terminal states — at minimum pending, running, stopping, and stopped — in the desired host set. It MUST exclude only instances that are terminated or shutting down.
+- **FR-018**: A retained instance's recorded connection address MUST NOT be degraded when the provider reports no address for it (as happens while stopped). The last known address MUST be preserved. This is the AWS-specific case of the general field-ownership rule in FR-041.
+- **FR-019**: Sync output MUST indicate the observed state of each instance where that state is not "running", so a user can see which registered environments are parked. This state MUST NOT be persisted in the registry — it is read from the provider and reported at sync time only, so it can never be stale.
+- **FR-020**: An AWS registry entry MUST retain its recorded region across sync so that later commands targeting it by name resolve to the correct region.
+
+#### Marker semantics and preserved behavior
+
+- **FR-021**: The managed marker MUST govern **eligibility for addition** only — the `user.remo` config key on Incus, the `remo` tag on Proxmox, the `remo` label on Hetzner, and the `remo` tag on AWS determine which provider-side hosts sync will newly register.
+- **FR-022**: An in-scope registry entry whose host still exists at the provider MUST be retained regardless of whether that host carries the managed marker. Removal MUST be driven solely by confirmed absence from the provider, never by absence of a marker.
+- **FR-023**: If sync cannot determine whether an in-scope entry's host still exists at the provider, it MUST treat the entry as present and retain it.
+- **FR-024**: Sync MUST identify, in its report, any retained entry whose host lacks the managed marker, and MUST state how to mark it permanently.
+- **FR-025**: `--use-ip` MUST continue to work for Incus and Proxmox, storing each container's address instead of its name.
+- **FR-026**: `--all` MUST continue to adopt unmarked containers on Incus and Proxmox, and MUST continue to warn that adopted entries are not remo-created. Because removal is driven by absence rather than by the marker (FR-022), adopted entries now persist across later default syncs; the existing warning that a later default sync will drop them MUST be removed, as it will no longer be true.
+- **FR-027**: Incus and Proxmox sync MUST remain scoped to a single host, leaving other hosts' entries untouched.
+
+#### Adoption parity
+
+- **FR-028**: Hetzner and AWS sync MUST offer an explicit opt-in flag, with the same name and meaning as the Incus/Proxmox `--all`, that widens the set of addable hosts to include instances matching the provider's adoption criteria but lacking the managed marker. Because the query already enumerates unmarked hosts (FR-044), this flag changes only which hosts are eligible to be **added**; it never changes which are retained or removed.
+- **FR-029**: When adoption is available but not requested, sync MUST name the instances it skipped and state both how to adopt them for this run and how to mark them permanently.
+- **FR-030**: When adoption is requested, sync MUST state the criteria it used to match unmarked instances, so the user can verify what was pulled in.
+
+#### Hetzner managed-label gap
+
+- **FR-031**: Hetzner server creation MUST apply the `remo` managed label, so that servers remo creates are discoverable by a default sync without any adoption flag.
+- **FR-032**: `remo hetzner update` MUST backfill the `remo` label onto an existing server that lacks it, mirroring the marker backfill Incus and Proxmox already perform.
+- **FR-033**: Label application MUST be idempotent: creating or updating a server that already carries the label MUST report no change.
+- **FR-034**: Labels MUST be applied without disturbing any other labels already present on the server.
+- **FR-035**: After this feature, a default `remo hetzner sync` MUST discover every remo-created Hetzner server with no manual labeling step.
+
+#### Consistency and documentation
+
+- **FR-036**: Sync MUST be idempotent: running it twice in succession against an unchanged provider MUST produce no changes on the second run and MUST NOT prompt.
+- **FR-037**: Sync MUST detect two provider-side hosts that resolve to the same registry name within one scope, and MUST refuse to write rather than silently letting one displace the other.
+- **FR-038**: User-facing documentation MUST be updated to describe the new sync semantics — scoping, the confirmation gate, `--yes`, the report format, stopped-instance retention, marker-gates-addition-not-removal, adoption parity, and Hetzner labeling — before this feature is considered complete.
+
+### Key Entities
+
+- **Registry entry**: A record of one reachable environment. Identified within the registry by provider type plus name. Carries the connection address, login user, access mode, and per-provider details such as region or instance identifier.
+- **Scope**: The bounded slice of the registry a single sync run is allowed to change — provider type, optionally narrowed by region (AWS) or host (Incus, Proxmox). Everything outside the scope is invisible to that run.
+- **Desired host set**: A provider's answer, for one scope, at one moment. It carries two distinguishable facts per host: whether the host **exists** at the provider, and whether it is **eligible** to be newly registered. Eligibility is governed by the managed marker, optionally widened by the adoption flag; existence is independent of the marker, which is why the enumeration itself must never be narrowed by it (FR-044). The set also carries whether its enumeration was **complete**, since removals may only be derived from a complete enumeration.
+- **Reconcile plan**: The computed difference between the desired host set and the in-scope registry entries, partitioned into added, updated, unchanged, and removed, keyed by registry name. Additions come from eligibility; removals come only from confirmed non-existence within a complete enumeration. A plan can be printed without being applied, and when applied is applied in full or not at all.
+- **Managed marker**: The provider-side signal that an instance belongs to remo — a config key, tag, or label depending on provider. Sync reads it and never writes it; `create` and `update` write it.
+- **Observed instance state**: A provider's report of whether a host is running, stopped, pending, or stopping. Reported in the sync summary and never stored in the registry.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: No sync operation, under any provider, query result, or failure mode, removes a registry entry without first naming it and obtaining consent — verified by a test suite covering empty results, query failures, partial results, and out-of-scope entries for all four providers.
+- **SC-002**: Syncing one AWS region leaves 100% of other regions' registry entries intact.
+- **SC-003**: An instance that is stopped and then synced remains usable by name — a user can start it and connect to it afterward without re-registering it or knowing its region.
+- **SC-004**: A user who has run sync on one provider can predict the flags, prompts, and output structure of sync on the other three, because all four match a single documented contract.
+- **SC-005**: The four providers' sync implementations share their reconcile logic, such that adding a fifth provider requires supplying only a desired-hosts query and no new registry-mutation, confirmation, or reporting code.
+- **SC-006**: Every sync run performs at most one registry write, regardless of how many hosts are involved.
+- **SC-007**: Running sync twice against an unchanged provider reports zero changes on the second run and prompts on neither.
+- **SC-008**: Automated tests cover sync for all four providers against a real temporary registry — including the removal path, the confirmation path, and the `--yes` path — where today two providers have no sync tests at all and the destructive step is mocked out everywhere it is exercised.
+- **SC-009**: A default `remo hetzner sync` discovers 100% of remo-created Hetzner servers with no manual labeling and no adoption flag, where today it discovers none.
+- **SC-010**: An entry adopted via the adoption flag survives every subsequent default sync, without a prompt, for as long as its host exists at the provider.
+- **SC-011**: No registry format change or migration is required by this feature; a registry written before it is readable after it, and vice versa.
+- **SC-012**: A user can see exactly what sync would change, on any provider, without writing to the registry and without answering a prompt.
+- **SC-013**: A script can distinguish "sync applied", "sync failed", and "sync declined to remove anything" from the exit code alone, without parsing output.
+- **SC-014**: No provider listing that returns more results than fit in a single page can cause an entry to be proposed for removal.
+- **SC-015**: A host that still exists but whose managed marker was removed is never proposed for removal, on any provider.
+- **SC-016**: Two syncs of different scopes running concurrently both succeed; two syncs of the same scope never produce a write the user did not see.
+
+## Assumptions
+
+- Registry identity remains provider type plus name; this feature does not change how entries are keyed.
+- "Atomic" means a reader never observes a partially written registry and a failed write leaves the prior contents intact — consistent with how the registry is already written today.
+- The confirmation prompt follows the project's established convention for destructive commands, including the `--yes` / `-y` flag spelling already used by destroy, stop, and snapshot commands.
+- Bare `remo aws sync` with no `--region` continues to resolve a single default region and scopes to it; syncing every region at once is out of scope for this feature.
+- `--all` is retained as the adoption flag name on Incus and Proxmox and is reused on Hetzner and AWS, rather than introducing a second spelling.
+- AWS adoption criteria can rely on the existing `remo-<name>` instance naming convention that remo already creates and already queries against.
+- Sync remains a read-only operation with respect to the provider; users who want to permanently mark an adopted instance continue to use the provider's `update` command. Hetzner label application happens in `create` and `update`, never in `sync`.
+- No registry format change is introduced. Instance state is reported, never stored, and adoption is inferred from provider presence rather than recorded — so no new fields and no migration.
+- Existing registry contents are already in the current format.
+- Because removal is driven by absence at the provider, an entry the user no longer wants but whose host still exists is removed through the provider's `destroy` command or by editing the registry, not by sync.
+- The three-value exit-code contract (FR-043) is a deliberate departure from the codebase's current uniform exit-1 convention, and applies to sync only. Other commands are unaffected by this feature.
+- "Complete enumeration" is a property the provider query reports, not something the reconcile logic infers. A provider that cannot express completeness is treated as never complete, and therefore never produces removals.
+- Enumerating unmarked hosts (FR-044) costs one broader query rather than several narrow ones. For cloud providers this means listing the non-terminal instances in the scope and evaluating markers locally, which is acceptable for a CLI that already paginates.
+- Incus enumeration covers the default project only, and Proxmox enumeration covers the addressed node only. Widening either — `--all-projects`, or cluster-wide discovery — is out of scope for this feature; the requirement is that the boundary be visible, not that it be removed.
+
+## Clarifications
+
+### Session 2026-07-25
+
+- **Q: Hetzner's `remo` label is queried by sync but never applied by provisioning. Is closing that gap in scope?**
+  **A: In scope — apply and backfill.** Server creation applies the label, and `remo hetzner update` backfills it onto existing servers, mirroring the Incus/Proxmox marker-backfill pattern. Recorded as FR-031 through FR-035. This extends the feature to the Hetzner provisioning path, not just the CLI/registry layer.
+
+- **Q: Stopped instances must be "retained and marked" — where does the observed state live?**
+  **A: Display-only at sync time.** State is read from the provider and shown in the sync report; nothing about state is written to the registry. No registry format change, no migration, and the value can never go stale after an out-of-band start or stop. Recorded as FR-019 and SC-011.
+
+- **Q: Entries adopted via `--all` lack the managed marker, so a later default sync would now prompt to remove them on every run. How should that resolve?**
+  **A: Markers gate addition, not removal.** An entry is proposed for removal only when its host is confirmed absent at the provider; an unmarked host that still exists is retained and reported as such. The marker decides what sync pulls in; presence decides what it drops. This needs no schema change, eliminates the repeat prompts, and makes `--all` adoptions durable as a side effect — so the existing "a later default sync will drop those unmarked one(s) again" warning becomes false and must be removed. Recorded as FR-021 through FR-024, FR-026, and SC-010.
+
+- **Q: How is a registry entry matched to a provider-side host when deciding present / absent / updated?**
+  **A: By registry name within the scope.** Provider-side identifiers (AWS instance id, Proxmox vmid) are recorded details subject to update, never identity. A second identity notion would create cases where the two disagree, and would make a host rebuilt under the same name look like a deletion. Recorded as FR-039.
+
+- **Q: Provider listings are paginated. What should happen when enumeration is incomplete?**
+  **A: Exhaustive enumeration required; incomplete listings suppress removals.** Sync paginates to exhaustion; if it cannot complete, it applies additions and updates, removes nothing, and warns. Under the old clear-then-repopulate a truncated page silently lost entries — under reconcile it would silently propose deleting them, so this generalizes FR-023's "undetermined → retain" to the whole listing. Recorded as FR-040 and SC-014.
+
+- **Q: On an updated entry, which recorded fields may sync overwrite?**
+  **A: Only provider-observed fields.** Connection address, access mode, provider identifiers, and region are refreshed; anything the provider does not determine or reports as unknown is preserved. FR-018 (do not clobber a stopped instance's address) is the AWS-specific case of this rule. Recorded as FR-041.
+
+- **Q: Is there a way to preview a plan without committing to a confirmation prompt?**
+  **A: Yes — `--dry-run` on every provider's sync.** Prints the plan, writes nothing, prompts for nothing, exits zero; takes precedence over `--yes` if both are given. The plan is already computed and rendered, so exposing it read-only is nearly free, and it closes a real hole: a pure-addition plan otherwise applies with no preview at all, and a non-interactive session cannot decline to see one. Recorded as FR-042 and SC-012.
+
+- **Q: What exit-code contract should sync follow?**
+  **A: 0 applied or no-op · 1 failed · 3 aborted without change.** Aborted covers both a declined confirmation and removals blocked non-interactively without `--yes`. The codebase currently exits 1 for everything, but this feature's purpose is scriptability, and a script must be able to distinguish a broken provider query from a deliberate refusal. Code 2 is skipped because the CLI framework and `remo shell` already use it for usage errors, so reusing it would make a mistyped flag indistinguishable from a deliberate refusal. Recorded as FR-043 and SC-013.
+
+### Session 2026-07-25 (post-planning)
+
+Three gaps surfaced while designing the implementation. All three were latent contradictions rather than open choices, so each is recorded with the reasoning that forced the answer.
+
+- **Q: May the provider query filter on the managed marker?**
+  **A: No.** The query must enumerate every host in scope and evaluate the marker afterwards; only conditions establishing genuine non-existence (a terminated instance) may narrow it. This was a contradiction, not a preference: FR-022 requires retaining an existing-but-unmarked host, but a marker-filtered query cannot see one, so it would report the host as absent and propose deleting it — the exact failure FR-022 exists to prevent. Incus and Proxmox already enumerate everything and evaluate the marker locally; this makes AWS and Hetzner match. It also simplifies FR-028: the adoption flag now changes only what may be *added*. Recorded as FR-044, FR-028, SC-015.
+
+- **Q: What happens to a host that leaves the enumerated boundary — moved to another Incus project or Proxmox node?**
+  **A: Keep today's boundary, but name it.** Incus enumeration stays default-project-only and Proxmox stays node-local; widening either is out of scope. Such a host looks absent and will be proposed for removal, so the scope line must state the boundary actually examined, letting a user recognise a "removal" that is really a relocation. The confirmation gate is what prevents the loss. Recorded as FR-045.
+
+- **Q: How should a concurrent modification of the registry be handled between planning and writing?**
+  **A: Fail loudly, never retry.** If the in-scope entries change after the plan is shown, the write is abandoned with an instruction to re-run, exiting with the failure code. Automatic retry would either apply a plan the user never saw or re-prompt confusingly. Only same-scope changes invalidate a plan, so concurrent syncs of different scopes do not obstruct each other. Recorded as FR-046 and SC-016.

--- a/specs/016-sync-reconcile/tasks.md
+++ b/specs/016-sync-reconcile/tasks.md
@@ -1,0 +1,304 @@
+---
+
+description: "Task list for 016-sync-reconcile"
+---
+
+# Tasks: Unified Sync Reconcile
+
+**Input**: Design documents from `/specs/016-sync-reconcile/`
+
+**Prerequisites**: [plan.md](./plan.md), [spec.md](./spec.md), [research.md](./research.md), [data-model.md](./data-model.md), [contracts/](./contracts/), [quickstart.md](./quickstart.md)
+
+**Tests**: Test tasks ARE included and are not optional. SC-008 requires automated sync coverage for all four providers against a real temporary registry, and Constitution Principle II ("Test All Conditional Paths") binds the consent gate, the completeness flag, and the marker branches. Two providers have zero sync tests today, and where sync *is* tested the destructive step is mocked out — which is why neither AWS bug was caught.
+
+**Organization**: Grouped by user story. **Phase ordering is risk-ordered, not strictly priority-ordered** — see the note below.
+
+## Format: `[ID] [P?] [Story] Description`
+
+- **[P]**: Can run in parallel (different files, no dependencies)
+- **[Story]**: Which user story this task belongs to (US1–US5)
+- Exact file paths are included in every task
+
+## Path Conventions
+
+Single project, three-layer CLI: `src/remo_cli/{cli,providers,core}/`, `tests/{unit,integration}/`, `ansible/`, `docs/`.
+
+## Why Hetzner comes early
+
+US4 is P2, but its Hetzner half is pulled ahead of the two P1 AWS phases. Until `sync()` is rewritten, `remo hetzner sync` still runs `clear_known_hosts_by_type("hetzner")` unguarded — and because the `remo` label it filters on is never applied by anything, **every invocation wipes the entire Hetzner registry**. It is the only provider whose bug fires unconditionally, and the consent gate does not protect it until its own probe lands. The Proxmox half of US4 stays at its priority position.
+
+---
+
+## Phase 1: Setup
+
+**Purpose**: Establish a baseline so new breakage is distinguishable from pre-existing state.
+
+- [X] T001 Capture the baseline by running `uv run pytest`, `uv run mypy src/remo_cli`, and `uv run ruff check src/remo_cli`; record any pre-existing failures in the PR description
+- [X] T002 Add a `seed_registry(config_dir, hosts)` helper to `tests/conftest.py` that writes a v2 registry from a list of `KnownHost` objects, wrapping the existing `build_v2_host_entry` and `write_v2_registry` helpers
+
+---
+
+## Phase 2: Foundational (Blocking Prerequisites)
+
+**Purpose**: Build `core/reconcile.py`, the provider-agnostic engine every user story depends on.
+
+**⚠️ CRITICAL**: No user story work can begin until this phase is complete.
+
+**Note on parallelism**: T003–T011 all edit the same new file, and T012–T015 all edit the same test file. This phase is inherently sequential.
+
+- [X] T003 Create `src/remo_cli/core/reconcile.py` with module docstring, `from __future__ import annotations`, exit-code constants (`EXIT_OK = 0`, `EXIT_FAILURE = 1`, `EXIT_ABORTED = 3`), and the exception hierarchy `ProbeError` / `ReconcileConflictError` / `AmbiguousPlanError` / `ScopeError`; the module must never raise `SystemExit`, per the boundary `core/registry.py` already observes
+- [X] T004 Implement the `SyncScope` frozen dataclass in `src/remo_cli/core/reconcile.py` with `in_update_scope()`, `in_removal_scope()`, `describe()`, and construction-time validation, per the predicate table in `data-model.md`; `describe()` must name the enumeration boundary (`incus host h (default project)`, `proxmox node n (this node only)`) per FR-045, and AWS's asymmetry applies — an entry with an empty region is matchable for update but never removable
+- [X] T005 Implement the `DiscoveredHost` and `ProbeResult` frozen dataclasses in `src/remo_cli/core/reconcile.py`, including `complete`, `incomplete_reason`, `adoption_criteria`, and `warnings`
+- [X] T006 Implement `merge_entry(existing, discovered)` in `src/remo_cli/core/reconcile.py`: refresh `host`/`access_mode`/`instance_id`/`region` only when the discovered value is non-empty, always preserve `user`, never touch `type`/`name` (FR-041, with FR-018 falling out of it)
+- [X] T007 Implement the `ReconcilePlan` dataclass and the pure `build_plan(current, probe, scope)` in `src/remo_cli/core/reconcile.py` per the classification matrix in `data-model.md`, including `skipped_unmarked`, `retained_unmarked`, `removals_suppressed`, `baseline`, and `AmbiguousPlanError` on duplicate names within a scope (FR-037)
+- [X] T008 Implement `render_plan(plan, dry_run)` in `src/remo_cli/core/reconcile.py` following the output contract in `contracts/cli-sync.md`: scope line first, four named categories with accurate counts, the explicit no-op message, unmarked-retained note, skipped-unmarked hints, adoption criteria, and the suppressed-removals warning
+- [X] T009 Implement the consent gate in `src/remo_cli/core/reconcile.py`: `ConsentOutcome` enum and a function returning `NOT_REQUIRED` / `APPLY` / `DECLINED` / `NON_INTERACTIVE`, using `sys.stdin.isatty()` before `confirm()` from `core/output.py` (FR-011–FR-014)
+- [X] T010 Implement `apply_plan(plan)` in `src/remo_cli/core/reconcile.py` using a single `mutate_registry()` call whose mutator re-derives the in-scope slice, compares it to `plan.baseline`, raises `ReconcileConflictError` on drift with a re-run instruction and no automatic retry (FR-046), and otherwise splices reconciled in-scope entries back beside untouched out-of-scope ones — the mutator must call no other registry function, as the lock is not reentrant
+- [X] T011 Implement the `run_sync(scope, probe_fn, auto_confirm, dry_run)` driver in `src/remo_cli/core/reconcile.py` sequencing probe → read → build → render → dry-run exit → consent → apply, catching all four exceptions, reporting via `print_error`, and returning the exit code
+- [X] T012 Write unit tests for `SyncScope` predicates, `describe()` boundary text, and `merge_entry` in `tests/unit/core/test_reconcile.py`, covering all four providers, the AWS empty-region asymmetry, and the stopped-instance address-preservation case
+- [X] T013 Write unit tests for `build_plan` in `tests/unit/core/test_reconcile.py` covering every row of the classification matrix: added, updated, unchanged, removed, skipped-unmarked, retained-unmarked, `complete=False` suppression, out-of-scope isolation, and the ambiguous-name refusal
+- [X] T014 Write unit tests for the consent gate and exit codes in `tests/unit/core/test_reconcile.py` covering all five outcomes (no removals, `--yes`, confirmed, declined, non-interactive) and asserting `2` is never returned
+- [X] T015 Write unit tests for `apply_plan` in `tests/unit/core/test_reconcile.py` using `tmp_config_dir`, asserting exactly one `mutate_registry` call, out-of-scope entries preserved byte-for-byte, `ReconcileConflictError` when the same-scope slice changes between plan and write, and no conflict when only a *different* scope changed (FR-046, SC-016)
+
+**Checkpoint**: The reconcile engine is complete and fully unit-tested with no provider wired. Nothing is user-visible yet.
+
+---
+
+## Phase 3: User Story 1 - Sync never silently deletes registry entries (Priority: P1) 🎯 MVP
+
+**Goal**: Prove the whole pipeline end-to-end on one provider — scope, plan, consent, single atomic write, exit codes. Incus is chosen for the smallest probe and because it already has `--all` and `--use-ip` to prove they survive.
+
+**Independent Test**: Seed a registry, force the probe to return zero hosts, run sync and decline — registry byte-identical, exit 3. Repeat with `--yes` — removals applied and named, exit 0.
+
+### Implementation for User Story 1
+
+- [X] T016 [US1] Change `_resolve_container_ip` in `src/remo_cli/providers/incus.py` to return `""` on SSH failure instead of `sys.exit(1)` (currently lines 113 and 117), and catch `FileNotFoundError`, so a transient failure no longer becomes a proposed deletion
+- [X] T017 [US1] Add `_probe(scope, user, use_ip, include_all)` to `src/remo_cli/providers/incus.py` returning a `ProbeResult` with every container (marked and unmarked), `marked` from `user.remo`, `complete=True`, per-container IP failures appended to `warnings`, and `ProbeError` raised when the listing itself fails
+- [X] T018 [US1] Rewrite `sync()` in `src/remo_cli/providers/incus.py` to build a `SyncScope(type="incus", host=host)`, delegate to `run_sync`, accept `auto_confirm` and `dry_run`, and return `int` instead of `None`
+- [X] T019 [US1] Delete the now-false "a later default `sync` will drop those unmarked one(s) again" warning from `src/remo_cli/providers/incus.py` (FR-026)
+- [X] T020 [US1] Add `--yes/-y` and `--dry-run` options to the sync command in `src/remo_cli/cli/providers/incus.py` using the explicit-destination style from `contracts/cli-sync.md`, and add the missing `sys.exit(rc)`
+
+### Tests for User Story 1
+
+- [X] T021 [P] [US1] Write probe tests in `tests/unit/providers/test_incus_sync.py` patching `remo_cli.providers.incus._ssh_run_on_incus_host`, covering marked/unmarked classification, `include_all`, `--use-ip` soft IP failure, listing failure raising `ProbeError`, and read-only behaviour (no `incus config set`)
+- [X] T022 [P] [US1] Update `tests/unit/cli/providers/test_incus_sync_all.py` for the `int` return type and the new `--yes`/`--dry-run` flags, asserting they thread through as `auto_confirm` and `dry_run`
+- [X] T023 [US1] Write the core safety matrix in `tests/integration/test_sync_reconcile.py` against a real registry via `tmp_config_dir`: empty probe + decline (unchanged, exit 3), empty probe + `--yes` (removed and named, exit 0), probe raises (unchanged, exit 1), no TTY without `--yes` (unchanged, exit 3), `--dry-run` (unchanged, no prompt, exit 0), and additions-only (no prompt)
+
+**Checkpoint**: The empty-result wipe is fixed for Incus. This is a shippable MVP.
+
+---
+
+## Phase 4: Hetzner critical path (User Story 4, with a User Story 5 pull-forward)
+
+**Goal**: Stop the only unconditional data-loss path in the product. Also the first time `remo hetzner sync` has ever worked.
+
+**Independent Test**: A labelled server is discovered by a plain sync with no flags; a 60-server project enumerates all 60, not 25; an unlabelled but live server is retained rather than proposed for deletion.
+
+### Implementation
+
+- [X] T024 [US4] Add `_hetzner_api_paged(path, key)` to `src/remo_cli/providers/hetzner.py` looping on `meta.pagination.next_page` with `per_page=50` and reporting whether it ran to exhaustion — today `sync` silently truncates at Hetzner's 25-item default
+- [X] T025 [US4] Add `_probe(scope, include_all)` to `src/remo_cli/providers/hetzner.py` routed through `_hetzner_api_paged`, replacing the inline `urllib` block at lines 396-407; it MUST call `GET /v1/servers` **without** `label_selector` (FR-044) and set `marked` from the presence of the `remo` label locally, set `entry.host=""` for a server with no IPv4, and raise `ProbeError` when the API call fails
+- [X] T026 [US4] Rewrite `sync()` in `src/remo_cli/providers/hetzner.py` to accept `include_all`/`auto_confirm`/`dry_run`, delegate to `run_sync` with `SyncScope(type="hetzner")`, and return `int` — it currently takes no parameters at all
+- [X] T027 [US4] Add `--yes/-y` and `--dry-run` options plus `sys.exit(rc)` to the sync command in `src/remo_cli/cli/providers/hetzner.py`
+- [X] T028 [P] [US5] Add `labels: {remo: "true"}` to the `hetzner.hcloud.server` task in `ansible/roles/hetzner_server/tasks/main.yml` as a sibling key of `state: present`; label the server only — not the shared SSH key, and not the volume, whose `state: present` re-assertion in `ansible/hetzner_resize.yml` could strip it
+
+### Tests
+
+- [X] T029 [P] [US4] Write probe and pagination tests in `tests/unit/providers/test_hetzner_sync.py` patching `remo_cli.providers.hetzner._hetzner_api`, covering a two-page walk to exhaustion, a second-page failure yielding `complete=False` with removals suppressed, and a server with no IPv4
+- [X] T030 [US4] Add a marker-independence test to `tests/unit/providers/test_hetzner_sync.py` proving an unlabelled but live server in the registry is retained and reported unmarked, never removed (FR-044, SC-015) — the regression guard for the server-side-filter bug
+
+**Checkpoint**: Hetzner sync is functional and non-destructive for the first time.
+
+---
+
+## Phase 5: User Story 2 - AWS sync respects region boundaries (Priority: P1)
+
+**Goal**: Stop a single-region sync from destroying other regions' entries.
+
+**Independent Test**: Register instances in `us-west-2` and `eu-central-1`, sync `eu-central-1`, verify the `us-west-2` entries survive untouched and appear in no report category.
+
+### Implementation for User Story 2
+
+- [X] T031 [US2] Replace the single-shot `describe_instances` in `src/remo_cli/providers/aws.py` (currently lines 721-731) with `ec2.get_paginator("describe_instances").paginate(...)`, returning the pages gathered plus a `complete` flag that is `False` if iteration ends early
+- [X] T032 [US2] Add `_probe(scope, include_all)` to `src/remo_cli/providers/aws.py` that filters **on instance state only, never on `tag:remo`** (FR-044), setting `marked` from `tags.get("remo") == "true"` locally, and deriving the registry name from the `remo_resource_name` tag with the `Name`-minus-`remo-` fallback (research R8)
+- [X] T033 [US2] Rewrite `sync()` in `src/remo_cli/providers/aws.py` to build a `SyncScope(type="aws", region=_effective_region(region))`, delegate to `run_sync`, accept `auto_confirm`/`dry_run`, and return `int`
+- [X] T034 [US2] Add `--yes/-y` and `--dry-run` options plus `sys.exit(rc)` to the sync command in `src/remo_cli/cli/providers/aws.py`
+
+### Tests for User Story 2
+
+- [X] T035 [P] [US2] Write probe and region-scoping tests in `tests/unit/providers/test_aws_sync.py`, including an entry with an empty region that is matched-and-stamped but never proposed for removal, and an untagged but live instance that is retained rather than removed (FR-044, SC-015)
+- [X] T036 [P] [US2] Add a `get_paginator` stub to the `ec2` fixture in `tests/unit/providers/test_aws_snapshot.py` so the existing suite keeps passing
+- [X] T037 [US2] Add a two-region integration test to `tests/integration/test_sync_reconcile.py` asserting out-of-region entries survive, retain their recorded region, and appear in no report category
+
+**Checkpoint**: The AWS region wipe is fixed.
+
+---
+
+## Phase 6: User Story 3 - Stopped instances survive sync (Priority: P1)
+
+**Goal**: Stop `remo aws stop` followed by any sync from destroying the thing that was stopped.
+
+**Independent Test**: Register an instance, report it `stopped` with no `PublicIpAddress`, sync — entry retained with region and last-known address intact, annotated `(stopped)`, and nothing about state written to `registry.json`.
+
+### Implementation for User Story 3
+
+- [X] T038 [US3] Set the state filter in the AWS probe in `src/remo_cli/providers/aws.py` to `pending`, `running`, `stopping`, `stopped` — matching the list every other AWS command already passes to `_find_remo_instance` — excluding only `shutting-down` and `terminated` (FR-017)
+- [X] T039 [US3] Set `entry.host` in the AWS probe in `src/remo_cli/providers/aws.py` to the public IP or `""`, never falling back to the instance id, so `merge_entry` preserves the last known address for a stopped instance (FR-018)
+- [X] T040 [US3] Populate `DiscoveredHost.state` from `instance["State"]["Name"]` in the AWS probe in `src/remo_cli/providers/aws.py`
+- [X] T041 [US3] Render non-running state annotations inline on entry names in `render_plan` in `src/remo_cli/core/reconcile.py` (FR-019)
+
+### Tests for User Story 3
+
+- [X] T042 [US3] Add stopped-instance tests to `tests/unit/providers/test_aws_sync.py` using a realistic stopped-instance payload with the `PublicIpAddress` key absent, plus a `terminated` instance that correctly lands in removals
+- [X] T043 [US3] Add a stopped-instance integration test to `tests/integration/test_sync_reconcile.py` asserting the entry is retained, the region and address survive, and `registry.json` contains no state field
+
+**Checkpoint**: All three named bugs are fixed. Every P1 story is complete.
+
+---
+
+## Phase 7: User Story 4 - Proxmox and cross-provider uniformity (Priority: P2)
+
+**Goal**: Bring the last provider onto the shared engine and prove all four behave identically.
+
+**Independent Test**: Run sync against each of the four providers with a mixed plan and verify identical output structure, flags, and counts.
+
+### Implementation for User Story 4
+
+- [X] T044 [US4] Add a return-code check to `_read_tags_by_vmid` in `src/remo_cli/providers/proxmox.py` (currently lines 145-180) raising `ProbeError` on non-zero — today an SSH failure silently yields an empty tag map, so every container reads unmarked and the node's entries are wiped
+- [X] T045 [US4] Add `_probe(scope, user, use_ip, include_all)` to `src/remo_cli/providers/proxmox.py` combining `pct list` and the tag map, with `complete=True` and `ProbeError` on any listing failure
+- [X] T046 [US4] Rewrite `sync()` in `src/remo_cli/providers/proxmox.py` to delegate to `run_sync` with `SyncScope(type="proxmox", host=host)` and return `int`
+- [X] T047 [US4] Delete the now-false unmarked-drop warning from `src/remo_cli/providers/proxmox.py` (FR-026)
+- [X] T048 [US4] Add `--yes/-y` and `--dry-run` options plus `sys.exit(rc)` to the sync command in `src/remo_cli/cli/providers/proxmox.py`
+
+### Tests for User Story 4
+
+- [X] T049 [P] [US4] Write probe tests in `tests/unit/providers/test_proxmox_sync.py` patching `remo_cli.providers.proxmox._run_on_node`, explicitly covering the SSH-failure case that must now raise instead of reporting zero marked containers
+- [X] T050 [P] [US4] Update `tests/unit/cli/providers/test_proxmox_sync_all.py` for the `int` return type and the new flags
+- [X] T051 [US4] Add cross-provider tests to `tests/integration/test_sync_reconcile.py` asserting identical report structure across all four providers, the scope-boundary text (FR-045), idempotency (second run is a no-op that does not prompt), and exactly one registry write per run
+- [X] T052 [US4] Update the pinned per-provider registry shapes in `tests/unit/providers/test_provider_registry_entries.py`, deliberately revising the AWS pin where `host` no longer falls back to the instance id
+
+**Checkpoint**: All four providers share one engine and one contract.
+
+---
+
+## Phase 8: User Story 5 - Adoption parity (Priority: P3)
+
+**Goal**: Give AWS and Hetzner the `--all` adoption flag, and complete the Hetzner label story with a backfill path.
+
+**Independent Test**: With an unmarked instance present, sync without the flag skips it with a hint; with the flag adopts it and states the criteria. An unlabelled Hetzner server gains the label via `update`, and re-running reports no change.
+
+### Implementation for User Story 5
+
+- [X] T053 [US5] Add `include_all` support to the AWS probe in `src/remo_cli/providers/aws.py`, widening **eligibility for addition** to instances whose `Name` tag matches `remo-*`, and setting `adoption_criteria`; the query itself is unchanged, since it already enumerates untagged instances (FR-044)
+- [X] T054 [US5] Add the `--all` option to the sync command in `src/remo_cli/cli/providers/aws.py`
+- [X] T055 [P] [US5] Add `include_all` support to the Hetzner probe in `src/remo_cli/providers/hetzner.py`, widening eligibility for addition to every server in the project (no naming convention exists to filter on, per research R7) and setting `adoption_criteria` to say so plainly
+- [X] T056 [US5] Add the `--all` option to the sync command in `src/remo_cli/cli/providers/hetzner.py`
+- [X] T057 [US5] Add `_apply_managed_label(server_name)` to `src/remo_cli/providers/hetzner.py` that reads the server's current labels, merges `remo: "true"`, and `PUT`s the merged map — a blind `PUT` replaces labels wholesale and would violate FR-034; return `(ok, err)` and never raise, mirroring `_apply_managed_marker` in the other providers
+- [X] T058 [US5] Call `_apply_managed_label` from `update()` in `src/remo_cli/providers/hetzner.py`, warning on failure without failing the update, mirroring `providers/incus.py:421-428`
+
+### Tests for User Story 5
+
+- [X] T059 [P] [US5] Add adoption tests to `tests/unit/providers/test_aws_sync.py` covering skipped-without-flag with hints, adopted-with-flag with criteria printed, and that the flag does not change what the query enumerates
+- [X] T060 [P] [US5] Add adoption tests to `tests/unit/providers/test_hetzner_sync.py` covering the same three cases
+- [X] T061 [P] [US5] Write label backfill tests in `tests/unit/providers/test_hetzner_label.py` asserting idempotency (no change when already labelled) and that an unrelated pre-existing label such as `env: prod` survives the merge
+- [X] T062 [US5] Add a durability test to `tests/integration/test_sync_reconcile.py` proving an entry adopted via `--all` is retained by a subsequent plain sync, reported as unmarked, with no prompt — the regression guard for the marker-semantics change
+
+**Checkpoint**: All five user stories complete.
+
+---
+
+## Phase 9: Polish & Cross-Cutting Concerns
+
+- [X] T063 Update `README.md`: add `--yes`/`--dry-run`/`--all` to the sync command reference (lines 291, 300, 313-314, 324-325) and rewrite the troubleshooting prose (lines 405-424) for the new marker semantics, deleting the claim that a later default sync drops `--all`-adopted entries
+- [X] T064 [P] Update the sync section in `docs/proxmox.md` (lines 64-65), replacing "rebuild known_hosts entries" — which describes the behaviour being removed — with the reconcile semantics, and note the node-only enumeration boundary
+- [X] T065 [P] Add a Sync section to `docs/incus.md` under CLI Commands, covering scope, the confirmation gate, `--yes`, `--dry-run`, `--all`, and the default-project enumeration boundary
+- [X] T066 [P] Add a Sync section to `docs/hetzner.md` covering the same, plus the new `remo` label applied at creation and the `update` backfill path
+- [X] T067 [P] Update the IAM permissions table in `docs/aws.md` (line 218) to reflect that sync now describes all non-terminal instances in the region and reads tags
+- [X] T068 Verify no stale copy remains by grepping `src/` for "will drop those unmarked" and "rebuild known_hosts", and confirm both return nothing
+- [X] T069 [P] Update `CLAUDE.md` Active Technologies and Recent Changes with the 016-sync-reconcile entry
+- [X] T070 Run the full validation from `quickstart.md` including the exit-code checks (0 for `--dry-run`, 2 for a bad flag, 3 for a declined removal)
+- [X] T071 Run `uv run pytest`, `uv run mypy src/remo_cli`, and `uv run ruff check src/remo_cli` and compare against the T001 baseline
+
+---
+
+## Dependencies & Execution Order
+
+### Phase Dependencies
+
+- **Setup (Phase 1)**: no dependencies
+- **Foundational (Phase 2)**: depends on Setup — **blocks every user story**
+- **Phase 3 (US1, Incus)**: depends on Phase 2
+- **Phase 4 (Hetzner)**: depends on Phase 2. Independent of Phase 3, though doing Incus first settles the contract on a simpler provider
+- **Phase 5 (US2, AWS region)**: depends on Phase 2
+- **Phase 6 (US3, AWS stopped)**: depends on Phase 5's AWS probe (T032). T041 edits `core/reconcile.py`
+- **Phase 7 (US4, Proxmox)**: depends on Phase 2; T051 additionally needs Phases 3–6 for the cross-provider assertions
+- **Phase 8 (US5)**: T053–T054 need Phase 5; T055–T058 need Phase 4
+- **Phase 9 (Polish)**: depends on all shipped stories
+
+### Within Each User Story
+
+- Provider probe before the `sync()` rewrite before the CLI flags
+- `core/` before `providers/` before `cli/`
+- Implementation before that story's tests, except where a test pins existing behaviour about to change (T036, T052)
+
+### Parallel Opportunities
+
+- **Phase 2**: none — all tasks share two files
+- **Phase 3**: T021, T022 (different test files)
+- **Phase 4**: T028 (Ansible) is independent of the whole Python chain; T029 pairs with it
+- **Phase 5**: T035, T036 (different test files)
+- **Phase 7**: T049, T050 (different test files)
+- **Phase 8**: T055 with T053; T059, T060, T061 (three different test files)
+- **Phase 9**: T064, T065, T066, T067, T069 (five different documents)
+- **Across phases**: once Phase 2 lands, Phases 3, 4, 5 and 7 touch disjoint provider modules and can be staffed concurrently
+
+---
+
+## Parallel Example: after Phase 2
+
+```bash
+# Developer A — Incus MVP (Phase 3)
+Task: "Add _probe() to src/remo_cli/providers/incus.py"
+
+# Developer B — Hetzner critical path (Phase 4), concurrently
+Task: "Add _hetzner_api_paged() to src/remo_cli/providers/hetzner.py"
+Task: "Add labels: {remo: 'true'} to ansible/roles/hetzner_server/tasks/main.yml"
+
+# Developer C — AWS (Phase 5), concurrently
+Task: "Replace describe_instances with get_paginator in src/remo_cli/providers/aws.py"
+```
+
+---
+
+## Implementation Strategy
+
+### MVP First (Phases 1–3)
+
+1. Setup → Foundational → User Story 1
+2. **STOP and VALIDATE**: the empty-result wipe is fixed for Incus, with consent, dry-run, and correct exit codes
+3. Shippable on its own — it fixes the failure mode common to all providers, for one of them
+
+### Incremental Delivery
+
+1. Phases 1–2 → engine ready, nothing user-visible
+2. Phase 3 → **MVP**: no silent deletion (Incus)
+3. Phase 4 → the unconditional Hetzner wipe is stopped; `hetzner sync` works for the first time
+4. Phase 5 → AWS region wipe fixed
+5. Phase 6 → AWS stopped-instance wipe fixed; **all three named bugs closed**
+6. Phase 7 → all four providers uniform
+7. Phase 8 → adoption parity and the Hetzner backfill path
+8. Phase 9 → documentation truthful again
+
+### Minimum Risk-Reduction Set
+
+If only part of this ships, Phases 1–4 remove every unconditional data-loss path: the engine, the consent gate, and the one provider whose bug fires on every invocation. Phases 5–6 then close the two conditional AWS paths.
+
+---
+
+## Notes
+
+- `[P]` marks tasks in different files with no incomplete dependencies
+- Every task names the exact file it touches
+- Commit after each task or logical group
+- Stop at any checkpoint to validate a story independently
+- Constitution Principle II is the binding gate: the consent gate's five outcomes, `complete` True/False, and `marked` True/False must each be exercised, not sampled

--- a/src/remo_cli/cli/providers/aws.py
+++ b/src/remo_cli/cli/providers/aws.py
@@ -124,11 +124,31 @@ def list_cmd() -> None:
 
 @aws.command()
 @click.option("--region", default="", help="AWS region to sync.")
-def sync(region: str) -> None:
-    """Sync local registry with running AWS instances."""
+@click.option(
+    "--all",
+    "include_all",
+    is_flag=True,
+    help="Also register unmarked instances named remo-* (this run only).",
+)
+@click.option("--yes", "-y", "auto_confirm", is_flag=True, default=False, help="Skip the removal confirmation prompt.")
+@click.option(
+    "--dry-run",
+    "dry_run",
+    is_flag=True,
+    default=False,
+    help="Show what would change without writing to the registry.",
+)
+def sync(region: str, include_all: bool, auto_confirm: bool, dry_run: bool) -> None:
+    """Discover EC2 instances in one region and reconcile the registry."""
     from remo_cli.providers.aws import sync as aws_sync
 
-    aws_sync(region=region)
+    rc = aws_sync(
+        region=region,
+        include_all=include_all,
+        auto_confirm=auto_confirm,
+        dry_run=dry_run,
+    )
+    sys.exit(rc)
 
 
 @aws.command()

--- a/src/remo_cli/cli/providers/hetzner.py
+++ b/src/remo_cli/cli/providers/hetzner.py
@@ -127,11 +127,26 @@ def info(name: str) -> None:
 
 
 @hetzner.command()
-def sync() -> None:
-    """Discover VMs and update registry."""
+@click.option(
+    "--all",
+    "include_all",
+    is_flag=True,
+    help="Also register servers that lack the remo managed marker.",
+)
+@click.option("--yes", "-y", "auto_confirm", is_flag=True, default=False, help="Skip the removal confirmation prompt.")
+@click.option(
+    "--dry-run",
+    "dry_run",
+    is_flag=True,
+    default=False,
+    help="Show what would change without writing to the registry.",
+)
+def sync(include_all: bool, auto_confirm: bool, dry_run: bool) -> None:
+    """Discover Hetzner Cloud servers and reconcile the registry."""
     from remo_cli.providers.hetzner import sync as do_sync
 
-    do_sync()
+    rc = do_sync(include_all=include_all, auto_confirm=auto_confirm, dry_run=dry_run)
+    sys.exit(rc)
 
 
 # ---------------------------------------------------------------------------

--- a/src/remo_cli/cli/providers/incus.py
+++ b/src/remo_cli/cli/providers/incus.py
@@ -198,9 +198,32 @@ def info(name: str, host: str, user: str) -> None:
     is_flag=True,
     help="Register every container on the host, including those without the remo managed marker (pre-feature behavior).",
 )
-def sync(host: str, user: str, use_ip: bool, include_all: bool) -> None:
+@click.option(
+    "--yes", "-y", "auto_confirm", is_flag=True, default=False,
+    help="Skip the removal confirmation prompt.",
+)
+@click.option(
+    "--dry-run", "dry_run", is_flag=True, default=False,
+    help="Show what would change without writing to the registry.",
+)
+def sync(
+    host: str,
+    user: str,
+    use_ip: bool,
+    include_all: bool,
+    auto_confirm: bool,
+    dry_run: bool,
+) -> None:
     """Discover containers from an Incus host."""
-    providers_incus.sync(host=host, user=user, use_ip=use_ip, include_all=include_all)
+    rc = providers_incus.sync(
+        host=host,
+        user=user,
+        use_ip=use_ip,
+        include_all=include_all,
+        auto_confirm=auto_confirm,
+        dry_run=dry_run,
+    )
+    sys.exit(rc)
 
 
 @incus.command()

--- a/src/remo_cli/cli/providers/proxmox.py
+++ b/src/remo_cli/cli/providers/proxmox.py
@@ -225,9 +225,32 @@ def info(name: str, host: str, user: str) -> None:
     is_flag=True,
     help="Register every container on the host, including those without the remo managed marker (pre-feature behavior).",
 )
-def sync(host: str, user: str, use_ip: bool, include_all: bool) -> None:
+@click.option(
+    "--yes", "-y", "auto_confirm", is_flag=True, default=False,
+    help="Skip the removal confirmation prompt.",
+)
+@click.option(
+    "--dry-run", "dry_run", is_flag=True, default=False,
+    help="Show what would change without writing to the registry.",
+)
+def sync(
+    host: str,
+    user: str,
+    use_ip: bool,
+    include_all: bool,
+    auto_confirm: bool,
+    dry_run: bool,
+) -> None:
     """Discover containers from a Proxmox host."""
-    providers_proxmox.sync(host=host, user=user, use_ip=use_ip, include_all=include_all)
+    rc = providers_proxmox.sync(
+        host=host,
+        user=user,
+        use_ip=use_ip,
+        include_all=include_all,
+        auto_confirm=auto_confirm,
+        dry_run=dry_run,
+    )
+    sys.exit(rc)
 
 
 @proxmox.command()

--- a/src/remo_cli/core/reconcile.py
+++ b/src/remo_cli/core/reconcile.py
@@ -1,0 +1,477 @@
+"""Provider-agnostic sync reconcile engine (feature 016-sync-reconcile).
+
+A provider's sync boils down to one *probe* — "what hosts exist in this
+scope, which carry the managed marker, and was the enumeration complete?"
+— fed through :func:`run_sync`. Everything else (diffing against the
+registry, rendering the plan, gating removals behind consent, and writing
+exactly once) lives here so no provider hand-rolls it again.
+
+House rules inherited from :mod:`core.registry`:
+
+- Never raise :class:`SystemExit`. Every entry point returns an exit code
+  (``EXIT_OK`` / ``EXIT_FAILURE`` / ``EXIT_ABORTED``); only the thin CLI
+  wrapper built in a later phase calls ``sys.exit(rc)``.
+- Exit code ``2`` is reserved for Click/usage errors and is never returned
+  from this module.
+
+See specs/016-sync-reconcile/data-model.md and contracts/{cli-sync,
+provider-probe}.md for the authoritative contracts this module implements.
+"""
+
+from __future__ import annotations
+
+import sys
+from collections.abc import Callable, Iterable
+from dataclasses import dataclass, field
+from enum import Enum
+
+from remo_cli.core.output import confirm, print_error, print_info, print_success, print_warning
+from remo_cli.core.registry import mutate_registry, read_registry
+from remo_cli.models.host import KnownHost
+
+# ---------------------------------------------------------------------------
+# Exit codes (FR-043) -- 2 is deliberately never defined here, it is Click's.
+# ---------------------------------------------------------------------------
+
+EXIT_OK = 0
+EXIT_FAILURE = 1
+EXIT_ABORTED = 3
+
+
+# ---------------------------------------------------------------------------
+# Error taxonomy -- none of these are ever allowed to escape run_sync.
+# ---------------------------------------------------------------------------
+
+
+class ReconcileError(Exception):
+    """Base class for all reconcile-layer errors."""
+
+
+class ProbeError(ReconcileError):
+    """A provider probe could not ask its provider (FR-009)."""
+
+
+class ReconcileConflictError(ReconcileError):
+    """The in-scope registry slice moved between plan and write (R2)."""
+
+
+class AmbiguousPlanError(ReconcileError):
+    """Two probed hosts resolved to the same registry name in scope (FR-037)."""
+
+
+class ScopeError(ReconcileError):
+    """A :class:`SyncScope` was constructed with an invalid field combination."""
+
+
+# ---------------------------------------------------------------------------
+# SyncScope
+# ---------------------------------------------------------------------------
+
+_HOST_SCOPED_TYPES = ("incus", "proxmox")
+
+
+@dataclass(frozen=True)
+class SyncScope:
+    type: str
+    host: str = ""
+    region: str = ""
+
+    def __post_init__(self) -> None:
+        if self.type in _HOST_SCOPED_TYPES:
+            if not self.host:
+                raise ScopeError(f"{self.type} sync scope requires a non-empty host")
+        elif self.type == "aws":
+            if not self.region:
+                raise ScopeError("aws sync scope requires a non-empty region")
+        elif self.type == "hetzner":
+            if self.host or self.region:
+                raise ScopeError("hetzner sync scope must not carry a host or region")
+        else:
+            raise ScopeError(f"unknown provider type for sync scope: {self.type!r}")
+
+    def in_update_scope(self, entry: KnownHost) -> bool:
+        if self.type in _HOST_SCOPED_TYPES:
+            return entry.type == self.type and entry.name.startswith(f"{self.host}/")
+        if self.type == "hetzner":
+            return entry.type == "hetzner"
+        if self.type == "aws":
+            # A region-less legacy AWS entry matches every region's update
+            # scope, so a hit against the queried region self-heals it --
+            # but it can never be *removed* while region-less (see below).
+            return entry.type == "aws" and entry.region in (self.region, "")
+        return False
+
+    def in_removal_scope(self, entry: KnownHost) -> bool:
+        if self.type == "aws":
+            return entry.type == "aws" and entry.region == self.region
+        return self.in_update_scope(entry)
+
+    def describe(self) -> str:
+        if self.type == "aws":
+            return f"aws region {self.region}"
+        if self.type == "incus":
+            return f"incus host {self.host} (default project)"
+        if self.type == "proxmox":
+            return f"proxmox node {self.host} (this node only)"
+        if self.type == "hetzner":
+            return "hetzner (all servers in project)"
+        raise ScopeError(f"unknown provider type for sync scope: {self.type!r}")  # pragma: no cover
+
+
+# ---------------------------------------------------------------------------
+# Probe seam
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class DiscoveredHost:
+    entry: KnownHost
+    marked: bool
+    state: str = ""
+    # Eligible for addition when --all is passed and this host is unmarked
+    # (FR-030). Defaults to True (most providers widen --all to "every host
+    # in scope"); a provider with a narrower adoption convention -- AWS's
+    # remo-* naming, per research.md R7 -- sets this per host instead.
+    adopted: bool = True
+
+
+@dataclass(frozen=True)
+class ProbeResult:
+    hosts: list[DiscoveredHost]
+    complete: bool
+    incomplete_reason: str = ""
+    adoption_criteria: str = ""
+    warnings: list[str] = field(default_factory=list)
+
+
+ProbeFn = Callable[[], ProbeResult]
+
+
+# ---------------------------------------------------------------------------
+# MergedEntry rule (FR-041)
+# ---------------------------------------------------------------------------
+
+
+def merge_entry(existing: KnownHost, discovered: KnownHost) -> KnownHost:
+    return KnownHost(
+        type=existing.type,
+        name=existing.name,
+        host=discovered.host or existing.host,
+        # Always the existing value: every provider hardcodes "remo" here,
+        # so preserving it only ever helps a hand-edited registry.
+        user=existing.user,
+        instance_id=discovered.instance_id or existing.instance_id,
+        access_mode=discovered.access_mode or existing.access_mode,
+        region=discovered.region or existing.region,
+    )
+
+
+# ---------------------------------------------------------------------------
+# ReconcilePlan + build_plan
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class ReconcilePlan:
+    scope: SyncScope
+    added: list[KnownHost] = field(default_factory=list)
+    updated: list[tuple[KnownHost, KnownHost]] = field(default_factory=list)
+    unchanged: list[KnownHost] = field(default_factory=list)
+    removed: list[KnownHost] = field(default_factory=list)
+    skipped_unmarked: list[str] = field(default_factory=list)
+    retained_unmarked: list[str] = field(default_factory=list)
+    states: dict[str, str] = field(default_factory=dict)
+    removals_suppressed: bool = False
+    baseline: tuple[KnownHost, ...] = field(default_factory=tuple)
+    warnings: list[str] = field(default_factory=list)
+
+    @property
+    def has_removals(self) -> bool:
+        return bool(self.removed)
+
+    @property
+    def is_noop(self) -> bool:
+        return not self.added and not self.updated and not self.removed
+
+
+def build_plan(
+    current: list[KnownHost],
+    probe: ProbeResult,
+    scope: SyncScope,
+    include_all: bool,
+) -> ReconcilePlan:
+    in_scope_current = [h for h in current if scope.in_update_scope(h)]
+    registry_by_name = {h.name: h for h in in_scope_current}
+
+    discovered_by_name: dict[str, DiscoveredHost] = {}
+    for discovered in probe.hosts:
+        name = discovered.entry.name
+        if name in discovered_by_name:
+            raise AmbiguousPlanError(
+                f"probe returned two or more hosts named {name!r} within "
+                f"{scope.describe()} -- this is a probe bug, not a diffable state"
+            )
+        discovered_by_name[name] = discovered
+
+    plan = ReconcilePlan(scope=scope, baseline=tuple(in_scope_current))
+
+    for name, discovered in discovered_by_name.items():
+        existing = registry_by_name.get(name)
+        if existing is None:
+            if discovered.marked or (include_all and discovered.adopted):
+                plan.added.append(discovered.entry)
+                if discovered.state:
+                    plan.states[name] = discovered.state
+            else:
+                plan.skipped_unmarked.append(name)
+            continue
+
+        merged = merge_entry(existing, discovered.entry)
+        if merged != existing:
+            plan.updated.append((existing, merged))
+        else:
+            plan.unchanged.append(existing)
+        if discovered.state:
+            plan.states[name] = discovered.state
+        if not discovered.marked:
+            plan.retained_unmarked.append(name)
+
+    for name, existing in registry_by_name.items():
+        if name in discovered_by_name:
+            continue
+        if probe.complete and scope.in_removal_scope(existing):
+            plan.removed.append(existing)
+        else:
+            plan.unchanged.append(existing)
+
+    # Communicates "enumeration incomplete", never "out of removal scope" --
+    # the latter is normal and expected, not a suppression warning.
+    plan.removals_suppressed = not probe.complete
+    plan.warnings = list(probe.warnings)
+
+    return plan
+
+
+# ---------------------------------------------------------------------------
+# render_plan (contracts/cli-sync.md "Output contract")
+# ---------------------------------------------------------------------------
+
+
+def _plural(count: int, singular: str, plural: str) -> str:
+    return singular if count == 1 else plural
+
+
+def render_plan(
+    plan: ReconcilePlan,
+    dry_run: bool,
+    adoption_criteria: str = "",
+    include_all: bool = False,
+    incomplete_reason: str = "",
+) -> None:
+    prefix = "[dry-run] " if dry_run else ""
+    print_info(f"{prefix}Reconciling {plan.scope.describe()}...")
+
+    for warning in plan.warnings:
+        print_warning(warning)
+
+    nothing_to_report = (
+        plan.is_noop
+        and not plan.removals_suppressed
+        and not plan.retained_unmarked
+        and not plan.skipped_unmarked
+    )
+    if nothing_to_report:
+        print_info(f"Nothing to reconcile — registry already matches {plan.scope.describe()}.")
+        return
+
+    def annotate(name: str) -> str:
+        state = plan.states.get(name, "")
+        return f"{name} ({state})" if state else name
+
+    if plan.added:
+        names = ", ".join(annotate(h.name) for h in plan.added)
+        print_info(f"  + added      {len(plan.added)}   {names}")
+    if plan.updated:
+        names = ", ".join(annotate(after.name) for _before, after in plan.updated)
+        print_info(f"  ~ updated    {len(plan.updated)}   {names}")
+    if plan.unchanged:
+        names = ", ".join(annotate(h.name) for h in plan.unchanged)
+        print_info(f"  = unchanged  {len(plan.unchanged)}   {names}")
+    if plan.removed:
+        names = ", ".join(h.name for h in plan.removed)
+        print_info(f"  - removed    {len(plan.removed)}   {names}")
+
+    # Only the host-scoped providers (incus, proxmox) accept `--host` on
+    # `update`; aws and hetzner do not, so the hint must not suggest it there.
+    mark_cmd = f"remo {plan.scope.type} update --name <n>"
+    if plan.scope.type in _HOST_SCOPED_TYPES:
+        mark_cmd += " --host <h>"
+
+    if plan.retained_unmarked:
+        names = ", ".join(plan.retained_unmarked)
+        entries = _plural(len(plan.retained_unmarked), "entry is", "entries are")
+        print_info(
+            f"{len(plan.retained_unmarked)} retained {entries} not remo-marked: {names}"
+        )
+        print_info(f"Mark permanently: {mark_cmd}")
+
+    if plan.skipped_unmarked:
+        names = ", ".join(plan.skipped_unmarked)
+        print_info(
+            f"Skipped {len(plan.skipped_unmarked)} unmarked instance(s): {names}"
+        )
+        print_info("Adopt this run: rerun with --all")
+        print_info(f"Mark permanently: {mark_cmd}")
+
+    if include_all and adoption_criteria:
+        print_info(f"--all: {adoption_criteria}")
+
+    if plan.removals_suppressed:
+        reason = incomplete_reason or "enumeration did not complete"
+        print_warning(
+            f"Removals skipped: the provider listing was incomplete ({reason}). "
+            "Additions and updates were applied."
+        )
+
+    if plan.has_removals and not dry_run:
+        entry_word = _plural(len(plan.removed), "entry", "entries")
+        print_info(
+            f"The following {len(plan.removed)} {entry_word} will be REMOVED from the registry:"
+        )
+        for h in plan.removed:
+            details = ", ".join(v for v in (h.instance_id, h.region) if v)
+            print_info(f"  - {h.name} ({details})" if details else f"  - {h.name}")
+
+
+# ---------------------------------------------------------------------------
+# Consent gate (FR-011 -- FR-014)
+# ---------------------------------------------------------------------------
+
+
+class ConsentOutcome(Enum):
+    NOT_REQUIRED = "not_required"
+    APPLY = "apply"
+    DECLINED = "declined"
+    NON_INTERACTIVE = "non_interactive"
+
+
+def gate_consent(plan: ReconcilePlan, auto_confirm: bool) -> ConsentOutcome:
+    if not plan.has_removals:
+        return ConsentOutcome.NOT_REQUIRED
+    if auto_confirm:
+        return ConsentOutcome.NOT_REQUIRED
+    if not sys.stdin.isatty():
+        return ConsentOutcome.NON_INTERACTIVE
+
+    count = len(plan.removed)
+    prompt = "Remove it?" if count == 1 else f"Remove {count} entries?"
+    return ConsentOutcome.APPLY if confirm(prompt) else ConsentOutcome.DECLINED
+
+
+# ---------------------------------------------------------------------------
+# apply_plan -- the single mutate_registry() call (R1, R2)
+# ---------------------------------------------------------------------------
+
+
+def _host_fingerprint_set(
+    hosts: Iterable[KnownHost],
+) -> frozenset[tuple[str, str, str, str, str, str, str]]:
+    return frozenset(
+        (h.type, h.name, h.host, h.user, h.instance_id, h.access_mode, h.region) for h in hosts
+    )
+
+
+def apply_plan(plan: ReconcilePlan) -> None:
+    if plan.is_noop:
+        return
+
+    def _mutator(full: list[KnownHost]) -> list[KnownHost]:
+        # Pure list-in/list-out: the registry lock is not reentrant, so no
+        # other registry function may be called from in here (R1).
+        current_in_scope = tuple(h for h in full if plan.scope.in_update_scope(h))
+        if _host_fingerprint_set(current_in_scope) != _host_fingerprint_set(plan.baseline):
+            raise ReconcileConflictError(
+                f"the registry changed for {plan.scope.describe()} after this "
+                "plan was built"
+            )
+
+        out_of_scope = [h for h in full if not plan.scope.in_update_scope(h)]
+        reconciled = (
+            [after for _before, after in plan.updated] + plan.unchanged + plan.added
+        )
+        return out_of_scope + reconciled
+
+    mutate_registry(_mutator)
+
+
+# ---------------------------------------------------------------------------
+# run_sync -- the top-level driver; the only boundary that never raises
+# ---------------------------------------------------------------------------
+
+
+def run_sync(
+    scope: SyncScope,
+    probe_fn: ProbeFn,
+    auto_confirm: bool = False,
+    dry_run: bool = False,
+    include_all: bool = False,
+) -> int:
+    # NOTE: contracts/provider-probe.md's illustrative `run_sync(...)` example
+    # omits include_all because the provider's own probe closure already
+    # captures it for eligibility widening. build_plan/render_plan also need
+    # it (for the added-vs-skipped split and the adoption-criteria line), so
+    # it is accepted here too -- providers pass the same flag twice: once
+    # baked into their probe lambda, once explicitly to run_sync.
+    try:
+        probe = probe_fn()
+    except ProbeError as exc:
+        print_error(str(exc))
+        return EXIT_FAILURE
+
+    # The initial read only builds the plan and the concurrency baseline; the
+    # authoritative write -- and any lazy legacy known_hosts -> registry.json
+    # migration -- happens under the lock in apply_plan -> mutate_registry.
+    # Reading read-only on a dry-run keeps the "dry-run writes nothing"
+    # contract (FR-042) even when a legacy store still needs migrating.
+    current = read_registry(readonly=dry_run).hosts
+
+    try:
+        plan = build_plan(current, probe, scope, include_all)
+    except AmbiguousPlanError as exc:
+        print_error(str(exc))
+        return EXIT_FAILURE
+
+    render_plan(
+        plan,
+        dry_run,
+        adoption_criteria=probe.adoption_criteria,
+        include_all=include_all,
+        incomplete_reason=probe.incomplete_reason,
+    )
+
+    if dry_run:
+        return EXIT_OK
+
+    outcome = gate_consent(plan, auto_confirm)
+
+    if outcome in (ConsentOutcome.NOT_REQUIRED, ConsentOutcome.APPLY):
+        try:
+            apply_plan(plan)
+        except ReconcileConflictError as exc:
+            print_error(f"{exc}; re-run 'remo {scope.type} sync' to try again")
+            return EXIT_FAILURE
+        if plan.has_removals:
+            entry_word = _plural(len(plan.removed), "entry", "entries")
+            print_success(f"Removed {len(plan.removed)} {entry_word} from the registry.")
+        return EXIT_OK
+
+    if outcome is ConsentOutcome.DECLINED:
+        print_warning("Aborted: no changes were made to the registry.")
+        return EXIT_ABORTED
+
+    # NON_INTERACTIVE
+    print_warning(
+        "Removal needs confirmation, but no terminal is attached and --yes "
+        "was not given. Aborted: no changes were made to the registry."
+    )
+    return EXIT_ABORTED

--- a/src/remo_cli/providers/aws.py
+++ b/src/remo_cli/providers/aws.py
@@ -19,7 +19,6 @@ import time
 
 from remo_cli.core.ansible_runner import run_playbook
 from remo_cli.core.known_hosts import (
-    clear_known_hosts_by_type,
     get_aws_region,
     get_known_hosts,
     guard_not_added_ssh_host,
@@ -29,6 +28,13 @@ from remo_cli.core.known_hosts import (
 from datetime import datetime, timezone
 
 from remo_cli.core.output import confirm, print_error, print_info, print_success, print_warning
+from remo_cli.core.reconcile import (
+    DiscoveredHost,
+    ProbeError,
+    ProbeResult,
+    SyncScope,
+    run_sync,
+)
 from remo_cli.core.snapshot import (
     handle_destroy_snapshot_cleanup,
     validate_name as validate_snapshot_name,
@@ -704,67 +710,147 @@ def list_hosts() -> None:
         print(f"{host.name:<20} {instance_id:<20} remo shell")
 
 
-def sync(region: str = "") -> None:
-    """Sync local known-hosts registry with running AWS EC2 instances.
+def _paginate_instances(ec2) -> tuple[list[dict], bool]:  # noqa: ANN001
+    """Walk every page of ``describe_instances``, accumulating raw instance dicts.
 
-    Queries EC2 for instances tagged ``remo=true`` that are currently
-    running, clears all existing AWS entries in the registry, and
-    re-registers each discovered instance.
+    Filters on instance state only -- never ``tag:remo`` (FR-044): a
+    server-side marker filter would make an untagged-but-live instance
+    indistinguishable from a deleted one, and it would get proposed for
+    removal. ``pending``/``running``/``stopping``/``stopped`` matches the
+    list every other AWS command already passes to ``_find_remo_instance``
+    (FR-017); ``shutting-down``/``terminated`` are excluded.
+
+    Returns ``(instances, complete)``. A failure before any page is
+    gathered means we could not ask at all, so it raises :class:`ProbeError`
+    (R3, mirrors Hetzner's ``_hetzner_api_paged``); a failure after at least
+    one page succeeded means the enumeration is partial -- swallowed here
+    and reported as ``complete=False`` alongside whatever was gathered.
     """
-    _require_boto3()
-    effective_region = _effective_region(region)
-    session = _boto3_session(effective_region)
+    instances: list[dict] = []
+    got_a_page = False
+    try:
+        paginator = ec2.get_paginator("describe_instances")
+        pages = paginator.paginate(
+            Filters=[
+                {
+                    "Name": "instance-state-name",
+                    "Values": ["pending", "running", "stopping", "stopped"],
+                }
+            ]
+        )
+        for page in pages:
+            for reservation in page.get("Reservations", []):
+                instances.extend(reservation.get("Instances", []))
+            got_a_page = True
+        return instances, True
+    except ProbeError:
+        raise
+    except Exception as exc:  # noqa: BLE001 -- boto3 raises ClientError et al.
+        if not got_a_page:
+            raise ProbeError(f"describe_instances pagination failed: {exc}") from exc
+        return instances, False
+
+
+def _derive_resource_name(tags: dict[str, str]) -> str:
+    """Derive the registry name from instance tags (R8).
+
+    Prefers the authoritative ``remo_resource_name`` tag; falls back to the
+    ``Name`` tag with the ``remo-`` prefix stripped. Returns ``""`` when
+    neither yields a usable name -- the caller skips such an instance
+    entirely, since it can't be matched to any registry entry.
+    """
+    name = tags.get("remo_resource_name", "")
+    if name:
+        return name
+    name_tag = tags.get("Name", "")
+    return name_tag.removeprefix("remo-") if name_tag else ""
+
+
+def _probe(scope: SyncScope, include_all: bool) -> ProbeResult:
+    """Enumerate every non-terminal EC2 instance in ``scope.region``.
+
+    Never filtered server-side by ``tag:remo`` (FR-044) -- ``marked`` is
+    evaluated locally from the broad query so an untagged-but-live instance
+    is retained rather than proposed for removal.
+
+    ``include_all`` itself is not consulted here -- the query is unchanged
+    either way (FR-044) -- but each host's ``adopted`` flag *is* set here,
+    narrowing what ``--all`` may actually sweep in to instances whose
+    ``tag:Name`` matches ``remo-*`` (R7), rather than any untagged instance
+    in the region.
+    """
+    del include_all
+    session = _boto3_session(scope.region)
     ec2 = session.client("ec2")
 
-    print_info(f"Syncing AWS instances in region {effective_region}...")
+    instances, complete = _paginate_instances(ec2)
 
-    response = ec2.describe_instances(
-        Filters=[
-            {"Name": "tag:remo", "Values": ["true"]},
-            {"Name": "instance-state-name", "Values": ["running"]},
-        ]
-    )
-
-    instances: list[dict] = []
-    for reservation in response.get("Reservations", []):
-        for instance in reservation.get("Instances", []):
-            instances.append(instance)
-
-    # Clear all existing AWS entries before re-populating.
-    clear_known_hosts_by_type("aws")
-
-    if not instances:
-        print_info("No running remo instances found.")
-        return
-
+    hosts: list[DiscoveredHost] = []
     for instance in instances:
-        tags = {
-            t["Key"]: t["Value"] for t in instance.get("Tags", [])
-        }
-        name_tag = tags.get("Name", "")
-        # Strip the remo- prefix from the Name tag.
-        resource_name = name_tag.removeprefix("remo-") if name_tag else ""
-        if not resource_name:
+        tags = {t["Key"]: t["Value"] for t in instance.get("Tags", [])}
+        name = _derive_resource_name(tags)
+        if not name:
             continue
 
-        ip = instance.get("PublicIpAddress", "")
-        instance_id = instance.get("InstanceId", "")
-        access_mode = tags.get("remo_access_mode", "ssm")
-
-        save_known_host(
-            KnownHost(
-                type="aws",
-                name=resource_name,
-                host=ip or instance_id,
-                user="remo",
-                instance_id=instance_id,
-                access_mode=access_mode,
-                region=effective_region,
+        marked = tags.get("remo") == "true"
+        state = instance.get("State", {}).get("Name", "")
+        entry = KnownHost(
+            type="aws",
+            name=name,
+            # Never fall back to the instance id (FR-018): a stopped
+            # instance reports no PublicIpAddress, and an empty host here
+            # lets merge_entry preserve the last-known address instead of
+            # blanking or replacing it.
+            host=instance.get("PublicIpAddress", ""),
+            user="remo",
+            instance_id=instance.get("InstanceId", ""),
+            access_mode=tags.get("remo_access_mode", "ssm"),
+            region=scope.region,
+        )
+        hosts.append(
+            DiscoveredHost(
+                entry=entry,
+                marked=marked,
+                # Only a non-running state is worth annotating (FR-019);
+                # gating here keeps render_plan's annotate() correct
+                # without needing a core/reconcile.py change.
+                state=state if state != "running" else "",
+                adopted=tags.get("Name", "").startswith("remo-"),
             )
         )
-        print_success(f"  Registered: {resource_name} ({instance_id})")
 
-    print_success(f"Synced {len(instances)} instance(s).")
+    return ProbeResult(
+        hosts=hosts,
+        complete=complete,
+        incomplete_reason="" if complete else "pagination did not complete",
+        adoption_criteria="also matching instances named remo-* without the remo tag",
+    )
+
+
+def sync(
+    region: str = "",
+    include_all: bool = False,
+    auto_confirm: bool = False,
+    dry_run: bool = False,
+) -> int:
+    """Discover EC2 instances in one region and reconcile the registry.
+
+    Enumerates every non-terminal instance in the resolved region (never
+    filtered by ``tag:remo`` server-side), classifies each by the presence
+    of that tag, and reconciles the result against the registry through the
+    shared reconcile engine. Scoped to a single region -- entries recorded
+    against every other region are left untouched. Returns the process exit
+    code.
+    """
+    _require_boto3()
+    scope = SyncScope(type="aws", region=_effective_region(region))
+    return run_sync(
+        scope,
+        lambda: _probe(scope, include_all=include_all),
+        auto_confirm=auto_confirm,
+        dry_run=dry_run,
+        include_all=include_all,
+    )
 
 
 def stop(name: str = "", auto_confirm: bool = False) -> None:

--- a/src/remo_cli/providers/hetzner.py
+++ b/src/remo_cli/providers/hetzner.py
@@ -18,13 +18,19 @@ from datetime import datetime, timezone
 
 from remo_cli.core.ansible_runner import run_playbook
 from remo_cli.core.known_hosts import (
-    clear_known_hosts_by_type,
     get_known_hosts,
     guard_not_added_ssh_host,
     remove_known_host,
     save_known_host,
 )
 from remo_cli.core.output import confirm, print_error, print_info, print_success, print_warning
+from remo_cli.core.reconcile import (
+    DiscoveredHost,
+    ProbeError,
+    ProbeResult,
+    SyncScope,
+    run_sync,
+)
 from remo_cli.core.snapshot import (
     handle_destroy_snapshot_cleanup,
     validate_name as validate_snapshot_name,
@@ -253,6 +259,17 @@ def update(
     server_name = name or "remo"
     guard_not_added_ssh_host(server_name, "hetzner")  # FR-012
 
+    # `update` doubles as the backfill path for the remo managed label
+    # (T058) -- API-only, so it runs before/independent of the SSH-reachable
+    # steps below and is not skipped by a later playbook failure. Warn on
+    # failure but do not fail the whole update (FR-005 parity).
+    ok, err = _apply_managed_label(server_name)
+    if not ok:
+        print_warning(
+            f"Could not mark server '{server_name}' as remo-managed ({err}); "
+            f"it may not be picked up by a default `remo hetzner sync`."
+        )
+
     # Get server address from known_hosts.
     server_host = _lookup_hetzner_host(server_name)
     if not server_host:
@@ -380,59 +397,99 @@ def info(name: str = "") -> int:
     return 0
 
 
-def sync() -> None:
-    """Discover Hetzner VMs with the ``remo`` label and update the registry.
+def _hetzner_api_paged(path: str, key: str) -> tuple[list[dict], bool]:
+    """Walk every page of a Hetzner list endpoint, accumulating ``response[key]``.
 
-    Requires the ``HETZNER_API_TOKEN`` environment variable.  Queries the
-    Hetzner Cloud API for all servers carrying the ``remo`` label, clears
-    existing hetzner entries from the known-hosts registry, and re-registers
-    each discovered server.
+    Hetzner's list endpoints default to ``per_page=25`` (max 50) and report
+    ``meta.pagination.next_page`` (``None`` once exhausted); nothing in this
+    module used to read that field, so ``sync`` silently truncated at 25.
+
+    Returns ``(items, complete)`` -- ``complete`` is True only if the walk
+    reached a page with ``next_page is None``. A failure on the *first*
+    page means we could not ask at all, so it propagates (the caller turns
+    that into :class:`ProbeError`); a failure on a *later* page means the
+    enumeration is partial, so it is swallowed here and reported as
+    ``complete=False`` alongside whatever was already gathered.
     """
-    token = os.environ.get("HETZNER_API_TOKEN", "")
-    if not token:
-        print_error("HETZNER_API_TOKEN environment variable is not set.")
-        sys.exit(1)
+    items: list[dict] = []
+    page = 1
+    separator = "&" if "?" in path else "?"
+    while True:
+        query = f"{path}{separator}page={page}&per_page=50"
+        try:
+            response = _hetzner_api("GET", query)
+        except RuntimeError:
+            if page == 1:
+                raise
+            return items, False
+        items.extend(response.get(key, []))
+        next_page = response.get("meta", {}).get("pagination", {}).get("next_page")
+        if next_page is None:
+            return items, True
+        page = next_page
 
-    url = "https://api.hetzner.cloud/v1/servers?label_selector=remo"
-    req = urllib.request.Request(
-        url,
-        headers={"Authorization": f"Bearer {token}"},
-    )
 
+def _probe(scope: SyncScope, include_all: bool) -> ProbeResult:
+    """Enumerate every Hetzner server in the project (FR-044: never filtered
+    server-side by the ``remo`` label -- an unlabelled-but-live server must
+    still be seen, or it would look absent and get proposed for deletion).
+    """
+    del include_all  # eligibility widening happens in build_plan, not here
     try:
-        with urllib.request.urlopen(req, timeout=15) as resp:
-            data = json.loads(resp.read().decode())
-    except (urllib.error.URLError, json.JSONDecodeError) as exc:
-        print_error(f"Failed to query Hetzner API: {exc}")
-        sys.exit(1)
+        servers, complete = _hetzner_api_paged("/servers", "servers")
+    except RuntimeError as exc:
+        raise ProbeError(str(exc)) from exc
 
-    servers = data.get("servers", [])
-
-    clear_known_hosts_by_type("hetzner")
-
+    hosts: list[DiscoveredHost] = []
     for server in servers:
         name = server.get("name", "")
-        ip = (
-            server.get("public_net", {})
-            .get("ipv4", {})
-            .get("ip", "")
-        )
-        if name and ip:
-            save_known_host(
-                KnownHost(
-                    type="hetzner",
-                    name=name,
-                    host=ip,
-                    user="remo",
-                )
-            )
-            print_info(f"Registered: {name} ({ip})")
+        if not name:
+            continue
+        # Defensive `or {}` at each hop: an IPv6-only server reports
+        # public_net.ipv4 as null (key present, value None), so a plain
+        # chained .get() would raise AttributeError and crash the sync.
+        public_net = server.get("public_net") or {}
+        ipv4 = public_net.get("ipv4") or {}
+        ip = ipv4.get("ip", "") or ""
+        labels = server.get("labels", {}) or {}
+        # R6's chosen convention is the single-key label {"remo": "true"};
+        # matching on the exact value (rather than mere key presence) keeps
+        # this in lockstep with what create/update write.
+        marked = labels.get("remo") == "true"
+        entry = KnownHost(type="hetzner", name=name, host=ip, user="remo")
+        # FR-019: only non-running states are ever annotated in render_plan's
+        # output, so a normally-running server must report state="" here --
+        # otherwise every healthy server would print as "(running)".
+        status = server.get("status", "")
+        state = "" if status == "running" else status
+        hosts.append(DiscoveredHost(entry=entry, marked=marked, state=state))
 
-    count = len(servers)
-    if count == 0:
-        print_warning("No Hetzner VMs with 'remo' label found.")
-    else:
-        print_success(f"Synced {count} Hetzner VM(s).")
+    return ProbeResult(
+        hosts=hosts,
+        complete=complete,
+        incomplete_reason="" if complete else "pagination did not complete",
+        adoption_criteria="every server in this Hetzner project",
+    )
+
+
+def sync(
+    include_all: bool = False, auto_confirm: bool = False, dry_run: bool = False
+) -> int:
+    """Discover Hetzner Cloud servers and reconcile the registry.
+
+    Enumerates every server in the project via the paginated API (never
+    filtered by the ``remo`` label server-side), classifies each by the
+    presence of that label, and reconciles the result against the registry
+    through the shared reconcile engine. Returns the process exit code.
+    """
+    scope = SyncScope(type="hetzner")
+    return run_sync(
+        scope,
+        lambda: _probe(scope, include_all=include_all),
+        auto_confirm=auto_confirm,
+        dry_run=dry_run,
+        include_all=include_all,
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -496,6 +553,43 @@ def _get_server_by_name(server_name: str) -> dict:
     if not servers:
         raise RuntimeError(f"No Hetzner server found named '{server_name}'.")
     return servers[0]
+
+
+# ---------------------------------------------------------------------------
+# Managed label backfill (016-sync-reconcile, R6/T057)
+# ---------------------------------------------------------------------------
+
+
+def _apply_managed_label(server_name: str) -> tuple[bool, str]:
+    """Backfill the ``remo: "true"`` label onto an existing server (host-side).
+
+    `create` now applies the label via Ansible at creation time, but a server
+    created before this change (or otherwise unlabelled) needs a retroactive
+    path. Both ``hetzner.hcloud.server`` and a raw ``PUT /servers/{id}`` treat
+    the supplied label map as authoritative and replace it wholesale, so this
+    reads the current map first and merges rather than overwriting it --
+    a naive backfill would destroy the user's own labels (FR-034).
+
+    Already-labelled is a no-op with no API write (FR-033). Returns
+    ``(ok, err)`` -- never raises, never exits -- matching
+    ``_apply_managed_marker`` in the other providers; callers warn but do not
+    fail the whole command on this alone.
+    """
+    try:
+        server = _get_server_by_name(server_name)
+    except RuntimeError as e:
+        return False, str(e)
+
+    labels = server.get("labels", {}) or {}
+    if labels.get("remo") == "true":
+        return True, ""
+
+    merged = {**labels, "remo": "true"}
+    try:
+        _hetzner_api("PUT", f"/servers/{server.get('id', 0)}", {"labels": merged})
+    except RuntimeError as e:
+        return False, str(e)
+    return True, ""
 
 
 def _parse_hetzner_timestamp(s: str) -> datetime:

--- a/src/remo_cli/providers/incus.py
+++ b/src/remo_cli/providers/incus.py
@@ -20,13 +20,13 @@ from remo_cli.core.config import (
     INCUS_MANAGED_CONFIG_VALUE,
 )
 from remo_cli.core.known_hosts import (
-    clear_known_hosts_by_prefix,
     get_known_hosts,
     guard_not_added_ssh_host,
     remove_known_host,
     save_known_host,
 )
 from remo_cli.core.output import confirm, print_error, print_info, print_warning
+from remo_cli.core.reconcile import DiscoveredHost, ProbeError, ProbeResult, SyncScope, run_sync
 from remo_cli.core.snapshot import (
     handle_destroy_snapshot_cleanup,
     validate_name as validate_snapshot_name,
@@ -104,17 +104,21 @@ def _resolve_container_ip(
                 text=True,
             )
             if result.returncode != 0:
-                print_error(f"SSH to '{ssh_target}' failed: {result.stderr.strip()}")
+                # Soft-fail: a transient SSH hiccup must not abort a sync or
+                # crash create/update. Callers treat "" as "unknown", not
+                # "gone" -- merge_entry preserves the previously recorded
+                # address instead of overwriting it.
+                print_warning(f"SSH to '{ssh_target}' failed: {result.stderr.strip()}")
                 if not user:
                     print_warning(
                         f"Try specifying --user, e.g.: remo incus update --host {host} "
                         f"--user <username> {name}"
                     )
-                sys.exit(1)
+                return ""
             container_ip = _extract_eth0_ip(result.stdout)
         except FileNotFoundError:
-            print_error("ssh command not found")
-            sys.exit(1)
+            print_warning("ssh command not found")
+            return ""
 
     return container_ip
 
@@ -597,82 +601,86 @@ def info(name: str, host: str = "", user: str = "") -> int:
     return 0
 
 
+def _probe(scope: SyncScope, user: str, use_ip: bool, include_all: bool) -> ProbeResult:
+    """Provider-probe for :func:`sync` (contracts/provider-probe.md "Incus").
+
+    Returns every container on *scope.host* -- marked and unmarked alike;
+    the marker only decides eligibility for addition, never what is even
+    seen (FR-044). Read-only: issues one bulk listing query and, when
+    *use_ip* is set, one IP lookup per container. Never writes/mutates the
+    provider.
+    """
+    try:
+        rows = _list_containers_with_marker(scope.host, user)
+    except RuntimeError as exc:
+        raise ProbeError(f"Failed to list containers on '{scope.host}': {exc}") from exc
+
+    warnings: list[str] = []
+    hosts: list[DiscoveredHost] = []
+    for cname, marked in rows:
+        if use_ip:
+            ip = _resolve_container_ip(cname, scope.host, user)
+            if ip:
+                container_host = ip
+            else:
+                # Soft IP-lookup failure: leave entry.host empty so
+                # merge_entry preserves the previously recorded address
+                # instead of overwriting it with the bare container name.
+                container_host = ""
+                warnings.append(
+                    f"Could not resolve IP for '{cname}', keeping previously "
+                    "recorded address"
+                )
+        else:
+            container_host = cname
+
+        entry = KnownHost(
+            type="incus",
+            name=f"{scope.host}/{cname}",
+            host=container_host,
+            user="remo",
+            instance_id=user,
+            access_mode="direct",
+        )
+        hosts.append(DiscoveredHost(entry=entry, marked=marked))
+
+    return ProbeResult(
+        hosts=hosts,
+        complete=True,  # incus list never paginates
+        adoption_criteria="every container on this Incus host",
+        warnings=warnings,
+    )
+
+
 def sync(
     host: str = "localhost",
     user: str = "",
     use_ip: bool = False,
     include_all: bool = False,
-) -> None:
-    """Discover Incus containers on *host* and register them in known-hosts.
+    auto_confirm: bool = False,
+    dry_run: bool = False,
+) -> int:
+    """Reconcile the registry's Incus entries for *host* against reality.
 
-    Uses a single ``incus list -f csv -c n,user.remo`` query (locally when
-    ``host == "localhost"``, else over SSH) that returns each container's name
-    and managed-marker value (FR-013). By default (``include_all=False``) only
-    marker-bearing containers are registered (FR-006) and any skipped unmarked
-    containers are named in a hint (FR-008). With ``include_all=True`` every
-    container is registered — the pre-feature behavior (FR-007) — and unmarked
-    adoptions are called out in the summary (FR-009).
+    Delegates diffing, consent, and the single atomic write to
+    :func:`remo_cli.core.reconcile.run_sync`; this function's only job is
+    the probe closure above. By default only marker-bearing containers are
+    eligible for addition (FR-006); ``include_all=True`` widens that to
+    every container (FR-007). Removals require a complete enumeration and
+    consent (``auto_confirm`` or an interactive confirm), never happen on
+    ``dry_run``, and an unmarked host that still exists is never removed
+    (FR-022) -- there is no "later sync drops it again".
 
-    This function never mutates container state: it applies/removes no marker
-    (FR-010). When *use_ip* is true, each container's eth0 IP is resolved and
-    stored as the ``host`` field; otherwise the container name is stored.
+    Returns the process exit code (see ``core/reconcile.py`` EXIT_*).
     """
-    try:
-        discovered = _list_containers_with_marker(host, user)
-    except RuntimeError as e:
-        print_error(f"Failed to list containers on '{host}': {e}")
-        sys.exit(1)
-
-    # Clear existing entries for this host before re-populating.
-    clear_known_hosts_by_prefix("incus", f"{host}/")
-
-    registered = 0
-    skipped: list[str] = []
-    adopted_unmarked: list[str] = []
-    for name, marked in discovered:
-        if not include_all and not marked:
-            skipped.append(name)
-            continue
-        if include_all and not marked:
-            adopted_unmarked.append(name)
-        if use_ip:
-            container_host = _resolve_container_ip(name, host, user) or name
-        else:
-            container_host = name
-        save_known_host(
-            KnownHost(
-                type="incus",
-                name=f"{host}/{name}",
-                host=container_host,
-                user="remo",
-                instance_id=user,
-                access_mode="direct",
-            )
-        )
-        registered += 1
-
-    print_info(f"Synced {registered} container(s) from '{host}'.")
-
-    if not include_all and skipped:
-        print_warning(
-            f"Skipped {len(skipped)} unmarked container(s): {', '.join(skipped)}"
-        )
-        print_info(
-            f"  • Adopt all this run:      remo incus sync --host {host} --all"
-        )
-        print_info(
-            "  • Mark one permanently:    remo incus update --name <name> "
-            f"--host {host}"
-        )
-
-    if include_all and adopted_unmarked:
-        print_warning(
-            f"{len(adopted_unmarked)} of the registered container(s) are not "
-            f"remo-created (adopted via --all): {', '.join(adopted_unmarked)}"
-        )
-        print_info(
-            "Note: a later default `sync` will drop those unmarked one(s) again."
-        )
+    scope = SyncScope(type="incus", host=host)
+    return run_sync(
+        scope,
+        lambda: _probe(scope, user=user, use_ip=use_ip, include_all=include_all),
+        auto_confirm=auto_confirm,
+        dry_run=dry_run,
+        include_all=include_all,
+    )
 
 
 def bootstrap(

--- a/src/remo_cli/providers/proxmox.py
+++ b/src/remo_cli/providers/proxmox.py
@@ -22,13 +22,19 @@ from datetime import datetime, timezone
 from remo_cli.core.ansible_runner import run_playbook
 from remo_cli.core.config import PROXMOX_MANAGED_TAG
 from remo_cli.core.known_hosts import (
-    clear_known_hosts_by_prefix,
     get_known_hosts,
     guard_not_added_ssh_host,
     remove_known_host,
     save_known_host,
 )
 from remo_cli.core.output import confirm, print_error, print_info, print_warning
+from remo_cli.core.reconcile import (
+    DiscoveredHost,
+    ProbeError,
+    ProbeResult,
+    SyncScope,
+    run_sync,
+)
 from remo_cli.core.snapshot import (
     handle_destroy_snapshot_cleanup,
     validate_name as validate_snapshot_name,
@@ -158,6 +164,12 @@ def _read_tags_by_vmid(host: str, user: str) -> dict[str, set[str]]:
         user,
         'for f in /etc/pve/lxc/*.conf; do echo "@@@$f"; cat "$f"; done 2>/dev/null',
     )
+    if result.returncode != 0:
+        # An SSH failure here must be loud: silently treating an empty
+        # tag map as "nothing is marked" turns a transient failure into a
+        # proposed deletion of the node's entire fleet (research.md R5).
+        raise RuntimeError(result.stderr.strip() or result.stdout.strip())
+
     mapping: dict[str, set[str]] = {}
     vmid: str | None = None
     in_snapshot_section = False
@@ -728,49 +740,30 @@ def _parse_pct_config_field(config_text: str, field: str) -> str:
     return match.group(1).strip() if match else ""
 
 
-def sync(
-    host: str,
-    user: str = "",
-    use_ip: bool = False,
-    include_all: bool = False,
-) -> None:
-    """Discover Proxmox LXC containers on *host* and register them.
+def _probe(scope: SyncScope, user: str, use_ip: bool, include_all: bool) -> ProbeResult:
+    """Provider-probe for :func:`sync` (contracts/provider-probe.md "Proxmox").
 
-    Runs ``pct list`` for the vmid/name inventory and one bulk
-    ``grep '^tags:' /etc/pve/lxc/*.conf`` to read every container's tags in a
-    single round-trip (FR-013). By default (``include_all=False``) only
-    containers carrying the ``remo`` managed tag are registered (FR-006), and
-    skipped unmarked containers are named in a hint (FR-008). With
-    ``include_all=True`` every container is registered — the pre-feature
-    behavior (FR-007) — and unmarked adoptions are called out (FR-009).
-
-    This function never mutates container state (FR-010). When *use_ip* is true,
-    each container's eth0 IP is resolved and stored as the ``host`` field.
-
-    Existing entries with the host prefix are cleared first.
+    Returns every LXC container on *scope.host* -- marked and unmarked alike;
+    the marker only decides eligibility for addition, never what is even
+    seen (FR-044). Read-only: one ``pct list`` plus one bulk tag dump, and
+    when *use_ip* is set, one IP lookup per container. Never writes/mutates
+    the provider.
     """
-    if not host:
-        print_error("Proxmox host is required (use --host).")
-        sys.exit(1)
-
-    # `pct list` columns: VMID Status Lock Name
-    if host == "localhost":
-        result = subprocess.run(
-            ["pct", "list"], capture_output=True, text=True
-        )
-    else:
-        result = _ssh_run(host, user, "pct list")
+    result = _run_on_node(scope.host, user, "pct list")
 
     if result.returncode != 0:
-        print_error(
-            f"Failed to list containers on '{host}': {result.stderr.strip()}"
+        raise ProbeError(
+            f"Failed to list containers on '{scope.host}': {result.stderr.strip()}"
         )
-        sys.exit(1)
 
     containers: list[tuple[str, str]] = []  # (vmid, hostname)
     for line in result.stdout.splitlines()[1:]:  # skip header
         parts = line.split()
-        if len(parts) < 2:
+        # A real row is `VMID Status [Lock] Name` -- at least 3 columns even
+        # when Lock is empty. A 2-column row is a nameless container, whose
+        # Status ("running"/"stopped") would otherwise be misread as the
+        # name; skip it (it can't be matched to a named registry entry).
+        if len(parts) < 3:
             continue
         vmid = parts[0]
         if not vmid.isdigit():
@@ -779,59 +772,89 @@ def sync(
         hostname = parts[-1]
         containers.append((vmid, hostname))
 
-    tags_by_vmid = _read_tags_by_vmid(host, user)
+    try:
+        # No containers means no tags to read; skip the bulk dump entirely.
+        # On an empty node the `/etc/pve/lxc/*.conf` glob would not expand and
+        # the shell command would exit non-zero, which _read_tags_by_vmid
+        # (correctly) treats as a failure -- turning a legitimate empty node
+        # into a spurious probe error instead of a clean reconcile.
+        tags_by_vmid = _read_tags_by_vmid(scope.host, user) if containers else {}
+    except RuntimeError as exc:
+        # A tag-read failure must abort the whole probe, not silently treat
+        # every container as unmarked (the bug this phase fixes -- R5 #1).
+        raise ProbeError(
+            f"Failed to read managed tags on '{scope.host}': {exc}"
+        ) from exc
 
-    clear_known_hosts_by_prefix("proxmox", f"{host}/")
-
-    registered = 0
-    skipped: list[str] = []
-    adopted_unmarked: list[str] = []
+    warnings: list[str] = []
+    hosts: list[DiscoveredHost] = []
     for vmid, hostname in containers:
         marked = PROXMOX_MANAGED_TAG in tags_by_vmid.get(vmid, set())
-        if not include_all and not marked:
-            skipped.append(hostname)
-            continue
-        if include_all and not marked:
-            adopted_unmarked.append(hostname)
+
         if use_ip:
-            container_host = _resolve_container_ip(hostname, host, user, vmid=vmid) or hostname
+            ip = _resolve_container_ip(hostname, scope.host, user, vmid=vmid)
+            if ip:
+                container_host = ip
+            else:
+                # Soft IP-lookup failure: leave entry.host empty so
+                # merge_entry preserves the previously recorded address
+                # instead of overwriting it with the bare hostname.
+                container_host = ""
+                warnings.append(
+                    f"Could not resolve IP for '{hostname}', keeping "
+                    "previously recorded address"
+                )
         else:
             container_host = hostname
-        save_known_host(
-            KnownHost(
-                type="proxmox",
-                name=f"{host}/{hostname}",
-                host=container_host,
-                user="remo",
-                instance_id=vmid,
-                access_mode="direct",
-                region=user or "root",
-            )
-        )
-        registered += 1
 
-    print_info(f"Synced {registered} container(s) from '{host}'.")
+        entry = KnownHost(
+            type="proxmox",
+            name=f"{scope.host}/{hostname}",
+            host=container_host,
+            user="remo",
+            instance_id=vmid,
+            access_mode="direct",
+            region=user or "root",
+        )
+        hosts.append(DiscoveredHost(entry=entry, marked=marked))
 
-    if not include_all and skipped:
-        print_warning(
-            f"Skipped {len(skipped)} unmarked container(s): {', '.join(skipped)}"
-        )
-        print_info(
-            f"  • Adopt all this run:      remo proxmox sync --host {host} --all"
-        )
-        print_info(
-            "  • Mark one permanently:    remo proxmox update --name <name> "
-            f"--host {host}"
-        )
+    return ProbeResult(
+        hosts=hosts,
+        complete=True,  # neither `pct list` nor the tag dump paginates
+        adoption_criteria="every container on this Proxmox node",
+        warnings=warnings,
+    )
 
-    if include_all and adopted_unmarked:
-        print_warning(
-            f"{len(adopted_unmarked)} of the registered container(s) are not "
-            f"remo-created (adopted via --all): {', '.join(adopted_unmarked)}"
-        )
-        print_info(
-            "Note: a later default `sync` will drop those unmarked one(s) again."
-        )
+
+def sync(
+    host: str,
+    user: str = "",
+    use_ip: bool = False,
+    include_all: bool = False,
+    auto_confirm: bool = False,
+    dry_run: bool = False,
+) -> int:
+    """Reconcile the registry's Proxmox entries for *host* against reality.
+
+    Delegates diffing, consent, and the single atomic write to
+    :func:`remo_cli.core.reconcile.run_sync`; this function's only job is
+    the probe closure above. By default only marker-bearing containers are
+    eligible for addition (FR-006); ``include_all=True`` widens that to
+    every container (FR-007). Removals require a complete enumeration and
+    consent (``auto_confirm`` or an interactive confirm), never happen on
+    ``dry_run``, and an unmarked host that still exists is never removed
+    (FR-022) -- there is no "later sync drops it again".
+
+    Returns the process exit code (see ``core/reconcile.py`` EXIT_*).
+    """
+    scope = SyncScope(type="proxmox", host=host)
+    return run_sync(
+        scope,
+        lambda: _probe(scope, user=user, use_ip=use_ip, include_all=include_all),
+        auto_confirm=auto_confirm,
+        dry_run=dry_run,
+        include_all=include_all,
+    )
 
 
 def bootstrap(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -106,3 +106,15 @@ def write_v2_registry(config_dir, hosts: list[dict], version: int = 2) -> None:
     """Write a v2 registry.json document built from a list of hostEntry dicts."""
     doc = {"version": version, "hosts": hosts}
     (config_dir / "registry.json").write_text(json.dumps(doc, indent=2) + "\n")
+
+
+def seed_registry(config_dir, hosts: list) -> None:
+    """Write a v2 registry.json document from a list of ``KnownHost`` objects.
+
+    Wraps :func:`write_v2_registry`, converting each host via the real
+    ``known_host_to_entry`` serializer so seeded fixtures always match what
+    the registry accessor itself would have written.
+    """
+    from remo_cli.core.registry import known_host_to_entry
+
+    write_v2_registry(config_dir, [known_host_to_entry(h) for h in hosts])

--- a/tests/integration/test_sync_reconcile.py
+++ b/tests/integration/test_sync_reconcile.py
@@ -1,0 +1,245 @@
+"""Cross-provider sync-reconcile integration tests (feature 016-sync-reconcile).
+
+These exercise a provider's `sync()` end-to-end against a *real* temporary
+registry (`tmp_config_dir` + `seed_registry`): only the SSH/API boundary is
+mocked, everything downstream of the probe -- diffing, consent, the single
+atomic `mutate_registry()` write, and exit codes -- runs for real through
+`core/reconcile.py`.
+
+This module is shared across providers. Each provider's functions are
+grouped under a `Test<Provider>...` class and its test names are prefixed
+accordingly (e.g. `test_incus_...`), so later phases (AWS, Proxmox, Hetzner)
+can append their own classes as siblings without touching this one.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from remo_cli.core import reconcile
+from remo_cli.models.host import KnownHost
+from remo_cli.providers import hetzner as providers_hetzner
+from remo_cli.providers import incus as providers_incus
+
+from tests.conftest import seed_registry
+
+
+def _completed(rc: int, stdout: str = "", stderr: str = "") -> MagicMock:
+    cp = MagicMock()
+    cp.returncode = rc
+    cp.stdout = stdout
+    cp.stderr = stderr
+    return cp
+
+
+def _registry_bytes(config_dir) -> bytes:
+    return (config_dir / "registry.json").read_bytes()
+
+
+@pytest.fixture
+def existing_incus_host() -> KnownHost:
+    return KnownHost(
+        type="incus",
+        name="myhost/dev1",
+        host="dev1.incus",
+        user="remo",
+        instance_id="paul",
+        access_mode="direct",
+    )
+
+
+# ---------------------------------------------------------------------------
+# Incus (016-sync-reconcile User Story 1 -- the MVP; see tasks.md T023)
+# ---------------------------------------------------------------------------
+
+
+class TestIncusSyncSafetyMatrix:
+    def test_incus_empty_probe_non_interactive_decline_leaves_registry_unchanged(
+        self, tmp_config_dir, existing_incus_host, mocker
+    ):
+        seed_registry(tmp_config_dir, [existing_incus_host])
+        before = _registry_bytes(tmp_config_dir)
+
+        mocker.patch(
+            "remo_cli.providers.incus._ssh_run_on_incus_host",
+            return_value=_completed(0, stdout=""),
+        )
+        mocker.patch("sys.stdin.isatty", return_value=False)
+
+        rc = providers_incus.sync(host="myhost", user="paul", auto_confirm=False)
+
+        assert rc == reconcile.EXIT_ABORTED
+        assert _registry_bytes(tmp_config_dir) == before
+
+    def test_incus_empty_probe_interactive_decline_leaves_registry_unchanged(
+        self, tmp_config_dir, existing_incus_host, mocker
+    ):
+        seed_registry(tmp_config_dir, [existing_incus_host])
+        before = _registry_bytes(tmp_config_dir)
+
+        mocker.patch(
+            "remo_cli.providers.incus._ssh_run_on_incus_host",
+            return_value=_completed(0, stdout=""),
+        )
+        mocker.patch("sys.stdin.isatty", return_value=True)
+        mocker.patch("remo_cli.core.reconcile.confirm", return_value=False)
+
+        rc = providers_incus.sync(host="myhost", user="paul", auto_confirm=False)
+
+        assert rc == reconcile.EXIT_ABORTED
+        assert _registry_bytes(tmp_config_dir) == before
+
+    def test_incus_empty_probe_auto_confirm_removes_entry_and_names_it(
+        self, tmp_config_dir, existing_incus_host, mocker, capsys
+    ):
+        seed_registry(tmp_config_dir, [existing_incus_host])
+
+        mocker.patch(
+            "remo_cli.providers.incus._ssh_run_on_incus_host",
+            return_value=_completed(0, stdout=""),
+        )
+
+        rc = providers_incus.sync(host="myhost", user="paul", auto_confirm=True)
+
+        assert rc == reconcile.EXIT_OK
+        registry = read_registry_hosts(tmp_config_dir)
+        assert registry == []
+        out = capsys.readouterr().out
+        assert "myhost/dev1" in out
+
+    def test_incus_probe_failure_leaves_registry_unchanged(
+        self, tmp_config_dir, existing_incus_host, mocker
+    ):
+        seed_registry(tmp_config_dir, [existing_incus_host])
+        before = _registry_bytes(tmp_config_dir)
+
+        mocker.patch(
+            "remo_cli.providers.incus._ssh_run_on_incus_host",
+            return_value=_completed(1, stderr="ssh: connection refused"),
+        )
+
+        rc = providers_incus.sync(host="myhost", user="paul", auto_confirm=True)
+
+        assert rc == reconcile.EXIT_FAILURE
+        assert _registry_bytes(tmp_config_dir) == before
+
+    def test_incus_dry_run_leaves_registry_unchanged_and_never_prompts(
+        self, tmp_config_dir, existing_incus_host, mocker
+    ):
+        seed_registry(tmp_config_dir, [existing_incus_host])
+        before = _registry_bytes(tmp_config_dir)
+
+        mocker.patch(
+            "remo_cli.providers.incus._ssh_run_on_incus_host",
+            return_value=_completed(0, stdout=""),
+        )
+        confirm_spy = mocker.patch("remo_cli.core.reconcile.confirm")
+
+        rc = providers_incus.sync(host="myhost", user="paul", dry_run=True)
+
+        assert rc == reconcile.EXIT_OK
+        assert _registry_bytes(tmp_config_dir) == before
+        confirm_spy.assert_not_called()
+
+    def test_incus_additions_only_needs_no_prompt_regardless_of_tty(
+        self, tmp_config_dir, mocker
+    ):
+        # Nothing in the registry yet; the probe sees one marked container.
+        seed_registry(tmp_config_dir, [])
+
+        mocker.patch(
+            "remo_cli.providers.incus._ssh_run_on_incus_host",
+            return_value=_completed(0, stdout="dev1,true\n"),
+        )
+        confirm_spy = mocker.patch("remo_cli.core.reconcile.confirm")
+        mocker.patch("sys.stdin.isatty", return_value=False)
+
+        rc = providers_incus.sync(host="myhost", user="paul", auto_confirm=False)
+
+        assert rc == reconcile.EXIT_OK
+        confirm_spy.assert_not_called()
+        registry = read_registry_hosts(tmp_config_dir)
+        assert [h.name for h in registry] == ["myhost/dev1"]
+
+    def test_incus_no_removals_is_noop_and_exits_0(self, tmp_config_dir, mocker):
+        seed_registry(tmp_config_dir, [])
+        before = _registry_bytes(tmp_config_dir)
+
+        mocker.patch(
+            "remo_cli.providers.incus._ssh_run_on_incus_host",
+            return_value=_completed(0, stdout=""),
+        )
+
+        rc = providers_incus.sync(host="myhost", user="paul", auto_confirm=False)
+
+        assert rc == reconcile.EXIT_OK
+        assert _registry_bytes(tmp_config_dir) == before
+
+
+# ---------------------------------------------------------------------------
+# Hetzner (016-sync-reconcile User Story 5 -- adoption durability; T062)
+#
+# Regression guard for the marker-semantics change: an entry adopted via
+# `--all` is unmarked (no `remo` label) by definition. It must survive a
+# subsequent *plain* sync purely by being present -- reported as
+# `retained_unmarked`, never proposed for removal -- with no confirmation
+# prompt attempted, since nothing needs removing.
+# ---------------------------------------------------------------------------
+
+
+def _hetzner_page(name: str, ip: str = "9.9.9.9") -> dict:
+    return {
+        "servers": [
+            {
+                "id": 1,
+                "name": name,
+                "status": "running",
+                "labels": {},
+                "public_net": {"ipv4": {"ip": ip}},
+            }
+        ],
+        "meta": {"pagination": {"next_page": None}},
+    }
+
+
+class TestHetznerAdoptionDurability:
+    def test_all_adopted_entry_is_retained_unmarked_by_a_subsequent_plain_sync(
+        self, tmp_config_dir, mocker, capsys
+    ):
+        seed_registry(tmp_config_dir, [])
+
+        # First sync: --all adopts the unmarked, unlabelled server.
+        mocker.patch.object(
+            providers_hetzner, "_hetzner_api", side_effect=[_hetzner_page("dev1")]
+        )
+        rc = providers_hetzner.sync(include_all=True, auto_confirm=True)
+        assert rc == reconcile.EXIT_OK
+        assert [h.name for h in read_registry_hosts(tmp_config_dir)] == ["dev1"]
+
+        # Second sync: plain (no --all). The server is still unlabelled, but
+        # it must be retained -- not dropped -- because it is still present.
+        mocker.patch.object(
+            providers_hetzner, "_hetzner_api", side_effect=[_hetzner_page("dev1")]
+        )
+        confirm_spy = mocker.patch("remo_cli.core.reconcile.confirm")
+        mocker.patch("sys.stdin.isatty", return_value=True)
+
+        rc = providers_hetzner.sync(include_all=False, auto_confirm=False)
+
+        assert rc == reconcile.EXIT_OK
+        confirm_spy.assert_not_called()
+        assert [h.name for h in read_registry_hosts(tmp_config_dir)] == ["dev1"]
+
+        out = capsys.readouterr().out
+        assert "retained" in out
+        assert "not remo-marked" in out
+        assert "dev1" in out
+
+
+def read_registry_hosts(config_dir) -> list[KnownHost]:
+    """Read back the hosts actually persisted to registry.json."""
+    from remo_cli.core.registry import read_registry
+
+    return read_registry(readonly=True).hosts

--- a/tests/unit/cli/providers/test_incus_sync_all.py
+++ b/tests/unit/cli/providers/test_incus_sync_all.py
@@ -15,7 +15,7 @@ def runner():
 
 def test_default_sync_passes_include_all_false(runner, mocker):
     spy = mocker.patch(
-        "remo_cli.cli.providers.incus.providers_incus.sync", return_value=None
+        "remo_cli.cli.providers.incus.providers_incus.sync", return_value=0
     )
     result = runner.invoke(incus, ["sync", "--host", "h", "--user", "u"])
     assert result.exit_code == 0
@@ -24,8 +24,44 @@ def test_default_sync_passes_include_all_false(runner, mocker):
 
 def test_all_flag_threads_include_all_true(runner, mocker):
     spy = mocker.patch(
-        "remo_cli.cli.providers.incus.providers_incus.sync", return_value=None
+        "remo_cli.cli.providers.incus.providers_incus.sync", return_value=0
     )
     result = runner.invoke(incus, ["sync", "--host", "h", "--all"])
     assert result.exit_code == 0
     assert spy.call_args.kwargs["include_all"] is True
+
+
+def test_exit_code_propagates_from_sync(runner, mocker):
+    mocker.patch(
+        "remo_cli.cli.providers.incus.providers_incus.sync", return_value=1
+    )
+    result = runner.invoke(incus, ["sync", "--host", "h"])
+    assert result.exit_code == 1
+
+
+def test_yes_flag_threads_auto_confirm_true(runner, mocker):
+    spy = mocker.patch(
+        "remo_cli.cli.providers.incus.providers_incus.sync", return_value=0
+    )
+    result = runner.invoke(incus, ["sync", "--host", "h", "--yes"])
+    assert result.exit_code == 0
+    assert spy.call_args.kwargs["auto_confirm"] is True
+
+
+def test_dry_run_flag_threads_dry_run_true(runner, mocker):
+    spy = mocker.patch(
+        "remo_cli.cli.providers.incus.providers_incus.sync", return_value=0
+    )
+    result = runner.invoke(incus, ["sync", "--host", "h", "--dry-run"])
+    assert result.exit_code == 0
+    assert spy.call_args.kwargs["dry_run"] is True
+
+
+def test_default_sync_passes_auto_confirm_and_dry_run_false(runner, mocker):
+    spy = mocker.patch(
+        "remo_cli.cli.providers.incus.providers_incus.sync", return_value=0
+    )
+    result = runner.invoke(incus, ["sync", "--host", "h"])
+    assert result.exit_code == 0
+    assert spy.call_args.kwargs["auto_confirm"] is False
+    assert spy.call_args.kwargs["dry_run"] is False

--- a/tests/unit/cli/providers/test_proxmox_sync_all.py
+++ b/tests/unit/cli/providers/test_proxmox_sync_all.py
@@ -1,4 +1,4 @@
-"""Tests for the `--all` flag on `remo proxmox sync` (cli/providers/proxmox.py)."""
+"""Tests for the `remo proxmox sync` CLI flags (cli/providers/proxmox.py)."""
 
 from __future__ import annotations
 
@@ -15,7 +15,7 @@ def runner():
 
 def test_default_sync_passes_include_all_false(runner, mocker):
     spy = mocker.patch(
-        "remo_cli.cli.providers.proxmox.providers_proxmox.sync", return_value=None
+        "remo_cli.cli.providers.proxmox.providers_proxmox.sync", return_value=0
     )
     result = runner.invoke(proxmox, ["sync", "--host", "node", "--user", "root"])
     assert result.exit_code == 0
@@ -24,8 +24,53 @@ def test_default_sync_passes_include_all_false(runner, mocker):
 
 def test_all_flag_threads_include_all_true(runner, mocker):
     spy = mocker.patch(
-        "remo_cli.cli.providers.proxmox.providers_proxmox.sync", return_value=None
+        "remo_cli.cli.providers.proxmox.providers_proxmox.sync", return_value=0
     )
     result = runner.invoke(proxmox, ["sync", "--host", "node", "--all"])
     assert result.exit_code == 0
     assert spy.call_args.kwargs["include_all"] is True
+
+
+def test_exit_code_propagates_from_sync(runner, mocker):
+    mocker.patch(
+        "remo_cli.cli.providers.proxmox.providers_proxmox.sync", return_value=1
+    )
+    result = runner.invoke(proxmox, ["sync", "--host", "node"])
+    assert result.exit_code == 1
+
+
+def test_yes_flag_threads_auto_confirm_true(runner, mocker):
+    spy = mocker.patch(
+        "remo_cli.cli.providers.proxmox.providers_proxmox.sync", return_value=0
+    )
+    result = runner.invoke(proxmox, ["sync", "--host", "node", "--yes"])
+    assert result.exit_code == 0
+    assert spy.call_args.kwargs["auto_confirm"] is True
+
+
+def test_dry_run_flag_threads_dry_run_true(runner, mocker):
+    spy = mocker.patch(
+        "remo_cli.cli.providers.proxmox.providers_proxmox.sync", return_value=0
+    )
+    result = runner.invoke(proxmox, ["sync", "--host", "node", "--dry-run"])
+    assert result.exit_code == 0
+    assert spy.call_args.kwargs["dry_run"] is True
+
+
+def test_default_sync_passes_auto_confirm_and_dry_run_false(runner, mocker):
+    spy = mocker.patch(
+        "remo_cli.cli.providers.proxmox.providers_proxmox.sync", return_value=0
+    )
+    result = runner.invoke(proxmox, ["sync", "--host", "node"])
+    assert result.exit_code == 0
+    assert spy.call_args.kwargs["auto_confirm"] is False
+    assert spy.call_args.kwargs["dry_run"] is False
+
+
+def test_host_is_required(runner, mocker):
+    # Proxmox differs from Incus here: --host has no default, so a bare
+    # `sync` must fail as a Click usage error (exit 2), never construct a
+    # SyncScope with an empty host.
+    mocker.patch("remo_cli.cli.providers.proxmox.providers_proxmox.sync")
+    result = runner.invoke(proxmox, ["sync"])
+    assert result.exit_code == 2

--- a/tests/unit/core/test_reconcile.py
+++ b/tests/unit/core/test_reconcile.py
@@ -1,0 +1,773 @@
+"""Tests for the provider-agnostic sync reconcile engine (016-sync-reconcile).
+
+Covers, per Constitution Principle II (enumerate branches, don't sample):
+- SyncScope predicates/describe()/validation for all four provider shapes
+  (T012).
+- merge_entry's field-by-field precedence rules (T012).
+- build_plan's full classification matrix, one test per row, plus
+  AmbiguousPlanError (T013).
+- gate_consent's five outcomes and run_sync's exit codes, asserting 2 is
+  never returned (T014).
+- apply_plan's single-write guarantee, out-of-scope byte-for-byte
+  preservation, and the optimistic-concurrency conflict check (T015).
+"""
+
+from __future__ import annotations
+
+import sys
+
+import pytest
+
+from remo_cli.core.reconcile import (
+    AmbiguousPlanError,
+    ConsentOutcome,
+    DiscoveredHost,
+    ProbeResult,
+    ReconcileConflictError,
+    ScopeError,
+    SyncScope,
+    apply_plan,
+    build_plan,
+    gate_consent,
+    merge_entry,
+    run_sync,
+)
+from remo_cli.core.registry import read_registry
+from remo_cli.models.host import KnownHost
+from tests.conftest import seed_registry
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _kh(
+    type_: str,
+    name: str,
+    host: str = "1.2.3.4",
+    user: str = "remo",
+    instance_id: str = "",
+    access_mode: str = "",
+    region: str = "",
+) -> KnownHost:
+    return KnownHost(
+        type=type_,
+        name=name,
+        host=host,
+        user=user,
+        instance_id=instance_id,
+        access_mode=access_mode,
+        region=region,
+    )
+
+
+def _dh(entry: KnownHost, marked: bool = True, state: str = "", adopted: bool = True) -> DiscoveredHost:
+    return DiscoveredHost(entry=entry, marked=marked, state=state, adopted=adopted)
+
+
+def _probe(
+    hosts: list[DiscoveredHost],
+    complete: bool = True,
+    incomplete_reason: str = "",
+    adoption_criteria: str = "",
+    warnings: list[str] | None = None,
+) -> ProbeResult:
+    return ProbeResult(
+        hosts=hosts,
+        complete=complete,
+        incomplete_reason=incomplete_reason,
+        adoption_criteria=adoption_criteria,
+        warnings=warnings or [],
+    )
+
+
+class FakeStdin:
+    def __init__(self, is_tty: bool) -> None:
+        self._is_tty = is_tty
+
+    def isatty(self) -> bool:
+        return self._is_tty
+
+
+# ---------------------------------------------------------------------------
+# SyncScope: predicates
+# ---------------------------------------------------------------------------
+
+
+class TestSyncScopeIncusProxmox:
+    @pytest.mark.parametrize("ptype", ["incus", "proxmox"])
+    def test_matches_same_type_and_host_prefix(self, ptype):
+        scope = SyncScope(type=ptype, host="node1")
+        entry = _kh(ptype, "node1/dev1")
+        assert scope.in_update_scope(entry) is True
+        assert scope.in_removal_scope(entry) is True
+
+    @pytest.mark.parametrize("ptype", ["incus", "proxmox"])
+    def test_does_not_match_different_host_prefix(self, ptype):
+        scope = SyncScope(type=ptype, host="node1")
+        entry = _kh(ptype, "node2/dev1")
+        assert scope.in_update_scope(entry) is False
+        assert scope.in_removal_scope(entry) is False
+
+    @pytest.mark.parametrize("ptype", ["incus", "proxmox"])
+    def test_does_not_match_different_type(self, ptype):
+        scope = SyncScope(type=ptype, host="node1")
+        other_type = "proxmox" if ptype == "incus" else "incus"
+        entry = _kh(other_type, "node1/dev1")
+        assert scope.in_update_scope(entry) is False
+        assert scope.in_removal_scope(entry) is False
+
+    def test_prefix_match_is_not_a_substring_match(self):
+        # "node1" must not match "node10/dev1" -- the "/" makes it a prefix,
+        # not a bare startswith on the host string.
+        scope = SyncScope(type="incus", host="node1")
+        entry = _kh("incus", "node10/dev1")
+        assert scope.in_update_scope(entry) is False
+
+
+class TestSyncScopeAws:
+    def test_exact_region_match_is_in_both_scopes(self):
+        scope = SyncScope(type="aws", region="us-west-2")
+        entry = _kh("aws", "devbox", region="us-west-2")
+        assert scope.in_update_scope(entry) is True
+        assert scope.in_removal_scope(entry) is True
+
+    def test_different_region_is_in_neither_scope(self):
+        scope = SyncScope(type="aws", region="us-west-2")
+        entry = _kh("aws", "devbox", region="eu-central-1")
+        assert scope.in_update_scope(entry) is False
+        assert scope.in_removal_scope(entry) is False
+
+    def test_empty_region_matches_update_scope_but_never_removal_scope(self):
+        # The legacy/region-less asymmetry: a region-less AWS entry can be
+        # matched (and thus self-heal its region) but can never be removed.
+        scope = SyncScope(type="aws", region="us-west-2")
+        entry = _kh("aws", "legacybox", region="")
+        assert scope.in_update_scope(entry) is True
+        assert scope.in_removal_scope(entry) is False
+
+    def test_non_aws_type_never_matches_aws_scope(self):
+        scope = SyncScope(type="aws", region="us-west-2")
+        entry = _kh("hetzner", "devbox", region="us-west-2")
+        assert scope.in_update_scope(entry) is False
+        assert scope.in_removal_scope(entry) is False
+
+
+class TestSyncScopeHetzner:
+    def test_matches_unconditionally_regardless_of_host_or_region_fields(self):
+        scope = SyncScope(type="hetzner")
+        entry = _kh("hetzner", "web1")
+        assert scope.in_update_scope(entry) is True
+        assert scope.in_removal_scope(entry) is True
+
+    def test_non_hetzner_type_never_matches(self):
+        scope = SyncScope(type="hetzner")
+        entry = _kh("aws", "web1", region="us-west-2")
+        assert scope.in_update_scope(entry) is False
+        assert scope.in_removal_scope(entry) is False
+
+
+class TestSyncScopeDescribe:
+    def test_aws(self):
+        assert SyncScope(type="aws", region="us-west-2").describe() == "aws region us-west-2"
+
+    def test_incus(self):
+        assert (
+            SyncScope(type="incus", host="prox01").describe()
+            == "incus host prox01 (default project)"
+        )
+
+    def test_proxmox(self):
+        assert (
+            SyncScope(type="proxmox", host="pve1").describe()
+            == "proxmox node pve1 (this node only)"
+        )
+
+    def test_hetzner(self):
+        assert SyncScope(type="hetzner").describe() == "hetzner (all servers in project)"
+
+
+class TestSyncScopeValidation:
+    @pytest.mark.parametrize("ptype", ["incus", "proxmox"])
+    def test_empty_host_raises_scope_error(self, ptype):
+        with pytest.raises(ScopeError):
+            SyncScope(type=ptype, host="")
+
+    def test_aws_empty_region_raises_scope_error(self):
+        with pytest.raises(ScopeError):
+            SyncScope(type="aws", region="")
+
+    def test_hetzner_non_empty_host_raises_scope_error(self):
+        with pytest.raises(ScopeError):
+            SyncScope(type="hetzner", host="node1")
+
+    def test_hetzner_non_empty_region_raises_scope_error(self):
+        with pytest.raises(ScopeError):
+            SyncScope(type="hetzner", region="us-west-2")
+
+    def test_unknown_type_raises_scope_error(self):
+        with pytest.raises(ScopeError):
+            SyncScope(type="digitalocean")
+
+    def test_frozen_scope_cannot_be_mutated(self):
+        scope = SyncScope(type="hetzner")
+        with pytest.raises(Exception):
+            scope.type = "aws"  # type: ignore[misc]
+
+
+# ---------------------------------------------------------------------------
+# merge_entry
+# ---------------------------------------------------------------------------
+
+
+class TestMergeEntry:
+    def test_non_empty_discovered_values_win(self):
+        existing = _kh(
+            "aws", "devbox", host="1.1.1.1", instance_id="i-old", access_mode="ssm", region="us-east-1"
+        )
+        discovered = _kh(
+            "aws", "devbox", host="2.2.2.2", instance_id="i-new", access_mode="direct", region="us-west-2"
+        )
+        merged = merge_entry(existing, discovered)
+        assert merged.host == "2.2.2.2"
+        assert merged.instance_id == "i-new"
+        assert merged.access_mode == "direct"
+        assert merged.region == "us-west-2"
+
+    def test_empty_discovered_values_preserve_existing(self):
+        existing = _kh(
+            "aws", "devbox", host="1.1.1.1", instance_id="i-old", access_mode="ssm", region="us-east-1"
+        )
+        discovered = _kh("aws", "devbox", host="", instance_id="", access_mode="", region="")
+        merged = merge_entry(existing, discovered)
+        assert merged.host == "1.1.1.1"
+        assert merged.instance_id == "i-old"
+        assert merged.access_mode == "ssm"
+        assert merged.region == "us-east-1"
+
+    def test_stopped_instance_empty_host_preserves_last_known_address(self):
+        existing = _kh("aws", "devbox", host="203.0.113.7", instance_id="i-abc", region="us-west-2")
+        discovered = _kh("aws", "devbox", host="", instance_id="i-abc", region="us-west-2")
+        merged = merge_entry(existing, discovered)
+        assert merged.host == "203.0.113.7"
+
+    def test_user_always_preserved_from_existing(self):
+        existing = _kh("hetzner", "web1", user="remo")
+        discovered = _kh("hetzner", "web1", user="somebody-else")
+        merged = merge_entry(existing, discovered)
+        assert merged.user == "remo"
+
+    def test_type_and_name_never_change(self):
+        existing = _kh("incus", "node1/dev1", host="1.1.1.1")
+        # A discovered entry with a different type/name would be a probe
+        # bug, but merge_entry must not let it leak through identity.
+        discovered = _kh("incus", "node1/dev1", host="2.2.2.2")
+        merged = merge_entry(existing, discovered)
+        assert merged.type == existing.type
+        assert merged.name == existing.name
+
+
+# ---------------------------------------------------------------------------
+# build_plan: classification matrix (data-model.md)
+# ---------------------------------------------------------------------------
+
+
+class TestBuildPlanClassification:
+    def test_added_when_marked(self):
+        scope = SyncScope(type="incus", host="node1")
+        entry = _kh("incus", "node1/dev1")
+        plan = build_plan([], _probe([_dh(entry, marked=True)]), scope, include_all=False)
+        assert plan.added == [entry]
+        assert plan.skipped_unmarked == []
+
+    def test_added_via_include_all_when_unmarked(self):
+        scope = SyncScope(type="incus", host="node1")
+        entry = _kh("incus", "node1/dev1")
+        plan = build_plan([], _probe([_dh(entry, marked=False)]), scope, include_all=True)
+        assert plan.added == [entry]
+        assert plan.skipped_unmarked == []
+
+    def test_skipped_unmarked_when_unmarked_and_not_include_all(self):
+        scope = SyncScope(type="incus", host="node1")
+        entry = _kh("incus", "node1/dev1")
+        plan = build_plan([], _probe([_dh(entry, marked=False)]), scope, include_all=False)
+        assert plan.added == []
+        assert plan.skipped_unmarked == ["node1/dev1"]
+
+    def test_skipped_unmarked_when_include_all_but_not_adopted(self):
+        # A provider with a narrower adoption convention than "every host in
+        # scope" (AWS's remo-* naming, R7) reports adopted=False for a host
+        # that doesn't qualify -- --all must not sweep it in regardless.
+        scope = SyncScope(type="aws", region="us-west-2")
+        entry = _kh("aws", "unrelated-prod-box", region="us-west-2")
+        plan = build_plan(
+            [], _probe([_dh(entry, marked=False, adopted=False)]), scope, include_all=True
+        )
+        assert plan.added == []
+        assert plan.skipped_unmarked == ["unrelated-prod-box"]
+
+    def test_added_via_include_all_when_unmarked_and_adopted(self):
+        # The narrower-provider counterpart to the unconditional case above:
+        # adopted=True is what actually lets --all sweep an unmarked host in.
+        scope = SyncScope(type="aws", region="us-west-2")
+        entry = _kh("aws", "remo-devbox", region="us-west-2")
+        plan = build_plan(
+            [], _probe([_dh(entry, marked=False, adopted=True)]), scope, include_all=True
+        )
+        assert plan.added == [entry]
+        assert plan.skipped_unmarked == []
+
+    def test_updated_when_merge_differs(self):
+        scope = SyncScope(type="incus", host="node1")
+        existing = _kh("incus", "node1/dev1", host="1.1.1.1")
+        discovered_entry = _kh("incus", "node1/dev1", host="2.2.2.2")
+        plan = build_plan(
+            [existing], _probe([_dh(discovered_entry, marked=True)]), scope, include_all=False
+        )
+        assert len(plan.updated) == 1
+        before, after = plan.updated[0]
+        assert before == existing
+        assert after.host == "2.2.2.2"
+        assert plan.unchanged == []
+
+    def test_unchanged_when_merge_does_not_differ(self):
+        scope = SyncScope(type="incus", host="node1")
+        existing = _kh("incus", "node1/dev1", host="1.1.1.1")
+        discovered_entry = _kh("incus", "node1/dev1", host="1.1.1.1")
+        plan = build_plan(
+            [existing], _probe([_dh(discovered_entry, marked=True)]), scope, include_all=False
+        )
+        assert plan.unchanged == [existing]
+        assert plan.updated == []
+
+    def test_retained_unmarked_co_occurs_with_unchanged(self):
+        scope = SyncScope(type="incus", host="node1")
+        existing = _kh("incus", "node1/dev1", host="1.1.1.1")
+        discovered_entry = _kh("incus", "node1/dev1", host="1.1.1.1")
+        plan = build_plan(
+            [existing], _probe([_dh(discovered_entry, marked=False)]), scope, include_all=False
+        )
+        assert plan.unchanged == [existing]
+        assert plan.retained_unmarked == ["node1/dev1"]
+
+    def test_retained_unmarked_co_occurs_with_updated(self):
+        scope = SyncScope(type="incus", host="node1")
+        existing = _kh("incus", "node1/dev1", host="1.1.1.1")
+        discovered_entry = _kh("incus", "node1/dev1", host="2.2.2.2")
+        plan = build_plan(
+            [existing], _probe([_dh(discovered_entry, marked=False)]), scope, include_all=False
+        )
+        assert len(plan.updated) == 1
+        assert plan.retained_unmarked == ["node1/dev1"]
+
+    def test_removed_when_complete_and_in_removal_scope(self):
+        scope = SyncScope(type="incus", host="node1")
+        existing = _kh("incus", "node1/gone")
+        plan = build_plan([existing], _probe([], complete=True), scope, include_all=False)
+        assert plan.removed == [existing]
+        assert plan.unchanged == []
+        assert plan.removals_suppressed is False
+
+    def test_suppressed_not_removed_when_incomplete(self):
+        scope = SyncScope(type="incus", host="node1")
+        existing = _kh("incus", "node1/gone")
+        plan = build_plan(
+            [existing],
+            _probe([], complete=False, incomplete_reason="ssh timed out"),
+            scope,
+            include_all=False,
+        )
+        assert plan.removed == []
+        assert plan.unchanged == [existing]
+        assert plan.removals_suppressed is True
+
+    def test_out_of_removal_scope_not_removed_aws_region_less_entry(self):
+        # complete=True, but the region-less legacy entry is outside removal
+        # scope (FR-023) -- retained, and this alone must not trip
+        # removals_suppressed (that flag communicates incomplete enumeration
+        # only).
+        scope = SyncScope(type="aws", region="us-west-2")
+        existing = _kh("aws", "legacybox", region="")
+        plan = build_plan([existing], _probe([], complete=True), scope, include_all=False)
+        assert plan.removed == []
+        assert plan.unchanged == [existing]
+        assert plan.removals_suppressed is False
+
+    def test_out_of_update_scope_entry_is_completely_invisible(self):
+        scope = SyncScope(type="incus", host="node1")
+        other_host_entry = _kh("incus", "node2/other")
+        other_type_entry = _kh("aws", "devbox", region="us-west-2")
+        plan = build_plan(
+            [other_host_entry, other_type_entry], _probe([], complete=True), scope, include_all=False
+        )
+        assert plan.added == []
+        assert plan.updated == []
+        assert plan.unchanged == []
+        assert plan.removed == []
+        assert plan.skipped_unmarked == []
+        assert plan.retained_unmarked == []
+        assert plan.baseline == ()
+
+    def test_ambiguous_plan_error_on_duplicate_probe_names(self):
+        scope = SyncScope(type="incus", host="node1")
+        entry_a = _kh("incus", "node1/dup", host="1.1.1.1")
+        entry_b = _kh("incus", "node1/dup", host="2.2.2.2")
+        with pytest.raises(AmbiguousPlanError):
+            build_plan(
+                [], _probe([_dh(entry_a), _dh(entry_b)]), scope, include_all=False
+            )
+
+    def test_states_populated_for_added_updated_unchanged_but_not_skipped(self):
+        scope = SyncScope(type="aws", region="us-west-2")
+        existing_unchanged = _kh("aws", "alpha", host="1.1.1.1", region="us-west-2")
+        added_entry = _kh("aws", "beta", host="2.2.2.2", region="us-west-2")
+        skipped_entry = _kh("aws", "gamma", host="3.3.3.3", region="us-west-2")
+        plan = build_plan(
+            [existing_unchanged],
+            _probe(
+                [
+                    _dh(existing_unchanged, marked=True, state="stopped"),
+                    _dh(added_entry, marked=True, state="running"),
+                    _dh(skipped_entry, marked=False, state="running"),
+                ]
+            ),
+            scope,
+            include_all=False,
+        )
+        assert plan.states == {"alpha": "stopped", "beta": "running"}
+        assert "gamma" not in plan.states
+        assert plan.skipped_unmarked == ["gamma"]
+
+    def test_is_noop_and_has_removals_derived_properties(self):
+        scope = SyncScope(type="hetzner")
+        existing = _kh("hetzner", "web1", host="1.1.1.1")
+        noop_plan = build_plan(
+            [existing], _probe([_dh(existing, marked=True)]), scope, include_all=False
+        )
+        assert noop_plan.is_noop is True
+        assert noop_plan.has_removals is False
+
+        removal_plan = build_plan([existing], _probe([], complete=True), scope, include_all=False)
+        assert removal_plan.is_noop is False
+        assert removal_plan.has_removals is True
+
+    def test_baseline_is_exactly_the_in_scope_slice(self):
+        scope = SyncScope(type="incus", host="node1")
+        in_scope = _kh("incus", "node1/dev1")
+        out_of_scope = _kh("incus", "node2/other")
+        plan = build_plan(
+            [in_scope, out_of_scope],
+            _probe([_dh(in_scope, marked=True)]),
+            scope,
+            include_all=False,
+        )
+        assert plan.baseline == (in_scope,)
+
+
+# ---------------------------------------------------------------------------
+# gate_consent: five outcomes
+# ---------------------------------------------------------------------------
+
+
+class TestGateConsent:
+    def _plan_with_removals(self, count: int = 1):
+        scope = SyncScope(type="hetzner")
+        from remo_cli.core.reconcile import ReconcilePlan
+
+        removed = [_kh("hetzner", f"gone{i}") for i in range(count)]
+        return ReconcilePlan(scope=scope, removed=removed)
+
+    def _plan_without_removals(self):
+        scope = SyncScope(type="hetzner")
+        from remo_cli.core.reconcile import ReconcilePlan
+
+        return ReconcilePlan(scope=scope)
+
+    def test_no_removals_is_not_required_regardless_of_flags(self, monkeypatch):
+        monkeypatch.setattr(sys, "stdin", FakeStdin(is_tty=False))
+        plan = self._plan_without_removals()
+        assert gate_consent(plan, auto_confirm=False) is ConsentOutcome.NOT_REQUIRED
+        assert gate_consent(plan, auto_confirm=True) is ConsentOutcome.NOT_REQUIRED
+
+    def test_auto_confirm_skips_prompt_when_removals_present(self, monkeypatch):
+        monkeypatch.setattr(sys, "stdin", FakeStdin(is_tty=True))
+        plan = self._plan_with_removals()
+        assert gate_consent(plan, auto_confirm=True) is ConsentOutcome.NOT_REQUIRED
+
+    def test_confirmed_via_tty_and_confirm_returns_apply(self, monkeypatch):
+        monkeypatch.setattr(sys, "stdin", FakeStdin(is_tty=True))
+        monkeypatch.setattr("remo_cli.core.reconcile.confirm", lambda *a, **k: True)
+        plan = self._plan_with_removals()
+        assert gate_consent(plan, auto_confirm=False) is ConsentOutcome.APPLY
+
+    def test_declined_via_tty_and_confirm_returns_false(self, monkeypatch):
+        monkeypatch.setattr(sys, "stdin", FakeStdin(is_tty=True))
+        monkeypatch.setattr("remo_cli.core.reconcile.confirm", lambda *a, **k: False)
+        plan = self._plan_with_removals()
+        assert gate_consent(plan, auto_confirm=False) is ConsentOutcome.DECLINED
+
+    def test_non_interactive_when_stdin_is_not_a_tty(self, monkeypatch):
+        monkeypatch.setattr(sys, "stdin", FakeStdin(is_tty=False))
+        plan = self._plan_with_removals()
+        assert gate_consent(plan, auto_confirm=False) is ConsentOutcome.NON_INTERACTIVE
+
+
+# ---------------------------------------------------------------------------
+# run_sync: driver + exit codes (never 2)
+# ---------------------------------------------------------------------------
+
+
+class TestRunSyncExitCodes:
+    def test_probe_error_returns_failure_and_does_not_write(self, tmp_config_dir, capsys):
+        seed_registry(tmp_config_dir, [_kh("hetzner", "web1", host="1.1.1.1")])
+        expected = read_registry().hosts
+        scope = SyncScope(type="hetzner")
+
+        from remo_cli.core.reconcile import ProbeError
+
+        def failing_probe():
+            raise ProbeError("could not reach hetzner API")
+
+        rc = run_sync(scope, failing_probe)
+        assert rc == 1
+        assert rc != 2
+        assert read_registry().hosts == expected
+        assert "could not reach hetzner API" in capsys.readouterr().err
+
+    def test_ambiguous_plan_returns_failure(self, tmp_config_dir):
+        seed_registry(tmp_config_dir, [])
+        scope = SyncScope(type="hetzner")
+        dup_a = _dh(_kh("hetzner", "dup", host="1.1.1.1"))
+        dup_b = _dh(_kh("hetzner", "dup", host="2.2.2.2"))
+        rc = run_sync(scope, lambda: _probe([dup_a, dup_b]))
+        assert rc == 1
+        assert rc != 2
+
+    def test_dry_run_returns_ok_and_does_not_write(self, tmp_config_dir, monkeypatch):
+        seed_registry(tmp_config_dir, [_kh("hetzner", "gone", host="1.1.1.1")])
+        expected = read_registry().hosts
+        scope = SyncScope(type="hetzner")
+        monkeypatch.setattr(sys, "stdin", FakeStdin(is_tty=True))
+
+        rc = run_sync(scope, lambda: _probe([], complete=True), dry_run=True)
+        assert rc == 0
+        assert read_registry().hosts == expected
+
+    def test_declined_returns_aborted_and_does_not_write(self, tmp_config_dir, monkeypatch):
+        seed_registry(tmp_config_dir, [_kh("hetzner", "gone", host="1.1.1.1")])
+        expected = read_registry().hosts
+        scope = SyncScope(type="hetzner")
+        monkeypatch.setattr(sys, "stdin", FakeStdin(is_tty=True))
+        monkeypatch.setattr("remo_cli.core.reconcile.confirm", lambda *a, **k: False)
+
+        rc = run_sync(scope, lambda: _probe([], complete=True))
+        assert rc == 3
+        assert rc != 2
+        assert read_registry().hosts == expected
+
+    def test_non_interactive_returns_aborted_and_does_not_write(self, tmp_config_dir, monkeypatch):
+        seed_registry(tmp_config_dir, [_kh("hetzner", "gone", host="1.1.1.1")])
+        expected = read_registry().hosts
+        scope = SyncScope(type="hetzner")
+        monkeypatch.setattr(sys, "stdin", FakeStdin(is_tty=False))
+
+        rc = run_sync(scope, lambda: _probe([], complete=True))
+        assert rc == 3
+        assert rc != 2
+        assert read_registry().hosts == expected
+
+    def test_applied_returns_ok_and_writes_once(self, tmp_config_dir, monkeypatch):
+        existing = _kh("hetzner", "gone", host="1.1.1.1")
+        seed_registry(tmp_config_dir, [existing])
+        scope = SyncScope(type="hetzner")
+
+        rc = run_sync(scope, lambda: _probe([], complete=True), auto_confirm=True)
+        assert rc == 0
+        assert read_registry().hosts == []
+
+    def test_conflict_returns_failure(self, tmp_config_dir, monkeypatch):
+        existing = _kh("hetzner", "gone", host="1.1.1.1")
+        seed_registry(tmp_config_dir, [existing])
+        scope = SyncScope(type="hetzner")
+        monkeypatch.setattr(sys, "stdin", FakeStdin(is_tty=True))
+
+        def sneaky_confirm(*_a, **_k):
+            # Simulate a concurrent change to the same scope landing between
+            # plan-build and write: rewrite the registry mid-prompt.
+            seed_registry(tmp_config_dir, [_kh("hetzner", "gone", host="9.9.9.9")])
+            return True
+
+        monkeypatch.setattr("remo_cli.core.reconcile.confirm", sneaky_confirm)
+
+        rc = run_sync(scope, lambda: _probe([], complete=True))
+        assert rc == 1
+        assert rc != 2
+
+    def test_no_exit_code_path_ever_returns_2(self, tmp_config_dir, monkeypatch):
+        codes = []
+
+        # failure
+        from remo_cli.core.reconcile import ProbeError
+
+        seed_registry(tmp_config_dir, [])
+        codes.append(run_sync(SyncScope(type="hetzner"), lambda: (_ for _ in ()).throw(ProbeError("x"))))
+
+        # ambiguous
+        dup_a = _dh(_kh("hetzner", "dup"))
+        dup_b = _dh(_kh("hetzner", "dup", host="2.2.2.2"))
+        codes.append(run_sync(SyncScope(type="hetzner"), lambda: _probe([dup_a, dup_b])))
+
+        # dry-run
+        codes.append(
+            run_sync(SyncScope(type="hetzner"), lambda: _probe([], complete=True), dry_run=True)
+        )
+
+        # declined / non-interactive / applied all need a removal candidate
+        seed_registry(tmp_config_dir, [_kh("hetzner", "gone", host="1.1.1.1")])
+        monkeypatch.setattr(sys, "stdin", FakeStdin(is_tty=True))
+        monkeypatch.setattr("remo_cli.core.reconcile.confirm", lambda *a, **k: False)
+        codes.append(run_sync(SyncScope(type="hetzner"), lambda: _probe([], complete=True)))
+
+        monkeypatch.setattr(sys, "stdin", FakeStdin(is_tty=False))
+        codes.append(run_sync(SyncScope(type="hetzner"), lambda: _probe([], complete=True)))
+
+        seed_registry(tmp_config_dir, [_kh("hetzner", "gone", host="1.1.1.1")])
+        codes.append(
+            run_sync(SyncScope(type="hetzner"), lambda: _probe([], complete=True), auto_confirm=True)
+        )
+
+        assert 2 not in codes
+
+
+# ---------------------------------------------------------------------------
+# apply_plan
+# ---------------------------------------------------------------------------
+
+
+class TestApplyPlan:
+    def test_calls_mutate_registry_exactly_once(self, tmp_config_dir, monkeypatch):
+        import remo_cli.core.reconcile as reconcile_module
+        from remo_cli.core.registry import mutate_registry as real_mutate_registry
+
+        seed_registry(tmp_config_dir, [_kh("incus", "node1/dev1", host="1.1.1.1")])
+        current = read_registry().hosts
+        scope = SyncScope(type="incus", host="node1")
+
+        discovered_entry = _kh("incus", "node1/dev1", host="2.2.2.2")
+        plan = build_plan(
+            current, _probe([_dh(discovered_entry, marked=True)]), scope, include_all=False
+        )
+
+        call_count = 0
+
+        def spy(mutator):
+            nonlocal call_count
+            call_count += 1
+            return real_mutate_registry(mutator)
+
+        monkeypatch.setattr(reconcile_module, "mutate_registry", spy)
+        apply_plan(plan)
+        assert call_count == 1
+
+    def test_no_op_plan_does_not_write(self, tmp_config_dir, monkeypatch):
+        import remo_cli.core.reconcile as reconcile_module
+
+        existing = _kh("hetzner", "web1", host="1.1.1.1")
+        seed_registry(tmp_config_dir, [existing])
+        scope = SyncScope(type="hetzner")
+        plan = build_plan([existing], _probe([_dh(existing, marked=True)]), scope, include_all=False)
+        assert plan.is_noop is True
+
+        called = False
+
+        def spy(mutator):
+            nonlocal called
+            called = True
+            raise AssertionError("mutate_registry must not be called for a no-op plan")
+
+        monkeypatch.setattr(reconcile_module, "mutate_registry", spy)
+        apply_plan(plan)
+        assert called is False
+
+    def test_out_of_scope_entries_preserved_byte_for_byte(self, tmp_config_dir):
+        seed_registry(
+            tmp_config_dir,
+            [
+                _kh("incus", "node1/dev1", host="1.1.1.1"),
+                _kh(
+                    "aws",
+                    "prodbox",
+                    host="9.9.9.9",
+                    instance_id="i-xyz",
+                    access_mode="ssm",
+                    region="us-east-1",
+                ),
+            ],
+        )
+        current = read_registry().hosts
+        out_of_scope = next(h for h in current if h.name == "prodbox")
+        scope = SyncScope(type="incus", host="node1")
+
+        discovered_entry = _kh("incus", "node1/dev1", host="2.2.2.2")
+        plan = build_plan(
+            current,
+            _probe([_dh(discovered_entry, marked=True)]),
+            scope,
+            include_all=False,
+        )
+        apply_plan(plan)
+
+        after = read_registry().hosts
+        matching = [h for h in after if h.type == "aws" and h.name == "prodbox"]
+        assert matching == [out_of_scope]
+
+    def test_conflict_raised_when_same_scope_changes_on_disk(self, tmp_config_dir):
+        seed_registry(tmp_config_dir, [_kh("incus", "node1/dev1", host="1.1.1.1")])
+        current = read_registry().hosts
+        scope = SyncScope(type="incus", host="node1")
+
+        discovered_entry = _kh("incus", "node1/dev1", host="2.2.2.2")
+        plan = build_plan(
+            current, _probe([_dh(discovered_entry, marked=True)]), scope, include_all=False
+        )
+
+        # Simulate a concurrent write to the SAME scope between plan-build
+        # and apply_plan.
+        seed_registry(tmp_config_dir, [_kh("incus", "node1/dev1", host="3.3.3.3")])
+
+        with pytest.raises(ReconcileConflictError):
+            apply_plan(plan)
+
+    def test_no_conflict_when_only_a_different_scope_changed_on_disk(self, tmp_config_dir):
+        seed_registry(
+            tmp_config_dir,
+            [
+                _kh("incus", "node1/dev1", host="1.1.1.1"),
+                _kh("incus", "node2/dev2", host="5.5.5.5"),
+            ],
+        )
+        current = read_registry().hosts
+        in_scope_existing = next(h for h in current if h.name == "node1/dev1")
+        scope = SyncScope(type="incus", host="node1")
+
+        discovered_entry = _kh("incus", "node1/dev1", host="2.2.2.2")
+        plan = build_plan(
+            current,
+            _probe([_dh(discovered_entry, marked=True)]),
+            scope,
+            include_all=False,
+        )
+
+        # Concurrent change to a DIFFERENT scope (node2) must not trip the
+        # conflict check (FR-046/SC-016).
+        seed_registry(
+            tmp_config_dir,
+            [in_scope_existing, _kh("incus", "node2/dev2", host="6.6.6.6")],
+        )
+
+        apply_plan(plan)  # must not raise
+
+        after = read_registry().hosts
+        dev1 = next(h for h in after if h.name == "node1/dev1")
+        assert dev1.host == "2.2.2.2"

--- a/tests/unit/providers/test_aws_snapshot.py
+++ b/tests/unit/providers/test_aws_snapshot.py
@@ -85,9 +85,15 @@ def _snapshot_describe_response(
 @pytest.fixture
 def ec2(mocker):
     """Stub `_boto3_session(...).client('ec2')` to return a MagicMock and
-    `get_aws_region` to be a no-op."""
+    `get_aws_region` to be a no-op.
+
+    `get_paginator("describe_instances").paginate(...)` defaults to an empty
+    page list (sync tests configure `.paginate.return_value` per-test); no
+    test in this module calls it, so the default is a harmless no-op.
+    """
     mocker.patch("remo_cli.providers.aws.get_aws_region", return_value="us-east-1")
     ec2_client = MagicMock()
+    ec2_client.get_paginator.return_value.paginate.return_value = []
     session = MagicMock()
     session.client.return_value = ec2_client
     mocker.patch("remo_cli.providers.aws._boto3_session", return_value=session)

--- a/tests/unit/providers/test_aws_sync.py
+++ b/tests/unit/providers/test_aws_sync.py
@@ -1,0 +1,480 @@
+"""Tests for the AWS sync-reconcile probe (providers/aws.py `_probe`).
+
+AWS's old `sync` did a single-shot `describe_instances` filtered on
+`tag:remo=true` AND `instance-state-name=running`, then cleared *every*
+existing AWS registry entry regardless of region before re-populating from
+that one-region query -- so a bare `remo aws sync` (defaulting to
+`us-west-2`) destroyed every other region's entries, and a stopped instance
+(excluded by the `running` filter) was destroyed by the very next sync.
+`_probe` is the provider's only contribution to the new reconcile-based
+`sync()`: the diffing, consent, and write logic all live in
+`core/reconcile.py`. All boto3 calls are mocked; no live AWS account is
+required.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from remo_cli.core.reconcile import (
+    DiscoveredHost,
+    ProbeError,
+    ProbeResult,
+    SyncScope,
+    build_plan,
+)
+from remo_cli.models.host import KnownHost
+from remo_cli.providers import aws as providers_aws
+
+
+@pytest.fixture
+def ec2(mocker):
+    """Stub `_boto3_session(...).client('ec2')` to return a MagicMock."""
+    ec2_client = MagicMock()
+    session = MagicMock()
+    session.client.return_value = ec2_client
+    mocker.patch("remo_cli.providers.aws._boto3_session", return_value=session)
+    return ec2_client
+
+
+@pytest.fixture
+def scope() -> SyncScope:
+    return SyncScope(type="aws", region="us-west-2")
+
+
+def _instance(
+    instance_id: str = "i-1",
+    state: str = "running",
+    ip: str | None = "1.2.3.4",
+    tags: dict | None = None,
+) -> dict:
+    instance: dict = {
+        "InstanceId": instance_id,
+        "State": {"Name": state},
+        "Tags": [{"Key": k, "Value": v} for k, v in (tags or {}).items()],
+    }
+    if ip is not None:
+        instance["PublicIpAddress"] = ip
+    return instance
+
+
+def _page(instances: list[dict]) -> dict:
+    return {"Reservations": [{"Instances": instances}]}
+
+
+# ---------------------------------------------------------------------------
+# Pagination (T031/T035)
+# ---------------------------------------------------------------------------
+
+
+class TestProbePagination:
+    def test_two_page_walk_to_exhaustion_returns_all_and_complete(self, ec2, scope):
+        page1 = _page([_instance("i-1", tags={"remo_resource_name": "dev1"})])
+        page2 = _page([_instance("i-2", tags={"remo_resource_name": "dev2"})])
+        ec2.get_paginator.return_value.paginate.return_value = [page1, page2]
+
+        result = providers_aws._probe(scope, include_all=False)
+
+        assert {h.entry.name for h in result.hosts} == {"dev1", "dev2"}
+        assert result.complete is True
+        assert result.incomplete_reason == ""
+
+    def test_first_call_failure_raises_probe_error(self, ec2, scope):
+        ec2.get_paginator.return_value.paginate.side_effect = RuntimeError("boom")
+
+        with pytest.raises(ProbeError):
+            providers_aws._probe(scope, include_all=False)
+
+    def test_second_page_failure_yields_complete_false_without_probe_error(
+        self, ec2, scope
+    ):
+        page1 = _page([_instance("i-1", tags={"remo_resource_name": "dev1"})])
+
+        def _pages():
+            yield page1
+            raise RuntimeError("boom")
+
+        ec2.get_paginator.return_value.paginate.return_value = _pages()
+
+        # Partial-but-answered must not raise -- only a first-call failure
+        # (we could not ask at all) does.
+        result = providers_aws._probe(scope, include_all=False)
+
+        assert result.complete is False
+        assert result.incomplete_reason
+        assert {h.entry.name for h in result.hosts} == {"dev1"}
+
+    def test_query_filters_on_state_only_never_tag_remo(self, ec2, scope):
+        ec2.get_paginator.return_value.paginate.return_value = [_page([])]
+
+        providers_aws._probe(scope, include_all=False)
+
+        ec2.get_paginator.assert_called_with("describe_instances")
+        _, kwargs = ec2.get_paginator.return_value.paginate.call_args
+        filters = kwargs["Filters"]
+        assert len(filters) == 1
+        assert filters[0]["Name"] == "instance-state-name"
+        assert set(filters[0]["Values"]) == {
+            "pending",
+            "running",
+            "stopping",
+            "stopped",
+        }
+        assert not any(f["Name"] == "tag:remo" for f in filters)
+
+
+# ---------------------------------------------------------------------------
+# Entry shape / classification (T032)
+# ---------------------------------------------------------------------------
+
+
+class TestProbeClassification:
+    def test_marked_true_when_tag_remo_true(self, ec2, scope):
+        page = _page(
+            [_instance("i-1", tags={"remo": "true", "remo_resource_name": "dev1"})]
+        )
+        ec2.get_paginator.return_value.paginate.return_value = [page]
+        result = providers_aws._probe(scope, include_all=False)
+        assert result.hosts[0].marked is True
+
+    def test_marked_false_when_tag_remo_absent(self, ec2, scope):
+        page = _page([_instance("i-1", tags={"remo_resource_name": "dev1"})])
+        ec2.get_paginator.return_value.paginate.return_value = [page]
+        result = providers_aws._probe(scope, include_all=False)
+        assert result.hosts[0].marked is False
+
+    def test_marked_false_when_tag_remo_other_value(self, ec2, scope):
+        page = _page(
+            [_instance("i-1", tags={"remo": "false", "remo_resource_name": "dev1"})]
+        )
+        ec2.get_paginator.return_value.paginate.return_value = [page]
+        result = providers_aws._probe(scope, include_all=False)
+        assert result.hosts[0].marked is False
+
+    def test_entry_shape_matches_create(self, ec2, scope):
+        page = _page(
+            [
+                _instance(
+                    "i-1",
+                    ip="5.6.7.8",
+                    tags={
+                        "remo_resource_name": "dev1",
+                        "remo_access_mode": "direct",
+                    },
+                )
+            ]
+        )
+        ec2.get_paginator.return_value.paginate.return_value = [page]
+        result = providers_aws._probe(scope, include_all=False)
+        entry = result.hosts[0].entry
+        assert entry.type == "aws"
+        assert entry.name == "dev1"
+        assert entry.host == "5.6.7.8"
+        assert entry.user == "remo"
+        assert entry.instance_id == "i-1"
+        assert entry.access_mode == "direct"
+        assert entry.region == "us-west-2"
+
+    def test_access_mode_defaults_to_ssm(self, ec2, scope):
+        page = _page([_instance("i-1", tags={"remo_resource_name": "dev1"})])
+        ec2.get_paginator.return_value.paginate.return_value = [page]
+        result = providers_aws._probe(scope, include_all=False)
+        assert result.hosts[0].entry.access_mode == "ssm"
+
+    def test_adoption_criteria_is_set(self, ec2, scope):
+        page = _page([_instance("i-1", tags={"remo_resource_name": "dev1"})])
+        ec2.get_paginator.return_value.paginate.return_value = [page]
+        result = providers_aws._probe(scope, include_all=True)
+        assert result.adoption_criteria == (
+            "also matching instances named remo-* without the remo tag"
+        )
+
+    def test_adopted_true_for_remo_dash_prefixed_name_tag(self, ec2, scope):
+        # Widens under --all (R7) -- but only for instances actually named
+        # by the remo convention, not any untagged instance in the region.
+        page = _page(
+            [_instance("i-1", tags={"remo_resource_name": "dev1", "Name": "remo-dev1"})]
+        )
+        ec2.get_paginator.return_value.paginate.return_value = [page]
+        result = providers_aws._probe(scope, include_all=True)
+        assert result.hosts[0].adopted is True
+
+    def test_adopted_false_for_unrelated_name_tag(self, ec2, scope):
+        page = _page(
+            [_instance("i-1", tags={"remo_resource_name": "dev1", "Name": "some-other-box"})]
+        )
+        ec2.get_paginator.return_value.paginate.return_value = [page]
+        result = providers_aws._probe(scope, include_all=True)
+        assert result.hosts[0].adopted is False
+
+    def test_all_only_adds_remo_dash_named_instance_via_build_plan(self, ec2, scope):
+        # End-to-end proof of the narrowing: an unmarked, untagged instance
+        # with an unrelated Name is never swept in by --all; a remo-*-named
+        # one is.
+        page = _page(
+            [
+                _instance("i-1", tags={"remo_resource_name": "dev1", "Name": "remo-dev1"}),
+                _instance(
+                    "i-2", tags={"remo_resource_name": "prodbox", "Name": "some-other-box"}
+                ),
+            ]
+        )
+        ec2.get_paginator.return_value.paginate.return_value = [page]
+        probe = providers_aws._probe(scope, include_all=True)
+        plan = build_plan([], probe, scope, include_all=True)
+        assert {h.name for h in plan.added} == {"dev1"}
+        assert plan.skipped_unmarked == ["prodbox"]
+
+    def test_include_all_does_not_change_what_probe_returns(self, ec2, scope):
+        page = _page([_instance("i-1", tags={"remo_resource_name": "dev1"})])
+        ec2.get_paginator.return_value.paginate.return_value = [page]
+        without_all = providers_aws._probe(scope, include_all=False)
+
+        page = _page([_instance("i-1", tags={"remo_resource_name": "dev1"})])
+        ec2.get_paginator.return_value.paginate.return_value = [page]
+        with_all = providers_aws._probe(scope, include_all=True)
+
+        assert {h.entry.name for h in without_all.hosts} == {
+            h.entry.name for h in with_all.hosts
+        }
+
+    def test_running_state_is_not_annotated(self, ec2, scope):
+        page = _page(
+            [_instance("i-1", state="running", tags={"remo_resource_name": "dev1"})]
+        )
+        ec2.get_paginator.return_value.paginate.return_value = [page]
+        result = providers_aws._probe(scope, include_all=False)
+        assert result.hosts[0].state == ""
+
+    def test_non_running_state_is_populated(self, ec2, scope):
+        page = _page(
+            [_instance("i-1", state="pending", tags={"remo_resource_name": "dev1"})]
+        )
+        ec2.get_paginator.return_value.paginate.return_value = [page]
+        result = providers_aws._probe(scope, include_all=False)
+        assert result.hosts[0].state == "pending"
+
+
+# ---------------------------------------------------------------------------
+# Name derivation (R8)
+# ---------------------------------------------------------------------------
+
+
+class TestNameDerivation:
+    def test_prefers_remo_resource_name_tag(self, ec2, scope):
+        page = _page(
+            [
+                _instance(
+                    "i-1",
+                    tags={"remo_resource_name": "dev1", "Name": "remo-other"},
+                )
+            ]
+        )
+        ec2.get_paginator.return_value.paginate.return_value = [page]
+        result = providers_aws._probe(scope, include_all=False)
+        assert result.hosts[0].entry.name == "dev1"
+
+    def test_falls_back_to_name_tag_minus_remo_prefix(self, ec2, scope):
+        page = _page([_instance("i-1", tags={"Name": "remo-dev2"})])
+        ec2.get_paginator.return_value.paginate.return_value = [page]
+        result = providers_aws._probe(scope, include_all=False)
+        assert result.hosts[0].entry.name == "dev2"
+
+    def test_instance_with_neither_tag_is_skipped(self, ec2, scope):
+        page = _page([_instance("i-1", tags={})])
+        ec2.get_paginator.return_value.paginate.return_value = [page]
+        result = providers_aws._probe(scope, include_all=False)
+        assert result.hosts == []
+
+
+# ---------------------------------------------------------------------------
+# Region-boundary asymmetry (T035, US2)
+#
+# A region-less legacy entry matches every region's *update* scope (so a
+# hit in the queried region self-heals it) but can never be proposed for
+# *removal* while region-less -- this is SyncScope.in_update_scope vs
+# in_removal_scope, already implemented in core/reconcile.py. Tested at the
+# build_plan level per the task guidance, to keep it fast and precise.
+# ---------------------------------------------------------------------------
+
+
+class TestRegionScopingAsymmetry:
+    def test_region_less_entry_is_matched_and_stamped_when_discovered(self, scope):
+        existing = KnownHost(
+            type="aws",
+            name="legacy",
+            host="1.1.1.1",
+            user="remo",
+            instance_id="i-legacy",
+            access_mode="ssm",
+            region="",
+        )
+        discovered_entry = KnownHost(
+            type="aws",
+            name="legacy",
+            host="1.1.1.1",
+            user="remo",
+            instance_id="i-legacy",
+            access_mode="ssm",
+            region="us-west-2",
+        )
+        probe = ProbeResult(
+            hosts=[DiscoveredHost(entry=discovered_entry, marked=True)],
+            complete=True,
+        )
+
+        plan = build_plan([existing], probe, scope, include_all=False)
+
+        updated = {after.name: after for _before, after in plan.updated}
+        assert "legacy" in updated
+        assert updated["legacy"].region == "us-west-2"
+
+    def test_region_less_entry_never_removed_even_when_absent_from_probe(self, scope):
+        existing = KnownHost(
+            type="aws",
+            name="legacy",
+            host="1.1.1.1",
+            user="remo",
+            instance_id="i-legacy",
+            access_mode="ssm",
+            region="",
+        )
+        probe = ProbeResult(hosts=[], complete=True)
+
+        plan = build_plan([existing], probe, scope, include_all=False)
+
+        assert "legacy" not in {h.name for h in plan.removed}
+        assert "legacy" in {h.name for h in plan.unchanged}
+
+    def test_out_of_region_entry_absent_from_probe_still_never_removed(self, scope):
+        # An entry correctly stamped for a *different* region is out of
+        # in_update_scope entirely (region != "" and != scope.region), so it
+        # is not even a candidate in this region's plan -- the direct
+        # region-wipe regression guard.
+        other_region = KnownHost(
+            type="aws",
+            name="eastbox",
+            host="2.2.2.2",
+            user="remo",
+            instance_id="i-east",
+            access_mode="ssm",
+            region="eu-central-1",
+        )
+        probe = ProbeResult(hosts=[], complete=True)
+
+        plan = build_plan([other_region], probe, scope, include_all=False)
+
+        assert plan.removed == []
+        assert plan.unchanged == []
+        assert plan.updated == []
+        assert plan.added == []
+
+
+# ---------------------------------------------------------------------------
+# Marker-independence regression (FR-044, SC-015)
+# ---------------------------------------------------------------------------
+
+
+class TestMarkerIndependenceRegression:
+    def test_untagged_but_live_instance_is_retained_not_removed(self, ec2, scope):
+        existing = KnownHost(
+            type="aws",
+            name="legacy",
+            host="9.9.9.9",
+            user="remo",
+            instance_id="i-legacy",
+            access_mode="ssm",
+            region="us-west-2",
+        )
+        # No tag:remo=true -- the old server-side filter would have made
+        # this instance invisible and proposed it for deletion.
+        page = _page(
+            [_instance("i-legacy", ip="9.9.9.9", tags={"remo_resource_name": "legacy"})]
+        )
+        ec2.get_paginator.return_value.paginate.return_value = [page]
+
+        probe = providers_aws._probe(scope, include_all=False)
+        plan = build_plan([existing], probe, scope, include_all=False)
+
+        assert "legacy" not in {h.name for h in plan.removed}
+        retained_or_unchanged = set(plan.retained_unmarked) | {
+            h.name for h in plan.unchanged
+        }
+        assert "legacy" in retained_or_unchanged
+
+
+# ---------------------------------------------------------------------------
+# Stopped / terminated instances (T038-T042, US3)
+# ---------------------------------------------------------------------------
+
+
+class TestStoppedInstance:
+    def test_stopped_instance_has_empty_host_and_reports_state(self, ec2, scope):
+        # Real AWS responses omit PublicIpAddress entirely rather than
+        # sending an empty string.
+        instance = _instance(
+            "i-1", state="stopped", ip=None, tags={"remo_resource_name": "dev1"}
+        )
+        assert "PublicIpAddress" not in instance
+        ec2.get_paginator.return_value.paginate.return_value = [_page([instance])]
+
+        result = providers_aws._probe(scope, include_all=False)
+
+        assert len(result.hosts) == 1
+        host = result.hosts[0]
+        assert host.entry.host == ""
+        assert host.state == "stopped"
+
+    def test_stopped_instance_preserves_last_known_address_via_merge(
+        self, ec2, scope
+    ):
+        existing = KnownHost(
+            type="aws",
+            name="dev1",
+            host="1.2.3.4",
+            user="remo",
+            instance_id="i-1",
+            access_mode="ssm",
+            region="us-west-2",
+        )
+        instance = _instance(
+            "i-1",
+            state="stopped",
+            ip=None,
+            tags={"remo_resource_name": "dev1", "remo": "true"},
+        )
+        ec2.get_paginator.return_value.paginate.return_value = [_page([instance])]
+
+        probe = providers_aws._probe(scope, include_all=False)
+        plan = build_plan([existing], probe, scope, include_all=False)
+
+        merged_by_name = {after.name: after for _before, after in plan.updated}
+        merged_by_name.update({h.name: h for h in plan.unchanged})
+        assert merged_by_name["dev1"].host == "1.2.3.4"
+        assert merged_by_name["dev1"].region == "us-west-2"
+        assert plan.states.get("dev1") == "stopped"
+        # FR-019: reported, never persisted -- KnownHost carries no state field.
+        assert not hasattr(merged_by_name["dev1"], "state")
+
+    def test_terminated_instance_correctly_lands_in_removed(self, scope):
+        # The state filter already excludes shutting-down/terminated
+        # server-side, so a terminated instance simply never appears in a
+        # probe result -- exercised here as absence rather than a synthetic
+        # terminated payload, since AWS would never return one to us given
+        # the filter.
+        existing = KnownHost(
+            type="aws",
+            name="gone",
+            host="1.1.1.1",
+            user="remo",
+            instance_id="i-gone",
+            access_mode="ssm",
+            region="us-west-2",
+        )
+        probe = ProbeResult(hosts=[], complete=True)
+
+        plan = build_plan([existing], probe, scope, include_all=False)
+
+        assert "gone" in {h.name for h in plan.removed}

--- a/tests/unit/providers/test_hetzner_label.py
+++ b/tests/unit/providers/test_hetzner_label.py
@@ -1,0 +1,107 @@
+"""Tests for the Hetzner managed-label backfill (`_apply_managed_label`, T057/T058).
+
+`create` now applies `remo: "true"` at creation time via Ansible (T028), but a
+server created before that change -- or otherwise unlabelled -- needs a
+retroactive path. Both `hetzner.hcloud.server` and a raw `PUT /servers/{id}`
+treat the supplied label map as authoritative and replace it wholesale, so
+`_apply_managed_label` must read-merge rather than overwrite (FR-034). All
+HTTP is mocked via `_hetzner_api`; no live Hetzner project is required.
+"""
+
+from __future__ import annotations
+
+from remo_cli.providers import hetzner as providers_hetzner
+
+
+def _server(server_id: int = 42, name: str = "dev1", labels: dict | None = None) -> dict:
+    return {"id": server_id, "name": name, "labels": labels if labels is not None else {}}
+
+
+class TestApplyManagedLabel:
+    def test_already_labelled_is_a_noop_no_put(self, mocker):
+        get_response = {"servers": [_server(labels={"remo": "true"})]}
+        api = mocker.patch.object(
+            providers_hetzner, "_hetzner_api", side_effect=[get_response]
+        )
+
+        ok, err = providers_hetzner._apply_managed_label("dev1")
+
+        assert ok is True
+        assert err == ""
+        # Only the GET lookup happened -- no PUT was ever issued.
+        assert api.call_count == 1
+        assert api.call_args_list[0].args[0] == "GET"
+
+    def test_merge_preserves_unrelated_labels(self, mocker):
+        get_response = {"servers": [_server(labels={"env": "prod"})]}
+        api = mocker.patch.object(
+            providers_hetzner, "_hetzner_api", side_effect=[get_response, {}]
+        )
+
+        ok, err = providers_hetzner._apply_managed_label("dev1")
+
+        assert ok is True
+        assert err == ""
+        assert api.call_count == 2
+        method, path, body = api.call_args_list[1].args
+        assert method == "PUT"
+        assert path == "/servers/42"
+        assert body == {"labels": {"env": "prod", "remo": "true"}}
+
+    def test_no_prior_labels_still_writes_remo_true(self, mocker):
+        get_response = {"servers": [_server(labels={})]}
+        api = mocker.patch.object(
+            providers_hetzner, "_hetzner_api", side_effect=[get_response, {}]
+        )
+
+        ok, err = providers_hetzner._apply_managed_label("dev1")
+
+        assert ok is True
+        assert api.call_args_list[1].args[2] == {"labels": {"remo": "true"}}
+
+    def test_lookup_failure_returns_false_and_never_raises(self, mocker):
+        mocker.patch.object(
+            providers_hetzner,
+            "_hetzner_api",
+            side_effect=RuntimeError("No Hetzner server found named 'dev1'."),
+        )
+
+        ok, err = providers_hetzner._apply_managed_label("dev1")
+
+        assert ok is False
+        assert "dev1" in err
+
+    def test_put_failure_returns_false_and_never_raises(self, mocker):
+        get_response = {"servers": [_server(labels={})]}
+        mocker.patch.object(
+            providers_hetzner,
+            "_hetzner_api",
+            side_effect=[get_response, RuntimeError("Hetzner API PUT failed: 503")],
+        )
+
+        ok, err = providers_hetzner._apply_managed_label("dev1")
+
+        assert ok is False
+        assert "503" in err
+
+
+class TestUpdateWarnsWithoutFailing:
+    def test_update_warns_but_still_proceeds_when_label_backfill_fails(self, mocker):
+        mocker.patch.object(
+            providers_hetzner, "_apply_managed_label", return_value=(False, "boom")
+        )
+        mocker.patch.object(
+            providers_hetzner, "_lookup_hetzner_host", return_value="1.2.3.4"
+        )
+        warn = mocker.patch.object(providers_hetzner, "print_warning")
+        run_playbook = mocker.patch.object(
+            providers_hetzner, "run_playbook", return_value=0
+        )
+
+        rc = providers_hetzner.update(name="dev1")
+
+        assert rc == 0
+        run_playbook.assert_called_once()
+        assert warn.call_count == 1
+        assert "dev1" in warn.call_args.args[0]
+        assert "boom" in warn.call_args.args[0]

--- a/tests/unit/providers/test_hetzner_sync.py
+++ b/tests/unit/providers/test_hetzner_sync.py
@@ -1,0 +1,271 @@
+"""Tests for the Hetzner sync-reconcile probe (providers/hetzner.py `_probe`).
+
+Hetzner's `sync` used to build `?label_selector=remo` by hand with no
+pagination, so a plain `remo hetzner sync` always queried zero servers and
+the old clear-then-repopulate logic wiped the entire registry every run
+(FR-044). `_probe` is the provider's only contribution to the new
+reconcile-based `sync()`: the diffing, consent, and write logic live in
+`core/reconcile.py`. All HTTP is mocked via `_hetzner_api`; no live Hetzner
+project is required.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from remo_cli.core.reconcile import ProbeError, SyncScope, build_plan
+from remo_cli.models.host import KnownHost
+from remo_cli.providers import hetzner as providers_hetzner
+
+
+@pytest.fixture
+def scope() -> SyncScope:
+    return SyncScope(type="hetzner")
+
+
+def _server(
+    name: str,
+    ip: str | None = "1.2.3.4",
+    labels: dict | None = None,
+    status: str = "running",
+) -> dict:
+    server: dict = {"name": name, "status": status, "labels": labels or {}}
+    if ip is not None:
+        server["public_net"] = {"ipv4": {"ip": ip}}
+    return server
+
+
+def _page(servers: list[dict], next_page: int | None) -> dict:
+    return {"servers": servers, "meta": {"pagination": {"next_page": next_page}}}
+
+
+# ---------------------------------------------------------------------------
+# Pagination (T024/T029)
+# ---------------------------------------------------------------------------
+
+
+class TestProbePagination:
+    def test_two_page_walk_to_exhaustion_returns_all_servers_and_complete(
+        self, scope, mocker
+    ):
+        page1 = _page([_server("dev1"), _server("dev2")], next_page=2)
+        page2 = _page([_server("dev3")], next_page=None)
+        patched = mocker.patch.object(
+            providers_hetzner, "_hetzner_api", side_effect=[page1, page2]
+        )
+
+        result = providers_hetzner._probe(scope, include_all=False)
+
+        assert {h.entry.name for h in result.hosts} == {"dev1", "dev2", "dev3"}
+        assert result.complete is True
+        assert result.incomplete_reason == ""
+        assert patched.call_count == 2
+
+    def test_first_page_failure_raises_probe_error(self, scope, mocker):
+        mocker.patch.object(
+            providers_hetzner, "_hetzner_api", side_effect=RuntimeError("boom")
+        )
+
+        with pytest.raises(ProbeError):
+            providers_hetzner._probe(scope, include_all=False)
+
+    def test_second_page_failure_yields_complete_false_without_probe_error(
+        self, scope, mocker
+    ):
+        page1 = _page([_server("dev1"), _server("dev2")], next_page=2)
+        mocker.patch.object(
+            providers_hetzner,
+            "_hetzner_api",
+            side_effect=[page1, RuntimeError("boom")],
+        )
+
+        # Partial-but-answered must not raise -- only a first-page failure
+        # (we could not ask at all) does.
+        result = providers_hetzner._probe(scope, include_all=False)
+
+        assert result.complete is False
+        assert result.incomplete_reason
+        # What was gathered on the successful first page is preserved.
+        assert {h.entry.name for h in result.hosts} == {"dev1", "dev2"}
+
+    def test_query_never_includes_label_selector(self, scope, mocker):
+        page1 = _page([_server("dev1")], next_page=None)
+        patched = mocker.patch.object(
+            providers_hetzner, "_hetzner_api", side_effect=[page1]
+        )
+
+        providers_hetzner._probe(scope, include_all=False)
+
+        for call in patched.call_args_list:
+            method, path = call.args[0], call.args[1]
+            assert method == "GET"
+            assert "label_selector" not in path
+            assert path.startswith("/servers")
+
+
+# ---------------------------------------------------------------------------
+# Entry shape / classification (T025)
+# ---------------------------------------------------------------------------
+
+
+class TestProbeClassification:
+    def test_server_without_ipv4_is_still_included_with_empty_host(self, scope, mocker):
+        page = _page([_server("noip", ip=None)], next_page=None)
+        mocker.patch.object(providers_hetzner, "_hetzner_api", side_effect=[page])
+
+        result = providers_hetzner._probe(scope, include_all=False)
+
+        assert len(result.hosts) == 1
+        assert result.hosts[0].entry.name == "noip"
+        assert result.hosts[0].entry.host == ""
+
+    def test_marked_true_when_remo_label_true(self, scope, mocker):
+        page = _page([_server("dev1", labels={"remo": "true"})], next_page=None)
+        mocker.patch.object(providers_hetzner, "_hetzner_api", side_effect=[page])
+
+        result = providers_hetzner._probe(scope, include_all=False)
+
+        assert result.hosts[0].marked is True
+
+    def test_marked_false_when_label_absent(self, scope, mocker):
+        page = _page([_server("dev1", labels={})], next_page=None)
+        mocker.patch.object(providers_hetzner, "_hetzner_api", side_effect=[page])
+
+        result = providers_hetzner._probe(scope, include_all=False)
+
+        assert result.hosts[0].marked is False
+
+    def test_marked_false_when_label_present_with_other_value(self, scope, mocker):
+        page = _page([_server("dev1", labels={"remo": "false"})], next_page=None)
+        mocker.patch.object(providers_hetzner, "_hetzner_api", side_effect=[page])
+
+        result = providers_hetzner._probe(scope, include_all=False)
+
+        assert result.hosts[0].marked is False
+
+    def test_entry_shape_matches_create(self, scope, mocker):
+        page = _page([_server("dev1", ip="5.6.7.8")], next_page=None)
+        mocker.patch.object(providers_hetzner, "_hetzner_api", side_effect=[page])
+
+        result = providers_hetzner._probe(scope, include_all=False)
+        entry = result.hosts[0].entry
+
+        assert entry.type == "hetzner"
+        assert entry.name == "dev1"
+        assert entry.host == "5.6.7.8"
+        assert entry.user == "remo"
+        assert entry.instance_id == ""
+        assert entry.access_mode == ""
+        assert entry.region == ""
+
+    def test_state_reflects_server_status(self, scope, mocker):
+        page = _page([_server("dev1", status="stopped")], next_page=None)
+        mocker.patch.object(providers_hetzner, "_hetzner_api", side_effect=[page])
+
+        result = providers_hetzner._probe(scope, include_all=False)
+
+        assert result.hosts[0].state == "stopped"
+
+    def test_adoption_criteria_names_the_whole_project(self, scope, mocker):
+        page = _page([_server("dev1")], next_page=None)
+        mocker.patch.object(providers_hetzner, "_hetzner_api", side_effect=[page])
+
+        result = providers_hetzner._probe(scope, include_all=True)
+
+        assert result.adoption_criteria == "every server in this Hetzner project"
+
+    def test_include_all_does_not_change_what_probe_returns(self, scope, mocker):
+        page = _page([_server("dev1", labels={"remo": "true"}), _server("dev2")], next_page=None)
+        mocker.patch.object(
+            providers_hetzner, "_hetzner_api", side_effect=[page, _page(page["servers"], None)]
+        )
+
+        without_all = providers_hetzner._probe(scope, include_all=False)
+        with_all = providers_hetzner._probe(scope, include_all=True)
+
+        assert {h.entry.name for h in without_all.hosts} == {
+            h.entry.name for h in with_all.hosts
+        }
+
+
+# ---------------------------------------------------------------------------
+# Adoption (T060, US5): --all widens eligibility for a new, unmarked server
+# to every server in the project (R7 -- Hetzner has no naming convention to
+# narrow on, unlike AWS's remo-* prefix).
+# ---------------------------------------------------------------------------
+
+
+class TestAdoption:
+    def test_skipped_without_all_for_new_unmarked_server(self, scope, mocker):
+        page = _page([_server("dev1", labels={})], next_page=None)
+        mocker.patch.object(providers_hetzner, "_hetzner_api", side_effect=[page])
+
+        probe = providers_hetzner._probe(scope, include_all=False)
+        plan = build_plan([], probe, scope, include_all=False)
+
+        assert plan.added == []
+        assert plan.skipped_unmarked == ["dev1"]
+
+    def test_adopted_with_all_for_new_unmarked_server(self, scope, mocker):
+        page = _page([_server("dev1", labels={})], next_page=None)
+        mocker.patch.object(providers_hetzner, "_hetzner_api", side_effect=[page])
+
+        probe = providers_hetzner._probe(scope, include_all=True)
+        plan = build_plan([], probe, scope, include_all=True)
+
+        assert {h.name for h in plan.added} == {"dev1"}
+        assert plan.skipped_unmarked == []
+        assert probe.adoption_criteria == "every server in this Hetzner project"
+
+
+# ---------------------------------------------------------------------------
+# Marker-independence regression (T030, FR-044, SC-015)
+#
+# This is the direct regression guard for the bug this phase exists to fix:
+# the old sync's server-side `label_selector=remo` query always returned
+# zero servers (nothing in the codebase ever applied that label), so every
+# invocation wiped the entire Hetzner registry. An unlabelled-but-live
+# server must be retained, never proposed for removal, purely because the
+# probe still *saw* it.
+# ---------------------------------------------------------------------------
+
+
+class TestMarkerIndependenceRegression:
+    def test_unlabelled_but_live_server_is_retained_not_removed(self, scope, mocker):
+        existing = KnownHost(type="hetzner", name="legacy", host="9.9.9.9", user="remo")
+        page = _page([_server("legacy", ip="9.9.9.9", labels={})], next_page=None)
+        mocker.patch.object(providers_hetzner, "_hetzner_api", side_effect=[page])
+
+        probe = providers_hetzner._probe(scope, include_all=False)
+        plan = build_plan([existing], probe, scope, include_all=False)
+
+        removed_names = {h.name for h in plan.removed}
+        assert "legacy" not in removed_names
+        retained_or_unchanged = set(plan.retained_unmarked) | {
+            h.name for h in plan.unchanged
+        }
+        assert "legacy" in retained_or_unchanged
+
+    def test_a_plain_sync_no_longer_wipes_the_registry(self, scope, mocker):
+        # The exact failure mode fixed by this phase: previously the query
+        # was `?label_selector=remo`, which matched nothing remo ever
+        # created, so `probe.hosts` was always empty and every entry looked
+        # deletable. Now the (unfiltered) query returns the live server, so
+        # it survives even though it carries no label at all.
+        existing = [
+            KnownHost(type="hetzner", name="alpha", host="1.1.1.1", user="remo"),
+            KnownHost(type="hetzner", name="beta", host="2.2.2.2", user="remo"),
+        ]
+        page = _page(
+            [
+                _server("alpha", ip="1.1.1.1", labels={}),
+                _server("beta", ip="2.2.2.2", labels={}),
+            ],
+            next_page=None,
+        )
+        mocker.patch.object(providers_hetzner, "_hetzner_api", side_effect=[page])
+
+        probe = providers_hetzner._probe(scope, include_all=False)
+        plan = build_plan(existing, probe, scope, include_all=False)
+
+        assert plan.removed == []

--- a/tests/unit/providers/test_incus_marker.py
+++ b/tests/unit/providers/test_incus_marker.py
@@ -1,8 +1,10 @@
 """Tests for the Incus managed-marker feature (providers/incus.py).
 
-Covers marker apply/read helpers, create/update wiring, and filtered sync —
-including FR-010 (sync is read-only) and FR-013 (sync makes a bounded number of
-host queries). All SSH is mocked; no live Incus host is required.
+Covers marker apply/read helpers and create/update wiring. `sync()` itself
+is now a thin wrapper over the reconcile engine (016-sync-reconcile); its
+probe is covered by tests/unit/providers/test_incus_sync.py and the
+read-only / consent / write behaviour by tests/integration/test_sync_reconcile.py.
+All SSH is mocked; no live Incus host is required.
 """
 
 from __future__ import annotations
@@ -136,79 +138,3 @@ class TestUpdateBackfill:
         rc = providers_incus.update(name="dev1", host="h", user="u")
         assert rc == 0
         apply.assert_called_once_with("h", "u", "dev1")
-
-
-# ---------------------------------------------------------------------------
-# sync() — filtering, hint, FR-010 (read-only), FR-013 (bounded)
-# ---------------------------------------------------------------------------
-
-
-@pytest.fixture
-def patch_registry(mocker):
-    save = mocker.patch("remo_cli.providers.incus.save_known_host")
-    mocker.patch("remo_cli.providers.incus.clear_known_hosts_by_prefix")
-    return save
-
-
-class TestSyncFiltering:
-    def test_default_registers_only_marked(self, patch_host, patch_registry, mocker):
-        patch_host.return_value = _completed(0, stdout="dev1,true\nplex,\n")
-        info = mocker.patch("remo_cli.providers.incus.print_info")
-        warn = mocker.patch("remo_cli.providers.incus.print_warning")
-
-        providers_incus.sync(host="h", user="u")
-
-        # Only dev1 registered.
-        saved = [c.args[0].name for c in patch_registry.call_args_list]
-        assert saved == ["h/dev1"]
-        # Hint names the skipped container.
-        warn_text = " ".join(str(c.args[0]) for c in warn.call_args_list)
-        assert "plex" in warn_text
-        info_text = " ".join(str(c.args[0]) for c in info.call_args_list)
-        assert "--all" in info_text and "remo incus update" in info_text
-
-    def test_all_registers_everything(self, patch_host, patch_registry, mocker):
-        patch_host.return_value = _completed(0, stdout="dev1,true\nplex,\n")
-        warn = mocker.patch("remo_cli.providers.incus.print_warning")
-        mocker.patch("remo_cli.providers.incus.print_info")
-
-        providers_incus.sync(host="h", user="u", include_all=True)
-
-        saved = sorted(c.args[0].name for c in patch_registry.call_args_list)
-        assert saved == ["h/dev1", "h/plex"]
-        warn_text = " ".join(str(c.args[0]) for c in warn.call_args_list)
-        assert "plex" in warn_text
-        # The adopted-unmarked summary must actually be emitted (FR-009).
-        assert "not remo-created" in warn_text
-
-    def test_sync_is_read_only_and_bounded(self, patch_host, patch_registry, mocker):
-        patch_host.return_value = _completed(0, stdout="dev1,true\nplex,\n")
-        mocker.patch("remo_cli.providers.incus.print_info")
-        mocker.patch("remo_cli.providers.incus.print_warning")
-
-        providers_incus.sync(host="h", user="u")
-
-        # FR-013: a single bulk host query, regardless of container count.
-        assert patch_host.call_count == 1
-        # FR-010: sync issues no marker mutation.
-        for call in patch_host.call_args_list:
-            assert "config set" not in call.args[2]
-
-    def test_registry_shape_unchanged(self, patch_host, patch_registry, mocker):
-        # FR-012: the KnownHost written by sync keeps its pre-feature fields;
-        # marker state is not recorded in the registry.
-        patch_host.return_value = _completed(0, stdout="dev1,true\n")
-        mocker.patch("remo_cli.providers.incus.print_info")
-        mocker.patch("remo_cli.providers.incus.print_warning")
-
-        providers_incus.sync(host="h", user="u")
-
-        kh = patch_registry.call_args.args[0]
-        assert kh.type == "incus"
-        assert kh.name == "h/dev1"
-        assert kh.user == "remo"
-        assert kh.instance_id == "u"
-        assert kh.access_mode == "direct"
-        # No marker attribute leaked onto the registry entry.
-        assert not hasattr(kh, "marker")
-        assert not hasattr(kh, "managed")

--- a/tests/unit/providers/test_incus_sync.py
+++ b/tests/unit/providers/test_incus_sync.py
@@ -1,0 +1,175 @@
+"""Tests for the Incus sync-reconcile probe (providers/incus.py `_probe`).
+
+Covers marked/unmarked classification, `--use-ip` soft IP-lookup failure,
+listing failure -> ProbeError, and read-only behaviour. `_probe` is the
+provider's only contribution to `sync()`: the diffing, consent, and write
+logic all live in `core/reconcile.py` and are exercised end-to-end in
+tests/integration/test_sync_reconcile.py. All SSH is mocked; no live Incus
+host is required.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from remo_cli.core.reconcile import ProbeError, SyncScope
+from remo_cli.providers import incus as providers_incus
+
+
+def _completed(rc: int, stdout: str = "", stderr: str = "") -> MagicMock:
+    cp = MagicMock()
+    cp.returncode = rc
+    cp.stdout = stdout
+    cp.stderr = stderr
+    return cp
+
+
+@pytest.fixture
+def patch_host(mocker):
+    """Patch the per-host SSH helper used by both listing and IP lookup."""
+    return mocker.patch(
+        "remo_cli.providers.incus._ssh_run_on_incus_host", autospec=True
+    )
+
+
+@pytest.fixture
+def scope() -> SyncScope:
+    return SyncScope(type="incus", host="h")
+
+
+# ---------------------------------------------------------------------------
+# Marked / unmarked classification
+# ---------------------------------------------------------------------------
+
+
+class TestProbeClassification:
+    def test_returns_marked_and_unmarked_alike(self, patch_host, scope):
+        patch_host.return_value = _completed(
+            0, stdout="dev1,true\nplex,\nweb,false\n"
+        )
+        result = providers_incus._probe(scope, user="u", use_ip=False, include_all=False)
+
+        by_name = {h.entry.name: h for h in result.hosts}
+        assert set(by_name) == {"h/dev1", "h/plex", "h/web"}
+        assert by_name["h/dev1"].marked is True
+        assert by_name["h/plex"].marked is False
+        assert by_name["h/web"].marked is False
+
+    def test_include_all_does_not_change_what_probe_returns(self, patch_host, scope):
+        patch_host.return_value = _completed(0, stdout="dev1,true\nplex,\n")
+
+        without_all = providers_incus._probe(
+            scope, user="u", use_ip=False, include_all=False
+        )
+        with_all = providers_incus._probe(
+            scope, user="u", use_ip=False, include_all=True
+        )
+
+        assert {h.entry.name for h in without_all.hosts} == {
+            h.entry.name for h in with_all.hosts
+        }
+
+    def test_adoption_criteria_is_set(self, patch_host, scope):
+        patch_host.return_value = _completed(0, stdout="dev1,true\n")
+        result = providers_incus._probe(scope, user="u", use_ip=False, include_all=True)
+        assert result.adoption_criteria
+
+    def test_complete_is_always_true(self, patch_host, scope):
+        patch_host.return_value = _completed(0, stdout="dev1,true\n")
+        result = providers_incus._probe(scope, user="u", use_ip=False, include_all=False)
+        assert result.complete is True
+
+    def test_entry_shape_matches_create(self, patch_host, scope):
+        patch_host.return_value = _completed(0, stdout="dev1,true\n")
+        result = providers_incus._probe(scope, user="u", use_ip=False, include_all=False)
+        entry = result.hosts[0].entry
+        assert entry.type == "incus"
+        assert entry.name == "h/dev1"
+        assert entry.host == "dev1"
+        assert entry.user == "remo"
+        assert entry.instance_id == "u"
+        assert entry.access_mode == "direct"
+
+
+# ---------------------------------------------------------------------------
+# --use-ip soft failure
+# ---------------------------------------------------------------------------
+
+
+class TestProbeUseIp:
+    def test_use_ip_resolves_addresses(self, patch_host, scope, mocker):
+        patch_host.return_value = _completed(0, stdout="dev1,true\n")
+        mocker.patch(
+            "remo_cli.providers.incus._resolve_container_ip", return_value="10.0.0.5"
+        )
+        result = providers_incus._probe(scope, user="u", use_ip=True, include_all=False)
+        assert result.hosts[0].entry.host == "10.0.0.5"
+        assert result.hosts[0].entry.name == "h/dev1"
+
+    def test_soft_ip_failure_keeps_host_and_warns(self, patch_host, scope, mocker):
+        patch_host.return_value = _completed(0, stdout="dev1,true\nplex,\n")
+        mocker.patch(
+            "remo_cli.providers.incus._resolve_container_ip", return_value=""
+        )
+        result = providers_incus._probe(scope, user="u", use_ip=True, include_all=False)
+
+        # Neither container was dropped, both entries carry an empty host so
+        # merge_entry preserves the previously recorded address.
+        names = {h.entry.name for h in result.hosts}
+        assert names == {"h/dev1", "h/plex"}
+        for h in result.hosts:
+            assert h.entry.host == ""
+        assert len(result.warnings) == 2
+        assert any("dev1" in w for w in result.warnings)
+        assert any("plex" in w for w in result.warnings)
+
+    def test_partial_ip_failure_only_warns_for_failed_container(
+        self, patch_host, scope, mocker
+    ):
+        patch_host.return_value = _completed(0, stdout="dev1,true\nplex,\n")
+
+        def fake_resolve(name, host, user):
+            return "10.0.0.5" if name == "dev1" else ""
+
+        mocker.patch(
+            "remo_cli.providers.incus._resolve_container_ip", side_effect=fake_resolve
+        )
+        result = providers_incus._probe(scope, user="u", use_ip=True, include_all=False)
+
+        by_name = {h.entry.name: h for h in result.hosts}
+        assert by_name["h/dev1"].entry.host == "10.0.0.5"
+        assert by_name["h/plex"].entry.host == ""
+        assert len(result.warnings) == 1
+        assert "plex" in result.warnings[0]
+
+
+# ---------------------------------------------------------------------------
+# Listing failure
+# ---------------------------------------------------------------------------
+
+
+class TestProbeListingFailure:
+    def test_listing_failure_raises_probe_error(self, patch_host, scope):
+        patch_host.return_value = _completed(1, stderr="boom")
+        with pytest.raises(ProbeError):
+            providers_incus._probe(scope, user="u", use_ip=False, include_all=False)
+
+
+# ---------------------------------------------------------------------------
+# Read-only behaviour
+# ---------------------------------------------------------------------------
+
+
+class TestProbeReadOnly:
+    def test_probe_never_issues_config_set(self, patch_host, scope, mocker):
+        patch_host.return_value = _completed(0, stdout="dev1,true\nplex,\n")
+        mocker.patch(
+            "remo_cli.providers.incus._resolve_container_ip", return_value="10.0.0.5"
+        )
+        providers_incus._probe(scope, user="u", use_ip=True, include_all=True)
+
+        for call in patch_host.call_args_list:
+            cmd = call.args[2]
+            assert "config set" not in cmd

--- a/tests/unit/providers/test_proxmox_marker.py
+++ b/tests/unit/providers/test_proxmox_marker.py
@@ -1,8 +1,8 @@
 """Tests for the Proxmox managed-marker feature (providers/proxmox.py).
 
-Covers tag apply (union, preserve, no-op), bulk tag read, create/update wiring,
-and filtered sync — including FR-003 (preserve tags), FR-010 (read-only), and
-FR-013 (bounded queries). All SSH is mocked.
+Covers tag apply (union, preserve, no-op), bulk tag read, and create/update
+wiring — including FR-003 (preserve tags), FR-010 (read-only), and FR-013
+(bounded queries). All SSH is mocked.
 """
 
 from __future__ import annotations
@@ -105,6 +105,17 @@ class TestReadTags:
         mapping = providers_proxmox._read_tags_by_vmid("h", "u")
         assert mapping == {"100": {"media", "remo"}, "101": {"media"}}
 
+    def test_nonzero_returncode_raises_instead_of_reporting_empty(self, mocker):
+        # T044/research.md R5 #1: an SSH failure must never be interpreted
+        # as "no container has any tags" -- that reads every container as
+        # unmarked and a default sync would wipe the node's registry slice.
+        node = mocker.patch(
+            "remo_cli.providers.proxmox._run_on_node", autospec=True
+        )
+        node.return_value = _completed(1, stderr="ssh: connection refused")
+        with pytest.raises(RuntimeError, match="connection refused"):
+            providers_proxmox._read_tags_by_vmid("h", "u")
+
 
 # ---------------------------------------------------------------------------
 # create() / update() wiring
@@ -157,89 +168,10 @@ class TestCreateUpdateWiring:
 
 
 # ---------------------------------------------------------------------------
-# sync() — filtering, hint, FR-010 (read-only), FR-013 (bounded)
+# sync()'s probe now lives in providers/proxmox.py `_probe` and is covered by
+# tests/unit/providers/test_proxmox_sync.py (feature 016-sync-reconcile).
+# The direct-write internals this class used to exercise (save_known_host
+# called straight from sync(), clear_known_hosts_by_prefix) no longer exist:
+# sync() delegates to core/reconcile.run_sync, which owns diffing, consent,
+# and the single registry write.
 # ---------------------------------------------------------------------------
-
-
-_PCT_LIST = (
-    "VMID       Status     Lock         Name\n"
-    "100        running                 dev1\n"
-    "101        running                 plex\n"
-)
-
-
-@pytest.fixture
-def patch_registry(mocker):
-    save = mocker.patch("remo_cli.providers.proxmox.save_known_host")
-    mocker.patch("remo_cli.providers.proxmox.clear_known_hosts_by_prefix")
-    return save
-
-
-class TestSyncFiltering:
-    def _wire_ssh(self, mocker):
-        """Route `pct list` and the bulk conf dump through _ssh_run."""
-        def side_effect(host, user, cmd):
-            if cmd == "pct list":
-                return _completed(0, stdout=_PCT_LIST)
-            if cmd.startswith("for f in /etc/pve/lxc/"):
-                return _completed(
-                    0, stdout="@@@/etc/pve/lxc/100.conf\ntags: remo\n"
-                )
-            return _completed(0)
-
-        return mocker.patch(
-            "remo_cli.providers.proxmox._ssh_run", side_effect=side_effect
-        )
-
-    def test_default_registers_only_marked(self, patch_registry, mocker):
-        self._wire_ssh(mocker)
-        mocker.patch("remo_cli.providers.proxmox.print_info")
-        warn = mocker.patch("remo_cli.providers.proxmox.print_warning")
-
-        providers_proxmox.sync(host="node", user="root")
-
-        saved = [c.args[0].name for c in patch_registry.call_args_list]
-        assert saved == ["node/dev1"]
-        warn_text = " ".join(str(c.args[0]) for c in warn.call_args_list)
-        assert "plex" in warn_text
-
-    def test_all_registers_everything(self, patch_registry, mocker):
-        self._wire_ssh(mocker)
-        mocker.patch("remo_cli.providers.proxmox.print_info")
-        mocker.patch("remo_cli.providers.proxmox.print_warning")
-
-        providers_proxmox.sync(host="node", user="root", include_all=True)
-
-        saved = sorted(c.args[0].name for c in patch_registry.call_args_list)
-        assert saved == ["node/dev1", "node/plex"]
-
-    def test_read_only_and_bounded(self, patch_registry, mocker):
-        ssh = self._wire_ssh(mocker)
-        mocker.patch("remo_cli.providers.proxmox.print_info")
-        mocker.patch("remo_cli.providers.proxmox.print_warning")
-
-        providers_proxmox.sync(host="node", user="root")
-
-        # FR-013: two bulk calls (pct list + one grep), no per-container loop.
-        assert ssh.call_count == 2
-        # FR-010: no marker mutation during sync.
-        for call in ssh.call_args_list:
-            assert "pct set" not in call.args[2]
-
-    def test_registry_shape_unchanged(self, patch_registry, mocker):
-        # FR-012: the KnownHost written by sync keeps its pre-feature fields.
-        self._wire_ssh(mocker)
-        mocker.patch("remo_cli.providers.proxmox.print_info")
-        mocker.patch("remo_cli.providers.proxmox.print_warning")
-
-        providers_proxmox.sync(host="node", user="root")
-
-        kh = patch_registry.call_args.args[0]
-        assert kh.type == "proxmox"
-        assert kh.name == "node/dev1"
-        assert kh.user == "remo"
-        assert kh.instance_id == "100"
-        assert kh.region == "root"
-        assert kh.access_mode == "direct"
-        assert not hasattr(kh, "marker")
-        assert not hasattr(kh, "managed")

--- a/tests/unit/providers/test_proxmox_sync.py
+++ b/tests/unit/providers/test_proxmox_sync.py
@@ -1,0 +1,252 @@
+"""Tests for the Proxmox sync-reconcile probe (providers/proxmox.py `_probe`).
+
+Covers marked/unmarked classification from `pct list` + the bulk tag dump,
+the SSH-failure regression guard for `_read_tags_by_vmid` (research.md R5 #1
+-- an SSH failure must raise ProbeError, never silently report zero marked
+containers), `pct list` failure, `--use-ip` soft IP-lookup failure, and
+read-only behaviour. `_probe` is the provider's only contribution to
+`sync()`: the diffing, consent, and write logic all live in
+`core/reconcile.py` and are exercised end-to-end in
+tests/integration/test_sync_reconcile.py. All SSH is mocked; no live Proxmox
+node is required.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from remo_cli.core.reconcile import ProbeError, SyncScope
+from remo_cli.providers import proxmox as providers_proxmox
+
+
+def _completed(rc: int, stdout: str = "", stderr: str = "") -> MagicMock:
+    cp = MagicMock()
+    cp.returncode = rc
+    cp.stdout = stdout
+    cp.stderr = stderr
+    return cp
+
+
+_PCT_LIST = (
+    "VMID       Status     Lock         Name\n"
+    "100        running                 dev1\n"
+    "101        running                 plex\n"
+    "102        stopped                 web\n"
+)
+
+_TAG_DUMP = (
+    "@@@/etc/pve/lxc/100.conf\n"
+    "arch: amd64\n"
+    "tags: remo\n"
+    "@@@/etc/pve/lxc/101.conf\n"
+    "arch: amd64\n"
+    "@@@/etc/pve/lxc/102.conf\n"
+    "tags: media\n"
+)
+
+
+def _wire_ssh(mocker, pct_list_result=None, tag_dump_result=None):
+    """Route `pct list` and the bulk conf dump through `_run_on_node`."""
+
+    def side_effect(host, user, cmd):
+        if cmd == "pct list":
+            return pct_list_result if pct_list_result is not None else _completed(
+                0, stdout=_PCT_LIST
+            )
+        if cmd.startswith("for f in /etc/pve/lxc/"):
+            return tag_dump_result if tag_dump_result is not None else _completed(
+                0, stdout=_TAG_DUMP
+            )
+        return _completed(0)
+
+    return mocker.patch(
+        "remo_cli.providers.proxmox._run_on_node", side_effect=side_effect
+    )
+
+
+@pytest.fixture
+def scope() -> SyncScope:
+    return SyncScope(type="proxmox", host="node")
+
+
+# ---------------------------------------------------------------------------
+# Marked / unmarked classification
+# ---------------------------------------------------------------------------
+
+
+class TestProbeClassification:
+    def test_returns_marked_and_unmarked_alike(self, scope, mocker):
+        _wire_ssh(mocker)
+        result = providers_proxmox._probe(
+            scope, user="root", use_ip=False, include_all=False
+        )
+
+        by_name = {h.entry.name: h for h in result.hosts}
+        assert set(by_name) == {"node/dev1", "node/plex", "node/web"}
+        assert by_name["node/dev1"].marked is True
+        assert by_name["node/plex"].marked is False
+        assert by_name["node/web"].marked is False
+
+    def test_include_all_does_not_change_what_probe_returns(self, scope, mocker):
+        _wire_ssh(mocker)
+
+        without_all = providers_proxmox._probe(
+            scope, user="root", use_ip=False, include_all=False
+        )
+        with_all = providers_proxmox._probe(
+            scope, user="root", use_ip=False, include_all=True
+        )
+
+        assert {h.entry.name for h in without_all.hosts} == {
+            h.entry.name for h in with_all.hosts
+        }
+
+    def test_adoption_criteria_is_set(self, scope, mocker):
+        _wire_ssh(mocker)
+        result = providers_proxmox._probe(
+            scope, user="root", use_ip=False, include_all=True
+        )
+        assert result.adoption_criteria
+
+    def test_complete_is_always_true(self, scope, mocker):
+        _wire_ssh(mocker)
+        result = providers_proxmox._probe(
+            scope, user="root", use_ip=False, include_all=False
+        )
+        assert result.complete is True
+
+    def test_entry_shape_matches_create(self, scope, mocker):
+        _wire_ssh(mocker)
+        result = providers_proxmox._probe(
+            scope, user="root", use_ip=False, include_all=False
+        )
+        by_name = {h.entry.name: h for h in result.hosts}
+        entry = by_name["node/dev1"].entry
+        assert entry.type == "proxmox"
+        assert entry.name == "node/dev1"
+        assert entry.host == "dev1"
+        assert entry.user == "remo"
+        assert entry.instance_id == "100"
+        assert entry.access_mode == "direct"
+        assert entry.region == "root"
+
+    def test_region_defaults_to_root_when_no_user_given(self, scope, mocker):
+        _wire_ssh(mocker)
+        result = providers_proxmox._probe(
+            scope, user="", use_ip=False, include_all=False
+        )
+        assert result.hosts[0].entry.region == "root"
+
+
+# ---------------------------------------------------------------------------
+# The SSH-failure regression guard (research.md R5 #1 / T044)
+# ---------------------------------------------------------------------------
+
+
+class TestProbeTagReadFailure:
+    def test_tag_dump_failure_raises_probe_error_not_zero_marked(self, scope, mocker):
+        # This is the exact bug this phase fixes: a non-zero returncode on
+        # the tag-read command must never be swallowed into "nothing is
+        # marked" -- that would make a default sync propose deleting every
+        # container on the node.
+        _wire_ssh(mocker, tag_dump_result=_completed(255, stderr="ssh: connection refused"))
+        with pytest.raises(ProbeError):
+            providers_proxmox._probe(
+                scope, user="root", use_ip=False, include_all=False
+            )
+
+    def test_pct_list_failure_also_raises_probe_error(self, scope, mocker):
+        _wire_ssh(mocker, pct_list_result=_completed(1, stderr="boom"))
+        with pytest.raises(ProbeError):
+            providers_proxmox._probe(
+                scope, user="root", use_ip=False, include_all=False
+            )
+
+
+# ---------------------------------------------------------------------------
+# --use-ip soft failure
+# ---------------------------------------------------------------------------
+
+
+class TestProbeUseIp:
+    def test_use_ip_resolves_addresses(self, scope, mocker):
+        _wire_ssh(mocker)
+        mocker.patch(
+            "remo_cli.providers.proxmox._resolve_container_ip",
+            return_value="10.0.0.5",
+        )
+        result = providers_proxmox._probe(
+            scope, user="root", use_ip=True, include_all=False
+        )
+        by_name = {h.entry.name: h for h in result.hosts}
+        assert by_name["node/dev1"].entry.host == "10.0.0.5"
+
+    def test_soft_ip_failure_keeps_host_and_warns(self, scope, mocker):
+        _wire_ssh(mocker)
+        mocker.patch(
+            "remo_cli.providers.proxmox._resolve_container_ip", return_value=""
+        )
+        result = providers_proxmox._probe(
+            scope, user="root", use_ip=True, include_all=False
+        )
+
+        # No container is dropped; each entry carries an empty host so
+        # merge_entry preserves the previously recorded address.
+        names = {h.entry.name for h in result.hosts}
+        assert names == {"node/dev1", "node/plex", "node/web"}
+        for h in result.hosts:
+            assert h.entry.host == ""
+        assert len(result.warnings) == 3
+
+    def test_partial_ip_failure_only_warns_for_failed_container(self, scope, mocker):
+        _wire_ssh(mocker)
+
+        def fake_resolve(name, host, user, vmid=""):
+            return "10.0.0.5" if name == "dev1" else ""
+
+        mocker.patch(
+            "remo_cli.providers.proxmox._resolve_container_ip",
+            side_effect=fake_resolve,
+        )
+        result = providers_proxmox._probe(
+            scope, user="root", use_ip=True, include_all=False
+        )
+
+        by_name = {h.entry.name: h for h in result.hosts}
+        assert by_name["node/dev1"].entry.host == "10.0.0.5"
+        assert by_name["node/plex"].entry.host == ""
+        assert by_name["node/web"].entry.host == ""
+        assert len(result.warnings) == 2
+
+
+# ---------------------------------------------------------------------------
+# Read-only behaviour
+# ---------------------------------------------------------------------------
+
+
+class TestProbeReadOnly:
+    def test_probe_never_issues_pct_set(self, scope, mocker):
+        node = _wire_ssh(mocker)
+        mocker.patch(
+            "remo_cli.providers.proxmox._resolve_container_ip",
+            return_value="10.0.0.5",
+        )
+        providers_proxmox._probe(scope, user="root", use_ip=True, include_all=True)
+
+        for call in node.call_args_list:
+            cmd = call.args[2]
+            assert "pct set" not in cmd
+
+    def test_probe_issues_exactly_two_bulk_calls(self, scope, mocker):
+        # FR-013: one `pct list` + one bulk tag dump, no per-container loop
+        # (the --use-ip lookups go through _resolve_container_ip, mocked
+        # here, so they don't inflate this count).
+        node = _wire_ssh(mocker)
+        mocker.patch(
+            "remo_cli.providers.proxmox._resolve_container_ip",
+            return_value="10.0.0.5",
+        )
+        providers_proxmox._probe(scope, user="root", use_ip=True, include_all=False)
+        assert node.call_count == 2


### PR DESCRIPTION
## Summary

Replaces each provider's hand-rolled clear-then-repopulate `sync` with one provider-agnostic reconcile engine (`core/reconcile.py`). Providers now contribute only a **read-only probe** (every host in scope — marked and unmarked — plus an enumeration-completeness flag); the engine diffs against the in-scope registry slice, prints a scope-first plan, gates removals behind consent, and writes exactly once via the existing `mutate_registry()` (aborting on a same-scope drift between plan and write).

## Data-loss bugs fixed

- **Hetzner** `sync` wiped its entire registry slice on every run — the `remo` label it filtered on was never applied by anything. Now applied at `create` (Ansible) and backfillable via `update` (label-preserving read-merge).
- A bare **`remo aws sync`** destroyed every other region's registry entries.
- **`remo aws stop`** followed by any sync destroyed the stopped instance's own entry.

## Behavior changes

- Managed marker now gates only *addition* eligibility; **provider presence alone protects an existing entry from removal**.
- New `--yes` / `--dry-run` on all four providers' `sync`; new `--all` on aws/hetzner (aws narrowed to `remo-*`-named instances, hetzner unrestricted).
- Three-value exit-code contract: `0` applied/no-op/dry-run, `1` failure, `3` aborted-with-no-change (`2` reserved for Click).
- Provider queries never filter server-side on the marker (an unmarked-but-live host must never look absent).

## Pre-merge review fixes (xhigh)

- Hetzner probe no longer crashes (`AttributeError`) on **IPv6-only servers** (null `ipv4` block).
- `remo proxmox sync` no longer errors on a node with **zero containers**.
- `--dry-run` no longer triggers a legacy→v2 **migration write** (`read_registry(readonly=dry_run)`).
- `render_plan` mark-hint omits `--host` for aws/hetzner (they don't expose it); Proxmox `pct list` parser skips nameless rows; aws `--all` help corrected.

## Testing

- `1500 passed, 17 skipped` (full suite), `mypy` + `ruff` clean.
- New `tests/unit/core/test_reconcile.py`, per-provider probe suites, and a cross-provider `tests/integration/test_sync_reconcile.py` exercising the safety matrix against a real temp registry.

## Known follow-up

- AWS probe `access_mode` default can overwrite a differing existing mode via `merge_entry` — tracked in #87 (low/edge; deliberately not force-fixed because blanking the default would break `remo shell` for newly adopted instances).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HAPB5GA4NVUgKFsVFVJDxN