### PR TITLE
fix(ci): read registry.json (v2) in aws smoke SSM step, not legacy known_hosts

### DIFF
--- a/.github/workflows/smoke-test.yml
+++ b/.github/workflows/smoke-test.yml
@@ -83,11 +83,21 @@ jobs:
 
       - name: Test SSM connectivity
         run: |
-          ENTRY=$(grep "^aws:${INSTANCE_NAME}:" ~/.config/remo/known_hosts | tail -1)
-          USER=$(echo "$ENTRY" | cut -d: -f4)
-          INSTANCE_ID=$(echo "$ENTRY" | cut -d: -f5)
-          REGION=$(echo "$ENTRY" | cut -d: -f7)
+          # Registry v2 (feature 015) stores entries in registry.json, not the
+          # legacy colon-delimited known_hosts (which is renamed to
+          # known_hosts.v1.bak on first read). Read the JSON directly.
+          REG=~/.config/remo/registry.json
+          read -r USER INSTANCE_ID REGION < <(
+            jq -r --arg n "$INSTANCE_NAME" \
+              '.hosts[] | select(.type=="aws" and .name==$n) | [.user, .aws.instance_id, .aws.region] | @tsv' \
+              "$REG"
+          )
           REGION="${REGION:-us-west-2}"
+          if [ -z "$INSTANCE_ID" ]; then
+            echo "No aws registry entry for '$INSTANCE_NAME' in $REG:"
+            cat "$REG" 2>/dev/null || echo "(registry.json not found)"
+            exit 1
+          fi
 
           # Wait for SSM to report the instance as connected. The provision
           # playbook polls PingStatus during create, but the agent can flap


### PR DESCRIPTION
## Problem

The AWS provisioning smoke's **Test SSM connectivity** step has failed on every `main` push since registry v2 (feature 015) — including #88, #89, #90 — and I initially mis-attributed it to an SSM infra flake. It is actually a **stale CI script**.

The step parsed the legacy colon-delimited registry:
```bash
ENTRY=$(grep "^aws:${INSTANCE_NAME}:" ~/.config/remo/known_hosts | tail -1)
INSTANCE_ID=$(echo "$ENTRY" | cut -d: -f5)   # etc.
```

But registry v2 stores entries in `registry.json` and renames `known_hosts` → `known_hosts.v1.bak` on first read. So the `grep` matched nothing:
- `INSTANCE_ID`/`USER` were empty → `describe-instance-information --filters …Values=` matched nothing → `PingStatus: unknown` for all 24 polls,
- SSH targeted `@` (the run log literally shows `Testing SSH via SSM to @...`).

The instance and SSM agent were healthy the whole time — the provision playbook's own 5-minute SSM-registration wait and SSH-over-SSM checks passed during `remo aws create`.

## Fix

Read `user`/`instance_id`/`region` from `~/.config/remo/registry.json` via `jq`, and fail loudly (dumping the registry) if the entry is missing:
```bash
read -r USER INSTANCE_ID REGION < <(
  jq -r --arg n "$INSTANCE_NAME" \
    '.hosts[] | select(.type=="aws" and .name==$n) | [.user, .aws.instance_id, .aws.region] | @tsv' \
    ~/.config/remo/registry.json)
```

Validated the jq against a real v2 `registry.json` and confirmed the extraction returns the correct `remo / i-… / us-west-2`. YAML validated.

## Verification

This PR changes the smoke workflow itself, so its own `aws` job runs the fixed step against live cloud — that run is the verification.

🤖 Generated with [Claude Code](https://claude.com/claude-code)