### PR TITLE
docs+ci: constitution v2.0.1 — multi-layer architecture, machine-checked gates, mypy gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -93,7 +93,7 @@ jobs:
           EOF
 
   lint:
-    name: Lint
+    name: Lint & Types
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
@@ -105,6 +105,13 @@ jobs:
 
       - name: Ruff check
         run: uv run ruff check src/remo_cli
+
+      # mypy analyses against python_version = "3.11" from [tool.mypy], so the
+      # result is independent of whichever interpreter uv resolves here. The
+      # `web` extra must be installed (it is, via --all-extras) or every
+      # src/remo_cli/web/ module degrades to Any and the gate goes blind.
+      - name: Mypy check
+        run: uv run mypy src/remo_cli
 
   frontend:
     name: Frontend (typecheck + unit + build)

--- a/.specify/memory/constitution.md
+++ b/.specify/memory/constitution.md
@@ -41,10 +41,33 @@
   - CLAUDE.md: ✅ updated (Architecture + Quality Gates sections)
   - AGENTS.md: ✅ updated (mirrors CLAUDE.md)
 
-  Follow-up TODOs:
-  - mypy is configured in pyproject.toml but is NOT yet a CI gate (see Quality
-    Gates → Known gap). Closing that gap is tracked work, not a constitution
-    deferral.
+  Follow-up TODOs: None
+-->
+
+<!--
+  Sync Impact Report
+  ===================
+  Version change: 2.0.0 → 2.0.1 (PATCH)
+
+  Bump rationale: no principle changed. v2.0.0 shipped with a stated "Known
+  gap" — mypy configured but not run in CI, with reviewers asked to compensate
+  manually. That gap is now closed by a real gate, so the note is replaced by a
+  table row. Refinement of an existing section, not a new constraint: PATCH.
+
+  Modified sections:
+  - Quality Gates: added the `Types` row (`uv run mypy src/remo_cli`); replaced
+    the "Known gap" paragraph with the `web`-extra requirement that keeps the
+    gate from silently passing on Any.
+  - Technology Standards → Python: ruff/mypy are now stated as CI gates, not
+    local-only expectations.
+
+  Templates requiring updates:
+  - .specify/templates/plan-template.md: ✅ no changes needed (gate table is
+    keyed to principles, not to individual CI jobs)
+  - CLAUDE.md: ✅ updated (Quality Gates table)
+  - AGENTS.md: ✅ updated (mirrors CLAUDE.md)
+
+  Follow-up TODOs: None
 -->
 
 # Remo Project Constitution
@@ -278,8 +301,8 @@ and diagrams drift fastest.
 - No docstrings on obvious methods; docstrings SHOULD explain *why*, and
   SHOULD cite the spec/contract they implement when one exists.
 - `ruff` (line length 100, `src = ["src"]`) and `mypy`
-  (`python_version = "3.11"`, `files = ["src"]`) MUST both pass locally before
-  commit.
+  (`python_version = "3.11"`, `files = ["src"]`) MUST both pass. Both are CI
+  gates; run them locally before commit rather than discovering them in CI.
 - Runtime dependencies MUST be justified. An SDK used only by an Ansible
   collection MUST say so in `pyproject.toml`.
 
@@ -354,6 +377,7 @@ These gates run in CI and MUST pass before merge. None may be skipped,
 | Schema drift (Python) | `tests/unit/test_schema_drift.py` | Principle IV |
 | Schema drift (Node) | `npm run check:types-fresh` | Principle IV |
 | Lint | `uv run ruff check src/remo_cli` | Technology Standards |
+| Types | `uv run mypy src/remo_cli` | Technology Standards |
 | Frontend | `npm run lint && npm run test && npm run build` | Technology Standards |
 | Packaging | wheel install smoke, Docker amd64+arm64 | Distribution integrity |
 | Security | CodeQL, dependency review | Supply chain |
@@ -365,9 +389,10 @@ uv run python scripts/export_openapi.py   # openapi.json + terminal-frames.json
 cd frontend && npm run generate:types      # schema.d.ts + terminal-frames.d.ts
 ```
 
-**Known gap:** `mypy` is configured in `pyproject.toml` and MUST pass locally,
-but is not yet wired into a CI job. Until it is, reviewers MUST treat a type
-regression as a blocking finding.
+The `Lint & Types` job MUST install the `web` extra (`uv sync --all-extras`).
+With `ignore_missing_imports = true`, an uninstalled FastAPI/pydantic would
+silently degrade every `web/` module to `Any` and leave the type gate passing
+while checking nothing.
 
 ## Development Workflow
 
@@ -433,4 +458,4 @@ is the defect.
 (current tree, commands, recent changes). They elaborate this constitution;
 they never override it.
 
-**Version**: 2.0.0 | **Ratified**: 2026-01-06 | **Last Amended**: 2026-07-27
+**Version**: 2.0.1 | **Ratified**: 2026-01-06 | **Last Amended**: 2026-07-27

--- a/.specify/memory/constitution.md
+++ b/.specify/memory/constitution.md
@@ -1,117 +1,329 @@
 <!--
   Sync Impact Report
   ===================
-  Version change: 0.0.0 → 1.0.0 (initial adoption)
+  Version change: 1.0.0 → 2.0.0 (MAJOR)
+
+  Bump rationale: the constitution was written when remo was an Ansible-only
+  project. It is now a four-layer system (Python CLI, FastAPI service,
+  TypeScript SPA, Ansible roles). Every original principle survives, but four
+  are renamed/redefined and three new NON-NEGOTIABLE principles apply
+  retroactively to existing code. Redefinition + newly-binding gates = MAJOR.
+
+  Modified principles:
+  - I. Defensive Variable Access (Ansible) → V. Defensive Variable Access (Ansible)
+    (unchanged in substance; renumbered, no longer the lead principle)
+  - II. Test All Conditional Paths → VI. Test Every Path That Can Skip or Fail
+    (expanded from Ansible-only to all four layers)
+  - III. Idempotent by Default → VII. Idempotent and Re-runnable by Default
+    (expanded to cover registry mutation and web push/sync)
+  - IV. Fail Fast with Clear Messages → merged into III. Typed Errors, One Exit
+    Boundary, Actionable Messages (now also binds the Python error taxonomy)
+  - V. Documentation Reflects Reality → VIII. Documentation Reflects Reality,
+    and CI Proves It (now machine-checked, not aspirational)
 
   Added principles:
-  - I. Defensive Variable Access (Ansible)
-  - II. Test All Conditional Paths
-  - III. Idempotent by Default
-  - IV. Fail Fast with Clear Messages
-  - V. Documentation Reflects Reality
+  - I. Layered Architecture with One-Way Dependencies
+  - II. Providers Are Declared, Not Special-Cased
+  - IV. Contracts Are Generated, Never Hand-Authored
 
   Added sections:
-  - Ansible-Specific Standards
-  - Development Workflow
-  - Governance
+  - Technology Standards (Python/CLI, Web Service, Frontend, Ansible)
+    — replaces the narrower "Ansible-Specific Standards"
+  - Quality Gates (enumerates the machine-checked gates and their commands)
+
+  Removed sections:
+  - "Ansible-Specific Standards" (absorbed into Technology Standards → Ansible)
 
   Templates requiring updates:
-  - plan-template.md: ⚠️ pending (Constitution Check section should reference these principles)
-  - spec-template.md: ✅ no changes needed
-  - tasks-template.md: ✅ no changes needed
+  - .specify/templates/plan-template.md: ✅ updated (Constitution Check gate list)
+  - .specify/templates/spec-template.md: ✅ no changes needed
+  - .specify/templates/tasks-template.md: ✅ no changes needed
+  - CLAUDE.md: ✅ updated (Architecture + Quality Gates sections)
+  - AGENTS.md: ✅ updated (mirrors CLAUDE.md)
 
-  Follow-up TODOs: None
+  Follow-up TODOs:
+  - mypy is configured in pyproject.toml but is NOT yet a CI gate (see Quality
+    Gates → Known gap). Closing that gap is tracked work, not a constitution
+    deferral.
 -->
 
 # Remo Project Constitution
 
+Remo is a multi-layer system: a Python CLI (`src/remo_cli/`), an optional
+FastAPI web service (`src/remo_cli/web/`), a TypeScript/React browser console
+(`frontend/`), and Ansible roles (`ansible/`) invoked by the CLI. These
+principles bind all four layers. Where a rule is layer-specific, it says so.
+
 ## Core Principles
 
-### I. Defensive Variable Access (Ansible)
+### I. Layered Architecture with One-Way Dependencies
 
-All Ansible registered variable attributes MUST use `| default()` filters when accessed in conditionals or templates.
+The Python package has exactly three layers, and dependencies flow in exactly
+one direction: `cli/` → `providers/` → `core/`.
 
 **Rules:**
-- NEVER access `.rc`, `.stdout`, `.stderr`, or `.stdout_lines` directly on registered variables
-- ALWAYS use `variable.rc | default(1)` for return codes (default to failure)
-- ALWAYS use `variable.stdout | default('')` for output strings
-- When checking if a task ran successfully, use `variable.stdout is defined` instead of `variable is defined`
 
-**Rationale:** When Ansible tasks are skipped, registered variables become dicts like `{"skipped": true}` without command result attributes. Direct attribute access causes "object of type 'dict' has no attribute" errors.
+- `cli/` MUST contain Click command wiring and argument parsing only. No
+  business logic.
+- `providers/` MUST NOT import Click, and MUST NOT call `sys.exit()`.
+- `core/` MUST NOT contain provider-specific knowledge. Provider-varying
+  behavior belongs behind a descriptor field or hook (e.g. AWS's SSM
+  `ProxyCommand` lives in `providers/aws.py:ssh_proxy_hook`, reached via
+  `descriptor.connection.proxy_hook` — never hardcoded in `core/ssh.py`).
+- `cli/` MUST NOT reach into a `providers/` module's private
+  (leading-underscore) helpers.
+- New cross-layer escape hatches MUST be justified in the PR description.
 
-**Example - WRONG:**
+**Rationale:** The one-way rule is what makes a provider addable without
+editing existing files, and what keeps `remo --help` from importing a single
+provider SDK. It is enforced by `tests/unit/test_architecture.py`, which has
+zero-tolerance (empty) allowlists — a new violation fails the build.
+
+### II. Providers Are Declared, Not Special-Cased
+
+Adding a provider MUST require exactly one implementation module plus one
+descriptor registration, and MUST NOT require editing any existing file.
+
+**Rules:**
+
+- Every provider MUST satisfy the `Provider` Protocol
+  (`core/provider_protocol.py`) and declare a `ProviderDescriptor`
+  (`core/provider_registry.py`) in a metadata-only `*_descriptor.py` module
+  that imports no SDK.
+- Branching on `host.type` string literals is FORBIDDEN outside the descriptor
+  layer. Per-type behavior MUST be driven by descriptor fields
+  (`name_format`, `registry_fields`, `connection`, `sdk_extra`, …).
+- A flag shared by multiple providers MUST be the *same* `OptionSpec` object
+  from the shared catalog, not a re-declared copy.
+- Provider implementation modules MUST be imported lazily by
+  `provider_registry.get_provider()`, so no optional SDK loads during
+  `--help` or shell completion.
+- A duplicated skeleton across providers is a defect: collapse it into a
+  shared template in `core/` (see `core/lifecycle.run_destroy`,
+  `core/snapshot.list_all_snapshots`, `core/ansible_runner`,
+  `core/output.render_host_table`).
+
+**Rationale:** The pre-018 provider layer was convention-by-copy: five
+near-identical skeletons that drifted independently. Declaring providers
+instead of copying them makes uniformity a property of the code, not of
+reviewer vigilance.
+
+### III. Typed Errors, One Exit Boundary, Actionable Messages
+
+Failures MUST be raised as typed exceptions and translated to exit codes in
+exactly one place.
+
+**Rules:**
+
+- The business layer MUST raise a `core/errors.py` subclass —
+  `MissingDependencyError`, `PreconditionError`, `OperationFailedError`, or
+  `UserAbortedError`. Bare `RuntimeError` and `sys.exit()` are FORBIDDEN
+  there.
+- `cli/providers/factory.py`'s `provider_command` wrapper is the ONLY
+  exception-to-exit-code translation boundary. Exit codes: `0` success,
+  `1` failure, `3` user-aborted.
+- Non-CLI consumers (the web service) MUST catch `ProviderError` directly
+  rather than shelling out to the CLI.
+- Prerequisites MUST be validated at the START of an operation (pre-flight),
+  not discovered halfway through.
+- Every error message MUST state: what failed, why it matters, and the
+  concrete command or edit that fixes it. A message that names a remediation
+  command is preferred over prose.
+- `failed_when: false` (Ansible) and bare `except:` (Python) are permitted
+  ONLY with explicit handling of the failure path immediately after.
+
+**Rationale:** One boundary means exit-code behavior is testable in one place
+and cannot drift per-provider. Actionable messages are the difference between
+a user fixing their own problem and filing an issue.
+
+### IV. Contracts Are Generated, Never Hand-Authored
+
+Where one layer consumes another's shapes, the producing layer is the single
+machine-checked source of truth and the consuming layer's types are generated
+from it.
+
+**Rules:**
+
+- The FastAPI app is the source of truth for every shape `frontend/` consumes.
+  The four generated artifacts (`openapi.json`, `terminal-frames.json`,
+  `schema.d.ts`, `terminal-frames.d.ts`) are checked in but MUST NEVER be
+  hand-edited.
+- A change to a service response model or WS control frame MUST be followed by
+  regeneration in the same commit.
+- Generated artifacts MUST be byte-reproducible (deterministic ordering,
+  stable trailing newline) so drift is a clean diff, not noise.
+- A drift check MUST fail the build — never skip, never auto-fix, and never
+  write a tracked file. Its failure message MUST name the stale artifact, group
+  the findings, and close with the exact regeneration command.
+- Generated artifacts are internal build inputs. They carry NO external
+  compatibility promise, and consumers outside this repository MUST NOT depend
+  on them.
+- Independently-evolving contracts MUST version independently. The
+  `remo-terminal.v1` WS frame contract is versioned separately from the REST
+  OpenAPI contract, with its own drift check.
+
+**Rationale:** Hand-mirrored types are correct only until the next service
+change. Generating them converts a whole class of runtime shape mismatch into a
+compile error or a build failure with a one-line fix.
+
+### V. Defensive Variable Access (Ansible)
+
+All Ansible registered-variable attributes MUST use `| default()` filters when
+accessed in conditionals or templates.
+
+**Rules:**
+
+- NEVER access `.rc`, `.stdout`, `.stderr`, or `.stdout_lines` directly on a
+  registered variable.
+- ALWAYS use `variable.rc | default(1)` for return codes (default to failure).
+- ALWAYS use `variable.stdout | default('')` for output strings.
+- To test whether a task actually ran, use `variable.stdout is defined`, not
+  `variable is defined`.
+
+**Rationale:** A skipped Ansible task registers `{"skipped": true}` — a dict
+with no command-result attributes. Direct access raises "object of type 'dict'
+has no attribute", usually in the error path where it is least expected.
+
+**Example — WRONG:**
+
 ```yaml
 when: my_result.rc == 0
 msg: "{{ my_result.stdout }}"
 ```
 
-**Example - CORRECT:**
+**Example — CORRECT:**
+
 ```yaml
 when: my_result.rc | default(1) == 0
 msg: "{{ my_result.stdout | default('N/A') }}"
 ```
 
-### II. Test All Conditional Paths
+### VI. Test Every Path That Can Skip or Fail
 
-Code with conditional logic MUST be tested under all possible conditions before committing.
-
-**Rules:**
-- For Ansible roles with `when:` conditions, test with conditions both true AND false
-- For tasks that may be skipped, verify downstream tasks handle skipped variables
-- Run playbooks against fresh systems AND systems with existing state
-- Document which conditional paths were tested in commit messages or PR descriptions
-
-**Rationale:** Bugs often hide in untested conditional branches. The "happy path" may work while error/skip paths fail silently or catastrophically.
-
-### III. Idempotent by Default
-
-All automation MUST be safely re-runnable without side effects.
+Conditional logic MUST be exercised under all of its conditions before merge.
 
 **Rules:**
-- Ansible tasks MUST use `changed_when` to accurately report changes
-- Tasks MUST check existing state before making modifications
-- Running the same playbook twice MUST produce identical end state
-- Destructive operations MUST have explicit safeguards (confirmation, backup, etc.)
 
-**Rationale:** Infrastructure automation runs in unpredictable environments. Users will re-run playbooks after failures, updates, or uncertainty.
+- Ansible roles with `when:` conditions MUST be tested with the condition both
+  true AND false, and downstream tasks MUST be verified against the skipped
+  variable.
+- Playbooks MUST be run against a fresh system AND a system with existing
+  state.
+- Python behavior that a refactor could silently change MUST be pinned by a
+  characterization test BEFORE the refactor lands (e.g. the WS control-frame
+  silent-drop path, the Hetzner HTTP raise-vs-swallow contracts).
+- Error, skip, and abort paths MUST be tested, not just the happy path.
+- A bug fix MUST arrive with a regression test that fails without the fix.
+- The PR description MUST say which conditional paths were exercised.
 
-### IV. Fail Fast with Clear Messages
+**Rationale:** Bugs hide in untested branches. The happy path is the one that
+gets manual attention; the skip path is the one that reaches production.
 
-Errors MUST be caught early with actionable guidance.
+### VII. Idempotent and Re-runnable by Default
 
-**Rules:**
-- Validate prerequisites at the START of playbooks/roles (pre-flight checks)
-- Error messages MUST explain: what failed, why it matters, and how to fix it
-- Use `ansible.builtin.assert` for validation with detailed `fail_msg`
-- Never swallow errors silently—use `failed_when: false` only with explicit error handling
-
-**Rationale:** Users encountering errors need immediate, clear guidance. Cryptic failures waste time and erode trust.
-
-### V. Documentation Reflects Reality
-
-Documentation MUST be updated alongside code changes.
+Every operation MUST be safe to run twice.
 
 **Rules:**
-- README changes MUST accompany feature changes
-- Default behavior changes MUST be documented before merge
-- Examples in documentation MUST be tested and working
-- Remove or update documentation for deprecated features immediately
 
-**Rationale:** Stale documentation is worse than no documentation—it actively misleads users.
+- Running the same playbook twice MUST produce an identical end state;
+  Ansible tasks MUST set `changed_when` accurately and check existing state
+  before modifying it.
+- Registry writes MUST go through `core/registry.py`, which owns locking
+  (`fcntl` on a `registry.lock` sidecar) and atomic replacement
+  (`os.replace`). Direct writes to `registry.json` are FORBIDDEN.
+- Schema migrations MUST be lazy, one-way, and preserve the prior file
+  (legacy `known_hosts` → `known_hosts.v1.bak`).
+- `remo web push` and `remo <provider> sync` MUST converge on repeat rather
+  than duplicate or thrash.
+- Destructive operations MUST have an explicit safeguard: a confirmation
+  prompt, a `--yes` opt-out, or a backup. A `--yes` flag MUST have a real
+  effect — a decorative one MUST be removed.
 
-## Ansible-Specific Standards
+**Rationale:** Users re-run automation after failures, timeouts, and
+uncertainty. Non-idempotent operations turn a recoverable error into a
+corrupted state.
 
-### Variable Handling Checklist
+### VIII. Documentation Reflects Reality, and CI Proves It
+
+Documentation MUST be updated in the same change as the code it describes, and
+the parts that can be checked mechanically MUST be.
+
+**Rules:**
+
+- The `## Project Structure` diagrams in `CLAUDE.md` and `AGENTS.md` MUST match
+  the real `src/remo_cli/**/*.py` tree. This is gated by
+  `tests/unit/test_docs_structure.py`; a deliberate omission MUST be added to
+  `EXCLUDED_FROM_DOCS` with a stated reason, never silently dropped.
+- A behavior change, a new flag, or a removed flag MUST be reflected in
+  `README.md` and the relevant `docs/*.md` before merge.
+- Documented examples and commands MUST be real and working. Documenting a
+  command that does not exist is a defect (see the removed phantom
+  `remo init`).
+- A dependency whose necessity is not visible from `src/remo_cli/` imports
+  alone MUST carry a comment in `pyproject.toml` naming its real consumer.
+- Deprecated behavior MUST be documented as deprecated at the moment it is
+  deprecated, with the release in which it will be removed.
+
+**Rationale:** Stale documentation is worse than none — it actively misleads.
+Anything a test can check, a test should check, because prose drifts silently
+and diagrams drift fastest.
+
+## Technology Standards
+
+### Python (CLI, core, providers)
+
+- Python 3.11+; the supported matrix is 3.11, 3.12, 3.13.
+- `from __future__ import annotations` at the top of every module; full type
+  hints on public functions.
+- No docstrings on obvious methods; docstrings SHOULD explain *why*, and
+  SHOULD cite the spec/contract they implement when one exists.
+- `ruff` (line length 100, `src = ["src"]`) and `mypy`
+  (`python_version = "3.11"`, `files = ["src"]`) MUST both pass locally before
+  commit.
+- Runtime dependencies MUST be justified. An SDK used only by an Ansible
+  collection MUST say so in `pyproject.toml`.
+
+### Web Service (`src/remo_cli/web/`)
+
+- The service is an OPTIONAL extra (`uv sync --extra web`). `remo --help` and
+  every non-web command MUST work without it installed; web imports MUST be
+  lazy.
+- Every route MUST declare a response model. A route that returns a `Response`
+  subclass directly MUST still construct its declared model, since FastAPI
+  skips `response_model` validation in that case.
+- The `{"error": {...}}` envelope MUST be declared only on routes that
+  actually return it.
+- Closed domains MUST be typed as enums; wire fields that must stay open MUST
+  be typed `KnownEnum | str`.
+- Enums exported into the OpenAPI artifact MUST be fixed at their declared set,
+  never derived from a live registry — a third-party install MUST NOT perturb
+  a generated artifact.
+- Secrets, tokens, and proxy commands MUST be redacted in logs
+  (`web/logging_config.py`).
+
+### Frontend (`frontend/`)
+
+- Service-shaped types MUST be imported from `src/api/generated/`. Console-owned
+  shapes (local UI state, client-side error wrappers) MAY be hand-written and
+  SHOULD be commented as such.
+- Presentation maps keyed off a generated union MUST use a
+  `Record<GeneratedUnion, …>` so a new enum member is a compile error — while
+  RETAINING a runtime fallback for off-union values. Deleting that fallback to
+  "achieve exhaustiveness" is a defect, not a cleanup.
+- `npm run lint` (`tsc --noEmit`), `npm run test` (Vitest), and
+  `npm run build` MUST pass before commit.
+
+### Ansible (`ansible/`)
 
 Before committing Ansible code, verify:
 
 - [ ] All `.rc` accesses use `| default(1)`
 - [ ] All `.stdout` accesses use `| default('')`
-- [ ] All `when:` conditions handle skipped task variables
+- [ ] All `when:` conditions handle skipped-task variables
 - [ ] All `debug` messages with variable interpolation use defaults
 - [ ] Jinja2 templates in `msg:` blocks use safe attribute access
 
-### Task Registration Pattern
+Task registration pattern:
 
 ```yaml
 # Pattern for tasks that may be skipped
@@ -122,43 +334,103 @@ Before committing Ansible code, verify:
   failed_when: false
   when: some_condition
 
-# Safe usage of potentially-skipped result
+# Safe usage of a potentially-skipped result
 - name: Use the result
   ansible.builtin.debug:
     msg: "Result: {{ check_result.stdout | default('skipped') }}"
   when: check_result.stdout is defined
 ```
 
+## Quality Gates
+
+These gates run in CI and MUST pass before merge. None may be skipped,
+`xfail`ed, or made conditional to get a build green.
+
+| Gate | Command | Enforces |
+|------|---------|----------|
+| Tests (3.11/3.12/3.13) | `uv run pytest` | Principles III, VI, VII |
+| Architecture | `tests/unit/test_architecture.py` | Principle I |
+| Docs structure | `tests/unit/test_docs_structure.py` | Principle VIII |
+| Schema drift (Python) | `tests/unit/test_schema_drift.py` | Principle IV |
+| Schema drift (Node) | `npm run check:types-fresh` | Principle IV |
+| Lint | `uv run ruff check src/remo_cli` | Technology Standards |
+| Frontend | `npm run lint && npm run test && npm run build` | Technology Standards |
+| Packaging | wheel install smoke, Docker amd64+arm64 | Distribution integrity |
+| Security | CodeQL, dependency review | Supply chain |
+
+Regeneration commands, when a drift gate fails:
+
+```bash
+uv run python scripts/export_openapi.py   # openapi.json + terminal-frames.json
+cd frontend && npm run generate:types      # schema.d.ts + terminal-frames.d.ts
+```
+
+**Known gap:** `mypy` is configured in `pyproject.toml` and MUST pass locally,
+but is not yet wired into a CI job. Until it is, reviewers MUST treat a type
+regression as a blocking finding.
+
 ## Development Workflow
 
 ### Pre-Commit Checklist
 
-1. **Variable Safety**: Grep for `.rc ==` and `.stdout` without `| default`
-2. **Conditional Coverage**: List all `when:` conditions and verify both branches tested
-3. **Documentation Sync**: Diff README against code changes
-4. **Idempotency Test**: Run playbook twice, verify no unexpected changes on second run
+1. **Layer boundaries**: no Click in `providers/`, no provider names in
+   `core/`, no `sys.exit` in `providers/`.
+2. **Variable safety** (Ansible): grep for `.rc ==` and `.stdout` without
+   `| default`.
+3. **Conditional coverage**: list every `when:`/branch touched and confirm both
+   sides are exercised.
+4. **Regeneration**: if a service model or WS frame changed, regenerate and
+   commit the four artifacts.
+5. **Documentation sync**: diff `README.md`, `docs/*.md`, and the structure
+   diagrams against the change.
+6. **Idempotency**: run the mutating path twice; verify the second run is a
+   no-op.
 
 ### Code Review Focus Areas
 
 Reviewers MUST specifically check:
-- Registered variable access patterns
-- Error message clarity and actionability
+
+- Layer-boundary violations and new escape hatches
+- Registered-variable access patterns (Ansible)
+- Error type selection, exit-code correctness, and message actionability
+- Hand-written types that duplicate a generated shape
+- Removed behavior — especially fallbacks and defaults deleted in the name of
+  strictness
+- Conditional path coverage and regression tests
 - Documentation completeness
-- Conditional path coverage
 
 ## Governance
 
-This constitution establishes non-negotiable standards for the Remo project. All contributions MUST comply.
+This constitution establishes non-negotiable standards for the Remo project.
+All contributions MUST comply. It supersedes ad-hoc convention; where a
+principle and an existing pattern conflict, the principle wins and the pattern
+is the defect.
 
 **Amendment Process:**
-1. Propose changes via PR with rationale
-2. Document what problem the amendment solves
-3. Update all affected templates and documentation
-4. Increment version appropriately
+
+1. Propose changes via PR with rationale.
+2. Document what problem the amendment solves.
+3. Update all affected templates, gates, and documentation in the same PR.
+4. Increment the version according to the versioning policy below.
+
+**Versioning Policy:**
+
+- **MAJOR**: a principle is removed or redefined, or a new binding constraint
+  applies retroactively to existing code.
+- **MINOR**: a principle or section is added, or guidance is materially
+  expanded.
+- **PATCH**: clarification, wording, or typo fixes with no semantic change.
 
 **Compliance:**
-- PRs that violate principles MUST be revised before merge
-- Existing code violations SHOULD be fixed when files are modified
-- Constitution violations discovered in production are P1 bugs
 
-**Version**: 1.0.0 | **Ratified**: 2026-01-06 | **Last Amended**: 2026-01-06
+- PRs that violate principles MUST be revised before merge.
+- Existing violations SHOULD be fixed when the containing file is modified.
+- Constitution violations discovered in production are P1 bugs.
+- A gate that is failing MUST be fixed or the gate amended by PR. Disabling a
+  gate to unblock a merge is FORBIDDEN.
+
+**Runtime guidance:** `CLAUDE.md` and `AGENTS.md` carry the operational detail
+(current tree, commands, recent changes). They elaborate this constitution;
+they never override it.
+
+**Version**: 2.0.0 | **Ratified**: 2026-01-06 | **Last Amended**: 2026-07-27

--- a/.specify/templates/plan-template.md
+++ b/.specify/templates/plan-template.md
@@ -40,7 +40,19 @@
 
 *GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
 
-[Gates determined based on constitution file]
+Source: `.specify/memory/constitution.md` (v2.0.0). Mark each row PASS / N/A /
+VIOLATION. Any VIOLATION must be justified in Complexity Tracking below.
+
+| # | Principle | Check for this feature |
+|---|-----------|------------------------|
+| I | Layered Architecture | No Click in `providers/`, no provider names in `core/`, no `cli/` → private `providers/` reach-ins |
+| II | Providers Are Declared | Any provider-varying behavior is driven by a `ProviderDescriptor` field, not a `host.type` literal |
+| III | Typed Errors, One Exit Boundary | Business layer raises `core/errors.py` types; messages name the fix |
+| IV | Generated Contracts | Service model / WS frame changes regenerate the four artifacts; no hand-mirrored types |
+| V | Defensive Variable Access | Every registered Ansible variable access uses `\| default()` |
+| VI | Test Skip/Fail Paths | Error, skip, and abort paths are covered; refactors are pinned by characterization tests first |
+| VII | Idempotent & Re-runnable | Mutating paths converge on a second run; registry writes go through `core/registry.py` |
+| VIII | Docs Reflect Reality | Structure diagrams, README, and `docs/*.md` updated in this change |
 
 ## Project Structure
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,7 +4,7 @@ Auto-generated from all feature plans. Last updated: 2026-07-27
 
 ## Constitution
 
-See `.specify/memory/constitution.md` (v2.0.0) for the full text. The eight
+See `.specify/memory/constitution.md` (v2.0.1) for the full text. The eight
 non-negotiable principles, in short:
 
 | # | Principle | One-line rule |
@@ -272,12 +272,16 @@ made conditional to get a build green — fix the code or amend the gate by PR.
 | Schema drift (Python) | `uv run pytest tests/unit/test_schema_drift.py` | Principle IV |
 | Schema drift (Node) | `cd frontend && npm run check:types-fresh` | Principle IV |
 | Lint | `uv run ruff check src/remo_cli` | Code Style |
+| Types | `uv run mypy src/remo_cli` | Code Style |
 | Frontend | `cd frontend && npm run lint && npm run test && npm run build` | Code Style |
 | Packaging | wheel install smoke, Docker amd64+arm64 | Distribution integrity |
 | Security | CodeQL, dependency review | Supply chain |
 
-**`mypy` is not yet a CI job** but is configured (`[tool.mypy]`, `files = ["src"]`)
-and must pass locally: `uv run mypy src/remo_cli`.
+`ruff` and `mypy` share the one `Lint & Types` job. That job must keep
+installing the `web` extra (`uv sync --all-extras`): with
+`ignore_missing_imports = true`, an uninstalled FastAPI/pydantic would degrade
+every `src/remo_cli/web/` module to `Any` and leave the type gate passing while
+checking nothing.
 
 ### Repo-wide pre-commit checklist
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,7 +4,21 @@ Auto-generated from all feature plans. Last updated: 2026-07-27
 
 ## Constitution
 
-See `.specify/memory/constitution.md` for project principles and non-negotiable standards.
+See `.specify/memory/constitution.md` (v2.0.0) for the full text. The eight
+non-negotiable principles, in short:
+
+| # | Principle | One-line rule |
+|---|-----------|---------------|
+| I | Layered Architecture with One-Way Dependencies | `cli/` → `providers/` → `core/`, never backwards |
+| II | Providers Are Declared, Not Special-Cased | A new provider = one module + one descriptor, zero edits elsewhere |
+| III | Typed Errors, One Exit Boundary, Actionable Messages | Raise `core/errors.py`; only `provider_command` maps to an exit code |
+| IV | Contracts Are Generated, Never Hand-Authored | The FastAPI app is the source of truth for every shape `frontend/` consumes |
+| V | Defensive Variable Access (Ansible) | Every registered-variable access uses `\| default()` |
+| VI | Test Every Path That Can Skip or Fail | Error/skip/abort paths are covered, not just the happy path |
+| VII | Idempotent and Re-runnable by Default | A second run is a no-op; registry writes go through `core/registry.py` |
+| VIII | Documentation Reflects Reality, and CI Proves It | Structure diagrams and docs ship in the same change as the code |
+
+Principles I, IV, and VIII are machine-enforced — see [Quality Gates](#quality-gates).
 
 ## Active Technologies
 - Ansible 2.14+ / YAML + `ansible.builtin`, `community.general` (existing), Incus CLI (local) (002-incus-container-support)
@@ -124,7 +138,7 @@ scripts/                   # Repo-root utility scripts (not part of the installe
 pyproject.toml             # Build config, dependencies (incl. `web` extra), console_scripts entry point
 ```
 
-## Ansible Standards (from Constitution)
+## Ansible Standards (Constitution Principle V)
 
 ### Variable Access - CRITICAL
 
@@ -140,9 +154,9 @@ when: my_result.rc | default(1) == 0
 msg: "{{ my_result.stdout | default('N/A') }}"
 ```
 
-### Pre-Commit Checklist
+### Ansible Pre-Commit Checklist
 
-Before committing Ansible code:
+Before committing Ansible code (the repo-wide checklist is under [Quality Gates](#quality-gates)):
 
 1. Grep for unsafe patterns: `grep -r '\.rc ==' ansible/` and `grep -r '\.stdout' ansible/`
 2. Verify all matches use `| default()`
@@ -209,17 +223,86 @@ npm run test                      # Vitest unit/component suite (jsdom, no backe
 npm run test:e2e                  # Playwright (needs REMO_E2E_BASE_URL -> live remo web serve)
 ```
 
-## Architecture (Three-Layer)
+## Architecture
+
+### System layers
+
+| Layer | Path | Depends on |
+|-------|------|------------|
+| Browser console (React/TS SPA) | `frontend/` | The web service's **generated** types only |
+| Web service (FastAPI, optional `web` extra) | `src/remo_cli/web/` | `core/`, `models/`, `providers/` (catches `ProviderError` directly) |
+| CLI package (Python) | `src/remo_cli/{cli,providers,core,models}/` | Ansible via subprocess |
+| Configuration (Ansible roles) | `ansible/` | — |
+
+The service is an optional extra: `remo --help` and every non-web command work
+without it installed, and web imports are lazy (NFR-008).
+
+### Python package (three layers, one-way)
 
 - **cli/** → Click commands, argument parsing only. No business logic.
-- **providers/** → Business logic. No Click imports. Called by cli layer.
+- **providers/** → Business logic. No Click imports. No `sys.exit`. Called by cli layer.
 - **core/** → Shared utilities. No provider knowledge. Used by both layers.
+
+`tests/unit/test_architecture.py` enforces this with zero-tolerance (empty)
+allowlists: no `sys.exit` in `providers/`, and no `cli/` reach-ins to a
+`providers/` module's private helpers.
+
+Provider-varying behavior lives behind a `ProviderDescriptor` field or hook —
+never a `host.type` string literal in `core/`. AWS's SSM `ProxyCommand` is the
+worked example: it sits in `providers/aws.py:ssh_proxy_hook`, reached via
+`descriptor.connection.proxy_hook`.
+
+Failures raise the `core/errors.py` taxonomy (`MissingDependencyError`,
+`PreconditionError`, `OperationFailedError`, `UserAbortedError`).
+`cli/providers/factory.py`'s `provider_command` wrapper is the *only*
+exception-to-exit-code boundary: `0` success, `1` failure, `3` user-aborted.
 
 Provider implementation modules are lazily imported by `core/provider_registry.get_provider()`; an `ImportError` during that import becomes a `MissingDependencyError` naming `descriptor.sdk_extra` (e.g. "aws", "hetzner") and the `uv sync --extra <name>` install command. In practice `boto3` and `hcloud` are both unconditional dependencies today, so this `ImportError` branch is currently unreachable for the built-in providers — the message is aspirational pending issue #94, which would introduce real optional extras; `descriptor.sdk_extra` itself is unchanged and the mechanism is exercised by third-party providers that do have an optional SDK.
 
+## Quality Gates
+
+These run in CI and must pass before merge. None may be skipped, `xfail`ed, or
+made conditional to get a build green — fix the code or amend the gate by PR.
+
+| Gate | Command | Enforces |
+|------|---------|----------|
+| Tests (3.11/3.12/3.13) | `uv run pytest` | Principles III, VI, VII |
+| Architecture | `uv run pytest tests/unit/test_architecture.py` | Principle I |
+| Docs structure | `uv run pytest tests/unit/test_docs_structure.py` | Principle VIII |
+| Schema drift (Python) | `uv run pytest tests/unit/test_schema_drift.py` | Principle IV |
+| Schema drift (Node) | `cd frontend && npm run check:types-fresh` | Principle IV |
+| Lint | `uv run ruff check src/remo_cli` | Code Style |
+| Frontend | `cd frontend && npm run lint && npm run test && npm run build` | Code Style |
+| Packaging | wheel install smoke, Docker amd64+arm64 | Distribution integrity |
+| Security | CodeQL, dependency review | Supply chain |
+
+**`mypy` is not yet a CI job** but is configured (`[tool.mypy]`, `files = ["src"]`)
+and must pass locally: `uv run mypy src/remo_cli`.
+
+### Repo-wide pre-commit checklist
+
+1. **Layer boundaries** — no Click in `providers/`, no provider names in `core/`, no `sys.exit` in `providers/`.
+2. **Variable safety (Ansible)** — grep for `.rc ==` and `.stdout` without `| default`.
+3. **Conditional coverage** — every branch touched has both sides exercised.
+4. **Regeneration** — a service model or WS frame change regenerates and commits all four artifacts.
+5. **Documentation sync** — `README.md`, `docs/*.md`, and the structure diagrams above match the change.
+6. **Idempotency** — the mutating path runs twice; the second run is a no-op.
+
 ## Code Style
 
-- Python: Type hints, `from __future__ import annotations`, no docstrings on obvious methods
+- Python: Type hints, `from __future__ import annotations`, no docstrings on obvious methods.
+  Docstrings explain *why*, and cite the spec/contract they implement when one exists.
+- Web service: every route declares a response model; a route returning a `Response`
+  subclass must still construct that model (FastAPI skips `response_model` otherwise).
+  Closed domains are enums; open wire fields are `KnownEnum | str`. Enums exported into
+  the OpenAPI artifact are fixed at their declared set, never derived from a live registry.
+- Frontend: service-shaped types come from `src/api/generated/`; console-owned shapes may be
+  hand-written and are commented as such. Presentation maps key off a generated union via
+  `Record<GeneratedUnion, …>` so a new member is a compile error — while keeping the runtime
+  fallback for off-union values (deleting that fallback is a defect, not a cleanup).
+- Generated artifacts (`openapi.json`, `terminal-frames.json`, `schema.d.ts`,
+  `terminal-frames.d.ts`) are checked in but never hand-edited. See
+  `docs/maintaining-generated-types.md`.
 - Ansible 2.14+ / YAML: Follow standard conventions plus Constitution principles
 
 ## Recent Changes

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@ Auto-generated from all feature plans. Last updated: 2026-07-27
 
 ## Constitution
 
-See `.specify/memory/constitution.md` (v2.0.0) for the full text. The eight
+See `.specify/memory/constitution.md` (v2.0.1) for the full text. The eight
 non-negotiable principles, in short:
 
 | # | Principle | One-line rule |
@@ -272,12 +272,16 @@ made conditional to get a build green — fix the code or amend the gate by PR.
 | Schema drift (Python) | `uv run pytest tests/unit/test_schema_drift.py` | Principle IV |
 | Schema drift (Node) | `cd frontend && npm run check:types-fresh` | Principle IV |
 | Lint | `uv run ruff check src/remo_cli` | Code Style |
+| Types | `uv run mypy src/remo_cli` | Code Style |
 | Frontend | `cd frontend && npm run lint && npm run test && npm run build` | Code Style |
 | Packaging | wheel install smoke, Docker amd64+arm64 | Distribution integrity |
 | Security | CodeQL, dependency review | Supply chain |
 
-**`mypy` is not yet a CI job** but is configured (`[tool.mypy]`, `files = ["src"]`)
-and must pass locally: `uv run mypy src/remo_cli`.
+`ruff` and `mypy` share the one `Lint & Types` job. That job must keep
+installing the `web` extra (`uv sync --all-extras`): with
+`ignore_missing_imports = true`, an uninstalled FastAPI/pydantic would degrade
+every `src/remo_cli/web/` module to `Any` and leave the type gate passing while
+checking nothing.
 
 ### Repo-wide pre-commit checklist
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,21 @@ Auto-generated from all feature plans. Last updated: 2026-07-27
 
 ## Constitution
 
-See `.specify/memory/constitution.md` for project principles and non-negotiable standards.
+See `.specify/memory/constitution.md` (v2.0.0) for the full text. The eight
+non-negotiable principles, in short:
+
+| # | Principle | One-line rule |
+|---|-----------|---------------|
+| I | Layered Architecture with One-Way Dependencies | `cli/` → `providers/` → `core/`, never backwards |
+| II | Providers Are Declared, Not Special-Cased | A new provider = one module + one descriptor, zero edits elsewhere |
+| III | Typed Errors, One Exit Boundary, Actionable Messages | Raise `core/errors.py`; only `provider_command` maps to an exit code |
+| IV | Contracts Are Generated, Never Hand-Authored | The FastAPI app is the source of truth for every shape `frontend/` consumes |
+| V | Defensive Variable Access (Ansible) | Every registered-variable access uses `\| default()` |
+| VI | Test Every Path That Can Skip or Fail | Error/skip/abort paths are covered, not just the happy path |
+| VII | Idempotent and Re-runnable by Default | A second run is a no-op; registry writes go through `core/registry.py` |
+| VIII | Documentation Reflects Reality, and CI Proves It | Structure diagrams and docs ship in the same change as the code |
+
+Principles I, IV, and VIII are machine-enforced — see [Quality Gates](#quality-gates).
 
 ## Active Technologies
 - Ansible 2.14+ / YAML + `ansible.builtin`, `community.general` (existing), Incus CLI (local) (002-incus-container-support)
@@ -124,7 +138,7 @@ scripts/                   # Repo-root utility scripts (not part of the installe
 pyproject.toml             # Build config, dependencies (incl. `web` extra), console_scripts entry point
 ```
 
-## Ansible Standards (from Constitution)
+## Ansible Standards (Constitution Principle V)
 
 ### Variable Access - CRITICAL
 
@@ -140,9 +154,9 @@ when: my_result.rc | default(1) == 0
 msg: "{{ my_result.stdout | default('N/A') }}"
 ```
 
-### Pre-Commit Checklist
+### Ansible Pre-Commit Checklist
 
-Before committing Ansible code:
+Before committing Ansible code (the repo-wide checklist is under [Quality Gates](#quality-gates)):
 
 1. Grep for unsafe patterns: `grep -r '\.rc ==' ansible/` and `grep -r '\.stdout' ansible/`
 2. Verify all matches use `| default()`
@@ -209,17 +223,86 @@ npm run test                      # Vitest unit/component suite (jsdom, no backe
 npm run test:e2e                  # Playwright (needs REMO_E2E_BASE_URL -> live remo web serve)
 ```
 
-## Architecture (Three-Layer)
+## Architecture
+
+### System layers
+
+| Layer | Path | Depends on |
+|-------|------|------------|
+| Browser console (React/TS SPA) | `frontend/` | The web service's **generated** types only |
+| Web service (FastAPI, optional `web` extra) | `src/remo_cli/web/` | `core/`, `models/`, `providers/` (catches `ProviderError` directly) |
+| CLI package (Python) | `src/remo_cli/{cli,providers,core,models}/` | Ansible via subprocess |
+| Configuration (Ansible roles) | `ansible/` | — |
+
+The service is an optional extra: `remo --help` and every non-web command work
+without it installed, and web imports are lazy (NFR-008).
+
+### Python package (three layers, one-way)
 
 - **cli/** → Click commands, argument parsing only. No business logic.
-- **providers/** → Business logic. No Click imports. Called by cli layer.
+- **providers/** → Business logic. No Click imports. No `sys.exit`. Called by cli layer.
 - **core/** → Shared utilities. No provider knowledge. Used by both layers.
+
+`tests/unit/test_architecture.py` enforces this with zero-tolerance (empty)
+allowlists: no `sys.exit` in `providers/`, and no `cli/` reach-ins to a
+`providers/` module's private helpers.
+
+Provider-varying behavior lives behind a `ProviderDescriptor` field or hook —
+never a `host.type` string literal in `core/`. AWS's SSM `ProxyCommand` is the
+worked example: it sits in `providers/aws.py:ssh_proxy_hook`, reached via
+`descriptor.connection.proxy_hook`.
+
+Failures raise the `core/errors.py` taxonomy (`MissingDependencyError`,
+`PreconditionError`, `OperationFailedError`, `UserAbortedError`).
+`cli/providers/factory.py`'s `provider_command` wrapper is the *only*
+exception-to-exit-code boundary: `0` success, `1` failure, `3` user-aborted.
 
 Provider implementation modules are lazily imported by `core/provider_registry.get_provider()`; an `ImportError` during that import becomes a `MissingDependencyError` naming `descriptor.sdk_extra` (e.g. "aws", "hetzner") and the `uv sync --extra <name>` install command. In practice `boto3` and `hcloud` are both unconditional dependencies today, so this `ImportError` branch is currently unreachable for the built-in providers — the message is aspirational pending issue #94, which would introduce real optional extras; `descriptor.sdk_extra` itself is unchanged and the mechanism is exercised by third-party providers that do have an optional SDK.
 
+## Quality Gates
+
+These run in CI and must pass before merge. None may be skipped, `xfail`ed, or
+made conditional to get a build green — fix the code or amend the gate by PR.
+
+| Gate | Command | Enforces |
+|------|---------|----------|
+| Tests (3.11/3.12/3.13) | `uv run pytest` | Principles III, VI, VII |
+| Architecture | `uv run pytest tests/unit/test_architecture.py` | Principle I |
+| Docs structure | `uv run pytest tests/unit/test_docs_structure.py` | Principle VIII |
+| Schema drift (Python) | `uv run pytest tests/unit/test_schema_drift.py` | Principle IV |
+| Schema drift (Node) | `cd frontend && npm run check:types-fresh` | Principle IV |
+| Lint | `uv run ruff check src/remo_cli` | Code Style |
+| Frontend | `cd frontend && npm run lint && npm run test && npm run build` | Code Style |
+| Packaging | wheel install smoke, Docker amd64+arm64 | Distribution integrity |
+| Security | CodeQL, dependency review | Supply chain |
+
+**`mypy` is not yet a CI job** but is configured (`[tool.mypy]`, `files = ["src"]`)
+and must pass locally: `uv run mypy src/remo_cli`.
+
+### Repo-wide pre-commit checklist
+
+1. **Layer boundaries** — no Click in `providers/`, no provider names in `core/`, no `sys.exit` in `providers/`.
+2. **Variable safety (Ansible)** — grep for `.rc ==` and `.stdout` without `| default`.
+3. **Conditional coverage** — every branch touched has both sides exercised.
+4. **Regeneration** — a service model or WS frame change regenerates and commits all four artifacts.
+5. **Documentation sync** — `README.md`, `docs/*.md`, and the structure diagrams above match the change.
+6. **Idempotency** — the mutating path runs twice; the second run is a no-op.
+
 ## Code Style
 
-- Python: Type hints, `from __future__ import annotations`, no docstrings on obvious methods
+- Python: Type hints, `from __future__ import annotations`, no docstrings on obvious methods.
+  Docstrings explain *why*, and cite the spec/contract they implement when one exists.
+- Web service: every route declares a response model; a route returning a `Response`
+  subclass must still construct that model (FastAPI skips `response_model` otherwise).
+  Closed domains are enums; open wire fields are `KnownEnum | str`. Enums exported into
+  the OpenAPI artifact are fixed at their declared set, never derived from a live registry.
+- Frontend: service-shaped types come from `src/api/generated/`; console-owned shapes may be
+  hand-written and are commented as such. Presentation maps key off a generated union via
+  `Record<GeneratedUnion, …>` so a new member is a compile error — while keeping the runtime
+  fallback for off-union values (deleting that fallback is a defect, not a cleanup).
+- Generated artifacts (`openapi.json`, `terminal-frames.json`, `schema.d.ts`,
+  `terminal-frames.d.ts`) are checked in but never hand-edited. See
+  `docs/maintaining-generated-types.md`.
 - Ansible 2.14+ / YAML: Follow standard conventions plus Constitution principles
 
 ## Recent Changes


### PR DESCRIPTION
## Why

The constitution was written when remo was an Ansible-only project — all five principles were about Ansible variable safety, playbook idempotency, and playbook testing. remo is now four layers: a Python CLI (`src/remo_cli/`), an optional FastAPI service (`src/remo_cli/web/`), a TypeScript/React console (`frontend/`), and the Ansible roles the CLI invokes. None of the architectural decisions from features 015–020 — the provider descriptor abstraction, the typed error taxonomy, registry v2's locking, the generated-types contract — had any governing principle.

This was the one remaining item from the July 2026 architecture evaluation tracked in #84, deliberately scoped as a constitution refresh rather than a spec.

Two commits: the rewrite, then closing the one gap the rewrite surfaced.

---

# 1. Constitution 1.0.0 → 2.0.0 (MAJOR) — `c98c81d`

All five original principles survive, but four are renamed or redefined and three new principles apply **retroactively to existing code**. Under the versioning policy the document now states, that combination is a MAJOR.

### New principles

| # | Principle | Grounded in |
|---|-----------|-------------|
| I | Layered Architecture with One-Way Dependencies | `tests/unit/test_architecture.py`'s zero-tolerance (empty) allowlists |
| II | Providers Are Declared, Not Special-Cased | feature 018 — a new provider is one module plus one descriptor registration, zero edits elsewhere |
| IV | Contracts Are Generated, Never Hand-Authored | feature 020 — four artifacts, three drift checks |

### Carried forward

| Was | Now | Change |
|-----|-----|--------|
| I. Defensive Variable Access (Ansible) | V | Unchanged in substance; no longer the lead principle |
| II. Test All Conditional Paths | VI. Test Every Path That Can Skip or Fail | Widened past Ansible; adds characterization-test-before-refactor |
| III. Idempotent by Default | VII. Idempotent and Re-runnable by Default | Now also covers registry locking and web push/sync convergence |
| IV. Fail Fast with Clear Messages | merged into III | Now also binds the `core/errors.py` taxonomy and the single exit boundary |
| V. Documentation Reflects Reality | VIII | Now machine-checked, not aspirational |

### New sections

- **Technology Standards** — per-layer rules for Python, the web service, the frontend, and Ansible. Replaces the narrower "Ansible-Specific Standards", which is absorbed intact.
- **Quality Gates** — the CI gates mapped to the principles they enforce, plus the regeneration commands to run when a drift gate fails.

### Propagation

- **`.specify/templates/plan-template.md`** — the empty `[Gates determined based on constitution file]` placeholder becomes a concrete eight-row Constitution Check table, so every future `/speckit-plan` gets a real gate list.
- **`CLAUDE.md` / `AGENTS.md`** — Constitution section names all eight principles; `## Architecture (Three-Layer)` becomes `## Architecture` with a system-layer table above the still-accurate three-layer Python breakdown; new `## Quality Gates` section; `## Code Style` gains web-service, frontend, and generated-artifact rules.
- `spec-template.md` / `tasks-template.md` — no constitution references; no changes needed.

The `## Project Structure` diagrams were deliberately left untouched, and the new sections sit outside the two headings (`## Active Technologies`, `## Recent Changes`) that `update-agent-context.sh` rewrites, so the generator will not clobber them.

---

# 2. mypy becomes a gate — Constitution → 2.0.1 (PATCH) — `e3df699`

Writing the Quality Gates section surfaced a gap: `mypy` was configured in `pyproject.toml` and documented as required, but **no workflow ran it** — the Lint job ran `ruff` only. v2.0.0 initially recorded this honestly as a "Known gap" asking reviewers to catch type regressions by hand. This commit closes it properly instead.

`mypy` already passed clean (68 source files), so this is wiring only — no type errors needed fixing.

- Added a `Mypy check` step to the existing lint job rather than a new job: it reuses the `uv sync --all-extras` already there, which is the slow part. Display name `Lint` → `Lint & Types`; `main` has no branch protection, so no required-check config referenced the old name.
- Constitution Quality Gates grows a `Types` row and loses the Known gap paragraph; Technology Standards now states ruff and mypy as CI gates rather than local-only expectations. `CLAUDE.md`/`AGENTS.md` mirror both.

PATCH bump: no principle changed — a stated gap became a gate.

### The non-obvious hazard, documented in-place

`[tool.mypy]` sets `ignore_missing_imports = true`. If the `Lint & Types` job ever stopped installing the `web` extra, FastAPI and pydantic would fail to resolve and **every `src/remo_cli/web/` module would silently degrade to `Any`** — the gate would keep passing green while checking nothing. That is worse than no gate, because it looks like coverage.

Verified empirically rather than assumed: a probe file dereferencing an arbitrary attribute chain on a type imported from a nonexistent package passes cleanly under `--ignore-missing-imports`. The requirement is recorded both as a comment on the workflow step and in the constitution's Quality Gates section.

### Deliberately out of scope

Neither is the documented gap, and both are scope decisions worth making on their own:

- `ignore_missing_imports = true` stays. Tightening it would surface errors from `InquirerPy`, `hcloud`, `boto3`, and `ansible-core`, none of which ship stubs.
- `files = ["src"]` stays, leaving `tests/` unchecked.

---

## Verification

`uv run mypy src/remo_cli` (68 files, clean), `uv run ruff check src/remo_cli` (clean), `test_docs_structure.py` / `test_architecture.py` / `test_schema_drift.py` (37 passed), and `ci.yml` parses with the expected five lint steps. No unresolved `[PLACEHOLDER]` tokens remain in the constitution.

Documentation and CI only; no source, dependency, or schema changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ER1fspJAScAo1o4jGdjuJE
