### PR TITLE
fix(providers): stop `remo shell` from touching the hypervisor, and say which machine `--user` means

### DIFF
--- a/docs/incus.md
+++ b/docs/incus.md
@@ -75,7 +75,7 @@ remo incus info --name dev1
 | Option | Default | Description |
 |--------|---------|-------------|
 | `--host <host>` | `localhost` | Incus host to connect to |
-| `--user <user>` | (current user) | SSH user for the Incus host |
+| `--user <user>` | (current user) | SSH user on the **Incus host**, for host-side `incus` commands — not the container login (always `remo`) |
 | `--domain <domain>` | (none) | Domain for FQDN (e.g., `int.example.com`) |
 | `--image <image>` | `images:ubuntu/24.04/cloud` | Cloud image to use |
 | `--volume-size <GiB>` | (profile default) | Override the root disk size via `incus config device override root size=...` |
@@ -92,7 +92,7 @@ remo incus info --name dev1
 | `--cores <n>` | Set CPU core limit (`limits.cpu`); live on cgroup v2 |
 | `--memory <MiB>` | Set memory limit (`limits.memory`); live on cgroup v2 |
 | `--host <host>` | Incus host |
-| `--user <user>` | SSH user for host |
+| `--user <user>` | SSH user on the **Incus host**, for host-side `incus` commands — not the container login (always `remo`) |
 
 Available tools: `docker`, `user_setup`, `nodejs`, `devcontainers`, `github_cli`, `fzf`, `zellij`
 
@@ -103,7 +103,7 @@ Available tools: `docker`, `user_setup`, `nodejs`, `devcontainers`, `github_cli`
 | `--yes`, `-y` | Skip confirmation prompt |
 | `--remove-storage` | Also remove host mount directories (e.g. `/home`, `/workspace`) bound into the container. Without this flag, mount directories on the host are preserved. |
 | `--host <host>` | Incus host |
-| `--user <user>` | SSH user for host |
+| `--user <user>` | SSH user on the **Incus host**, for host-side `incus` commands — not the container login (always `remo`) |
 
 ### Sync
 
@@ -140,7 +140,7 @@ only. To mark one permanently instead, use `remo incus update --name <n>
 | Option | Description |
 |--------|-------------|
 | `--host <host>` | Incus host (default: `localhost`) |
-| `--user <user>` | SSH user for remote Incus host |
+| `--user <user>` | SSH user on the **Incus host**, for host-side `incus` commands — not the container login (always `remo`) |
 | `--use-ip` | Store each container's resolved IP instead of its name |
 | `--all` | Also register containers without the managed marker (this run only) |
 | `--yes`, `-y` | Skip the removal confirmation prompt |

--- a/docs/incus.md
+++ b/docs/incus.md
@@ -137,6 +137,13 @@ By default only containers carrying the `user.remo=true` managed marker are
 only. To mark one permanently instead, use `remo incus update --name <n>
 --host <h>`.
 
+> **`remo shell` does not tag.** When `remo shell` offers a tools update, it
+> configures the instance only — it never writes provider-side state, because
+> tagging means reaching the hypervisor (a machine you did not name at the
+> prompt). Only explicit `remo incus update` and `remo incus sync` apply the marker. If
+> `sync` reports instances as unmarked, that is why, and either command fixes
+> it permanently.
+
 | Option | Description |
 |--------|-------------|
 | `--host <host>` | Incus host (default: `localhost`) |

--- a/docs/proxmox.md
+++ b/docs/proxmox.md
@@ -140,6 +140,13 @@ Available tools: `docker`, `user_setup`, `nodejs`, `devcontainers`, `github_cli`
 > `remo proxmox sync --host <node> --user <you>` — passing `--user` to `update`
 > alone is a one-shot override and is not persisted.
 
+> **`remo shell` does not tag.** When `remo shell` offers a tools update, it
+> configures the instance only — it never writes provider-side state, because
+> tagging means reaching the hypervisor (a machine you did not name at the
+> prompt). Only explicit `remo proxmox update` and `remo proxmox sync` apply the marker. If
+> `sync` reports instances as unmarked, that is why, and either command fixes
+> it permanently.
+
 ## Features
 
 | Feature | Description |

--- a/docs/proxmox.md
+++ b/docs/proxmox.md
@@ -89,7 +89,7 @@ remo proxmox info --name dev1
 | Option | Default | Description |
 |--------|---------|-------------|
 | `--host <host>` | (required) | SSH host for the Proxmox node |
-| `--user <user>` | (current user) | SSH user for the Proxmox host |
+| `--user <user>` | (ssh_config; recorded as `root`) | SSH user on the **Proxmox node**, for host-side `pct` commands — not the container login (always `remo`) |
 | `--node <node>` | `--host` | Proxmox cluster node name (only differs in clusters) |
 | `--bridge <name>` | `vmbr0` | Linux bridge to attach the container to |
 | `--storage <name>` | `local-lvm` | Storage pool for the rootfs volume |
@@ -111,7 +111,7 @@ remo proxmox info --name dev1
 | `--cores <n>` | Set CPU core count via `pct set` (live; cgroup v2) |
 | `--memory <MiB>` | Set memory limit via `pct set` (live) |
 | `--host <host>` | Proxmox host (auto-detected from registry if omitted) |
-| `--user <user>` | SSH user for the Proxmox host |
+| `--user <user>` | SSH user on the **Proxmox node** (default: `root`), for host-side `pct` commands — not the container login (always `remo`) |
 | `--devcontainer-runtime <name>` | `devcontainer` or `deacon` (experimental). Re-provisions the launcher scripts to use the chosen runtime. |
 
 Available tools: `docker`, `user_setup`, `nodejs`, `devcontainers`, `github_cli`, `fzf`, `zellij`
@@ -123,7 +123,22 @@ Available tools: `docker`, `user_setup`, `nodejs`, `devcontainers`, `github_cli`
 | `--yes`, `-y` | Skip confirmation prompt |
 | `--purge` | Pass `--purge` to `pct destroy`: also remove the container from backup/replication/HA job configs. The rootfs is destroyed regardless of this flag. |
 | `--host <host>` | Proxmox host |
-| `--user <user>` | SSH user for the Proxmox host |
+| `--user <user>` | SSH user on the **Proxmox node** (default: `root`), for host-side `pct` commands — not the container login (always `remo`) |
+
+> **`--user` is the *node* login, not the container login.** It is the account
+> remo SSHes into the Proxmox node as, to run host-side `pct` commands
+> (creating the container, resolving its VMID, and applying the `remo` tag).
+> The account you land in *inside* the container is always `remo` and is not
+> configurable. `pct` normally requires `root` on the node.
+>
+> Note the defaults differ by command: `create`/`sync` leave `--user` empty and
+> let your `ssh_config` decide, but record `node_user: root` in the registry;
+> `update`/`destroy`/`info` read that recorded value and fall back to `root`.
+> So a container created without `--user` may be reached as you at create time
+> and as `root` later. If root SSH is blocked (e.g. a Tailscale SSH policy),
+> re-record the right user with
+> `remo proxmox sync --host <node> --user <you>` — passing `--user` to `update`
+> alone is a one-shot override and is not persisted.
 
 ## Features
 

--- a/src/remo_cli/core/known_hosts.py
+++ b/src/remo_cli/core/known_hosts.py
@@ -56,6 +56,45 @@ def _print_migration_notice(report: MigrationReport) -> None:
         "Note: the next `remo web push` will re-verify all instances (the "
         "registry format changed)."
     )
+    _print_tagging_notice(report)
+
+
+def _print_tagging_notice(report: MigrationReport) -> None:
+    """Point at the command that backfills managed tags (feature 013).
+
+    Managed tagging and registry v2 are unrelated features that ship in the
+    same release, so every instance in a migrating registry predates tagging
+    and a default `sync` will list it as unmarked. Migration is the one moment
+    that reaches exactly that population exactly once, so the notice rides
+    along here rather than being discovered later.
+
+    This replaces the implicit backfill that used to run whenever `remo shell`
+    offered a tools update: tagging is a provider-side write (an SSH hop to the
+    hypervisor for incus/proxmox), and `remo shell` should touch the instance
+    only. Explicit `remo <type> update` and `remo <type> sync` still tag.
+
+    Says "may not be" rather than "are not": we cannot know an instance's tag
+    state without reaching the provider, which is the very thing being avoided.
+    """
+    from remo_cli.core.output import print_info  # noqa: PLC0415
+    from remo_cli.core.provider_registry import get_descriptor, is_provider_type  # noqa: PLC0415
+
+    taggable = [
+        t
+        for t in report.migrated_types
+        if is_provider_type(t) and get_descriptor(t).supports_managed_marker
+    ]
+    if not taggable:
+        return
+
+    print_info(
+        "Note: instances created before this release may not be tagged as "
+        "remo-managed, so a default `sync` will list them as unmarked. Tag "
+        "them with:"
+    )
+    for type_name in taggable:
+        scope = " --host <host>" if _is_host_scoped_type(type_name) else ""
+        print_info(f"  remo {type_name} sync{scope}")
 
 
 def _migrate_and_notify() -> None:

--- a/src/remo_cli/core/provider_registry.py
+++ b/src/remo_cli/core/provider_registry.py
@@ -144,6 +144,11 @@ class ProviderDescriptor:
     destroy_options: tuple[OptionSpec, ...] = field(default_factory=tuple)
     sync_options: tuple[OptionSpec, ...] = field(default_factory=tuple)
     info_options: tuple[OptionSpec, ...] = field(default_factory=tuple)
+    # True when the provider backfills a remo-managed marker on `update`/`sync`
+    # (incus/proxmox config keys and tags, hetzner labels). AWS has no backfill.
+    # Drives the post-migration tagging notice; keeps the type literals here
+    # rather than in core/ (Principle II).
+    supports_managed_marker: bool = False
     snapshot_region_scoped: bool = False
     snapshot_async: bool = False  # True when creation is async and status is meaningful (AWS/Hetzner)
     extra_commands: tuple[CommandSpec, ...] = field(default_factory=tuple)

--- a/src/remo_cli/core/registry.py
+++ b/src/remo_cli/core/registry.py
@@ -84,6 +84,10 @@ class MigrationReport:
     migrated_count: int
     backup_path: Path
     skipped_lines: list[str]
+    # Provider types present among the migrated entries, sorted. Lets the
+    # one-time notice name the providers the user actually has instead of
+    # listing all four (see core/known_hosts._print_migration_notice).
+    migrated_types: tuple[str, ...] = ()
 
 
 @dataclass
@@ -725,6 +729,7 @@ def _migrate_locked() -> MigrationReport | None:
         migrated_count=len(valid_hosts) + len(legacy_result.unknown_raw),
         backup_path=backup_path,
         skipped_lines=skipped,
+        migrated_types=tuple(sorted({h.type for h in valid_hosts})),
     )
 
 

--- a/src/remo_cli/providers/hetzner.py
+++ b/src/remo_cli/providers/hetzner.py
@@ -189,6 +189,7 @@ def update(
     tools_only: tuple[str, ...] = (),
     tools_skip: tuple[str, ...] = (),
     verbose: bool = False,
+    apply_marker: bool = True,
 ) -> None:
     """Re-configure dev tools on an existing Hetzner VM.
 
@@ -197,6 +198,13 @@ def update(
 
     Raises :class:`PreconditionError` if the server is not registered, or
     :class:`OperationFailedError` if a playbook fails.
+    
+    *apply_marker* gates the managed-marker backfill. Explicit
+    ``remo hetzner update`` backfills it (True); ``update_entry`` -- the
+    ``remo shell`` tools-update path -- passes False, so `remo shell` never
+    performs a provider-side write the user did not ask for. Instances that
+    predate tagging are pointed at ``sync`` by the one-time post-migration
+    notice instead (core/known_hosts._print_tagging_notice).
     """
     if name:
         validate_name(name, "server name")
@@ -209,12 +217,14 @@ def update(
     # (T058) -- API-only, so it runs before/independent of the SSH-reachable
     # steps below and is not skipped by a later playbook failure. Warn on
     # failure but do not fail the whole update (FR-005 parity).
-    ok, err = _apply_managed_label(server_name)
-    if not ok:
-        print_warning(
-            f"Could not mark server '{server_name}' as remo-managed ({err}); "
-            f"it may not be picked up by a default `remo hetzner sync`."
-        )
+    if apply_marker:
+        ok, err = _apply_managed_label(server_name)
+        if not ok:
+            print_warning(
+                f"Could not mark server '{server_name}' as remo-managed "
+                f"({err}); it may not be picked up by a default "
+                f"`remo hetzner sync`."
+            )
 
     # Get server address from known_hosts.
     server_host = _lookup_hetzner_host(server_name)
@@ -256,7 +266,7 @@ def update(
 
 def update_entry(entry: KnownHost, *, verbose: bool = False) -> None:
     """Re-apply tool configuration to an existing VM (Protocol Part A)."""
-    update(name=entry.name, verbose=verbose)
+    update(name=entry.name, verbose=verbose, apply_marker=False)
 
 
 _LIST_COLUMNS = (

--- a/src/remo_cli/providers/hetzner_descriptor.py
+++ b/src/remo_cli/providers/hetzner_descriptor.py
@@ -46,6 +46,7 @@ DESCRIPTOR = ProviderDescriptor(
     sync_options=(),
     info_options=(),
     extra_commands=(),
+    supports_managed_marker=True,
     snapshot_region_scoped=False,
     snapshot_async=True,
 )

--- a/src/remo_cli/providers/incus.py
+++ b/src/remo_cli/providers/incus.py
@@ -378,6 +378,7 @@ def update(
     tools_only: tuple[str, ...] = (),
     tools_skip: tuple[str, ...] = (),
     verbose: bool = False,
+    apply_marker: bool = True,
 ) -> None:
     """Re-configure dev tools on an existing Incus container.
 
@@ -388,6 +389,13 @@ def update(
     Raises :class:`PreconditionError` if the container's IP could not be
     resolved, or :class:`OperationFailedError` on a nonzero
     ansible-playbook rc.
+    
+    *apply_marker* gates the managed-marker backfill. Explicit
+    ``remo incus update`` backfills it (True); ``update_entry`` -- the
+    ``remo shell`` tools-update path -- passes False, so `remo shell` never
+    performs a provider-side write the user did not ask for. Instances that
+    predate tagging are pointed at ``sync`` by the one-time post-migration
+    notice instead (core/known_hosts._print_tagging_notice).
     """
     validate_name(name, "container name")
     guard_not_added_ssh_host(name, "incus")  # FR-012
@@ -401,16 +409,17 @@ def update(
 
     # FR-004: `update` doubles as the backfill path — ensure the managed marker
     # is present (idempotent). FR-005: warn on failure but do not fail update.
-    ok, err = _apply_managed_marker(host, user, name)
-    if not ok:
-        print_warning(
-            f"Could not mark container '{name}' as remo-managed on Incus host "
-            f"'{host}' ({_host_access_desc(host, user)}, needed for "
-            f"`incus config set`): {err}\n"
-            f"  This is a host-side bookkeeping step only — the update itself "
-            f"continues. Until the marker is set, a default `remo incus sync` "
-            f"will skip it; use `remo incus sync --all`."
-        )
+    if apply_marker:
+        ok, err = _apply_managed_marker(host, user, name)
+        if not ok:
+            print_warning(
+                f"Could not mark container '{name}' as remo-managed on Incus "
+                f"host '{host}' ({_host_access_desc(host, user)}, needed for "
+                f"`incus config set`): {err}\n"
+                f"  This is a host-side bookkeeping step only — the update "
+                f"itself continues. Until the marker is set, a default "
+                f"`remo incus sync` will skip it; use `remo incus sync --all`."
+            )
 
     if volume_size or cores or memory:
         bits: list[str] = []
@@ -470,7 +479,13 @@ def update_entry(entry: KnownHost, *, verbose: bool = False) -> None:
     incus_host, sep, container = entry.name.partition("/")
     if not sep:
         incus_host, container = "localhost", entry.name
-    update(name=container, host=incus_host, user=entry.instance_id, verbose=verbose)
+    update(
+        name=container,
+        host=incus_host,
+        user=entry.instance_id,
+        verbose=verbose,
+        apply_marker=False,
+    )
 
 
 def _split_host_container(entry: KnownHost) -> tuple[str, str]:

--- a/src/remo_cli/providers/incus.py
+++ b/src/remo_cli/providers/incus.py
@@ -296,9 +296,13 @@ def create(
     ok, err = _apply_managed_marker(host, user, name)
     if not ok:
         print_warning(
-            f"Container '{name}' was created but could not be marked as "
-            f"remo-managed ({err}). A default `remo incus sync` will skip "
-            f"it; use `--all` or re-run `remo incus update` to include it."
+            f"Container '{name}' was created, but could not be marked as "
+            f"remo-managed on Incus host '{host}' "
+            f"({_host_access_desc(host, user)}, needed for "
+            f"`incus config set`): {err}\n"
+            f"  The container is fine. Until the marker is set, a default "
+            f"`remo incus sync` will skip it; use `--all` or re-run "
+            f"`remo incus update` to include it."
         )
 
     if volume_size or cores or memory:
@@ -400,8 +404,12 @@ def update(
     ok, err = _apply_managed_marker(host, user, name)
     if not ok:
         print_warning(
-            f"Could not mark container '{name}' as remo-managed ({err}); "
-            f"it may not be picked up by a default `remo incus sync`."
+            f"Could not mark container '{name}' as remo-managed on Incus host "
+            f"'{host}' ({_host_access_desc(host, user)}, needed for "
+            f"`incus config set`): {err}\n"
+            f"  This is a host-side bookkeeping step only — the update itself "
+            f"continues. Until the marker is set, a default `remo incus sync` "
+            f"will skip it; use `remo incus sync --all`."
         )
 
     if volume_size or cores or memory:
@@ -694,6 +702,19 @@ def bootstrap(
 # ---------------------------------------------------------------------------
 # Snapshots
 # ---------------------------------------------------------------------------
+
+
+def _host_access_desc(host: str, user: str) -> str:
+    """Describe how :func:`_ssh_run_on_incus_host` reaches *host*, for warnings.
+
+    Mirrors that helper's localhost branch: host-side work on ``localhost``
+    runs as a local subprocess, so a warning must not claim an SSH hop that
+    never happened. An empty *user* means "let ssh_config decide" and prints
+    as a bare host, not ``@host``.
+    """
+    if host == "localhost":
+        return "locally"
+    return f"over ssh {user}@{host}" if user else f"over ssh {host}"
 
 
 def _ssh_run_on_incus_host(

--- a/src/remo_cli/providers/incus_descriptor.py
+++ b/src/remo_cli/providers/incus_descriptor.py
@@ -88,6 +88,7 @@ DESCRIPTOR = ProviderDescriptor(
         replace(HOST, default=""),
         HOST_USER,
     ),
+    supports_managed_marker=True,
     snapshot_region_scoped=False,
     extra_commands=(
         CommandSpec(

--- a/src/remo_cli/providers/incus_descriptor.py
+++ b/src/remo_cli/providers/incus_descriptor.py
@@ -39,6 +39,17 @@ NETWORK_TYPE = OptionSpec(
     help="Network type for Incus host.",
 )
 
+# The shared catalog's USER reads "SSH user for the remote host", which is
+# ambiguous here: for Incus it is the login on the *Incus host*, used to run
+# host-side `incus` commands -- NOT the account you land in inside the
+# container (that is always `remo`, set at create/sync time and not
+# configurable). Overridden so `--help` says which of the two machines it means.
+HOST_USER = replace(
+    USER,
+    help="SSH user on the Incus host, for host-side incus commands. "
+    "Not the container login, which is always 'remo'.",
+)
+
 DESCRIPTOR = ProviderDescriptor(
     type_name="incus",
     display_name="Incus",
@@ -50,7 +61,7 @@ DESCRIPTOR = ProviderDescriptor(
     sdk_extra=None,
     create_options=(
         replace(HOST, default="localhost"),
-        USER,
+        HOST_USER,
         DOMAIN,
         IMAGE,
         CORES,
@@ -59,23 +70,23 @@ DESCRIPTOR = ProviderDescriptor(
     ),
     update_options=(
         replace(HOST, default=""),
-        USER,
+        HOST_USER,
         CORES,
         MEMORY,
     ),
     destroy_options=(
         replace(HOST, default=""),
-        USER,
+        HOST_USER,
         REMOVE_STORAGE,
     ),
     sync_options=(
         replace(HOST, default="localhost"),
-        USER,
+        HOST_USER,
         USE_IP,
     ),
     info_options=(
         replace(HOST, default=""),
-        USER,
+        HOST_USER,
     ),
     snapshot_region_scoped=False,
     extra_commands=(
@@ -85,7 +96,7 @@ DESCRIPTOR = ProviderDescriptor(
             impl="bootstrap",
             options=(
                 replace(HOST, default="localhost"),
-                USER,
+                HOST_USER,
                 NETWORK_TYPE,
                 VERBOSE,
             ),

--- a/src/remo_cli/providers/proxmox.py
+++ b/src/remo_cli/providers/proxmox.py
@@ -507,6 +507,7 @@ def update(
     tools_skip: tuple[str, ...] = (),
     devcontainer_runtime: str | None = None,
     verbose: bool = False,
+    apply_marker: bool = True,
 ) -> None:
     """Re-configure dev tools on an existing Proxmox LXC container.
 
@@ -515,6 +516,13 @@ def update(
     dev-tools configure playbook.
 
     Raises :class:`OperationFailedError` on a nonzero playbook rc.
+    
+    *apply_marker* gates the managed-marker backfill. Explicit
+    ``remo proxmox update`` backfills it (True); ``update_entry`` -- the
+    ``remo shell`` tools-update path -- passes False, so `remo shell` never
+    performs a provider-side write the user did not ask for. Instances that
+    predate tagging are pointed at ``sync`` by the one-time post-migration
+    notice instead (core/known_hosts._print_tagging_notice).
     """
     validate_name(name, "container name")
     guard_not_added_ssh_host(name, "proxmox")  # FR-012
@@ -538,27 +546,33 @@ def update(
     # FR-004: `update` is the backfill path — ensure the managed marker is
     # present (idempotent, preserving existing tags). FR-005: warn on failure
     # but do not fail update. Resolve the VMID if the registry did not have it.
-    if not vmid:
+    # Resolve the VMID only when something actually needs it — tagging below,
+    # or a resize. Resolving costs an SSH round-trip to the node, and a
+    # tools-only update from `remo shell` needs neither, so it must not pay for
+    # one. (`_resolve_container_ip` further down resolves lazily on its own if
+    # the registry has no cached address.)
+    if not vmid and (apply_marker or volume_size or cores or memory):
         vmid = _resolve_vmid(name, host, user)
-    if vmid:
-        ok, err = _apply_managed_marker(host, user, vmid)
-        if not ok:
+
+    if apply_marker:
+        if vmid:
+            ok, err = _apply_managed_marker(host, user, vmid)
+            if not ok:
+                print_warning(
+                    f"Could not tag container '{name}' as remo-managed on "
+                    f"Proxmox node '{host}' ({_node_access_desc(host, user)}, "
+                    f"needed for `pct set`): {err}\n"
+                    f"  This is a node-side bookkeeping step only — the update "
+                    f"itself continues. Until '{name}' carries the "
+                    f"'{PROXMOX_MANAGED_TAG}' tag, a default `remo proxmox "
+                    f"sync` will skip it; use `remo proxmox sync --all`, or "
+                    f"add the tag in the Proxmox UI."
+                )
+        else:
             print_warning(
-                f"Could not tag container '{name}' as remo-managed on Proxmox "
-                f"node '{host}' ({_node_access_desc(host, user)}, needed for "
-                f"`pct set`): "
-                f"{err}\n"
-                f"  This is a node-side bookkeeping step only — the update "
-                f"itself continues. Until '{name}' carries the "
-                f"'{PROXMOX_MANAGED_TAG}' tag, a default `remo proxmox sync` "
-                f"will skip it; use `remo proxmox sync --all`, or add the tag "
-                f"in the Proxmox UI."
+                f"Could not resolve a VMID for '{name}'; it was not marked as "
+                f"remo-managed."
             )
-    else:
-        print_warning(
-            f"Could not resolve a VMID for '{name}'; it was not marked as "
-            f"remo-managed."
-        )
 
     if volume_size or cores or memory:
         bits: list[str] = []
@@ -614,7 +628,13 @@ def update_entry(entry: KnownHost, *, verbose: bool = False) -> None:
     node_host, sep, container = entry.name.partition("/")
     if not sep:
         node_host, container = "", entry.name
-    update(name=container, host=node_host, user=entry.region, verbose=verbose)
+    update(
+        name=container,
+        host=node_host,
+        user=entry.region,
+        verbose=verbose,
+        apply_marker=False,
+    )
 
 
 def _split_node_container(entry: KnownHost) -> tuple[str, str]:

--- a/src/remo_cli/providers/proxmox.py
+++ b/src/remo_cli/providers/proxmox.py
@@ -71,6 +71,28 @@ def _lookup_proxmox_host(name: str) -> tuple[str, str, str]:
     return "", "", ""
 
 
+def _ssh_target(host: str, user: str) -> str:
+    """Render the SSH destination exactly as :func:`_ssh_run` builds it.
+
+    Kept in lockstep with ``_ssh_run`` so a warning never advertises a
+    destination we did not actually try (an empty *user* means "let ssh_config
+    decide", which prints as a bare host, not ``@host``).
+    """
+    return f"{user}@{host}" if user else host
+
+
+def _node_access_desc(host: str, user: str) -> str:
+    """Describe how :func:`_run_on_node` reaches *host*, for warning text.
+
+    Mirrors ``_run_on_node``'s localhost branch: node-side work on
+    ``localhost`` runs as a local subprocess, so a warning must not claim an
+    SSH hop that never happened.
+    """
+    if host == "localhost":
+        return "locally"
+    return f"over ssh {_ssh_target(host, user)}"
+
+
 def _ssh_run(host: str, user: str, command: str) -> subprocess.CompletedProcess[str]:
     """Run *command* on *host* via SSH and return the completed process.
 
@@ -383,8 +405,12 @@ def create(
         ok, err = _apply_managed_marker(host, user, vmid)
         if not ok:
             print_warning(
-                f"Container '{name}' was created but could not be marked "
-                f"as remo-managed ({err}); a default `remo proxmox sync` "
+                f"Container '{name}' was created, but could not be tagged as "
+                f"remo-managed on Proxmox node '{host}' "
+                f"({_node_access_desc(host, user)}, needed for `pct set`): "
+                f"{err}\n"
+                f"  The container is fine. Until it carries the "
+                f"'{PROXMOX_MANAGED_TAG}' tag, a default `remo proxmox sync` "
                 f"will skip it (use `--all` or `remo proxmox update`)."
             )
     else:
@@ -518,8 +544,15 @@ def update(
         ok, err = _apply_managed_marker(host, user, vmid)
         if not ok:
             print_warning(
-                f"Could not mark container '{name}' as remo-managed ({err}); "
-                f"it may not be picked up by a default `remo proxmox sync`."
+                f"Could not tag container '{name}' as remo-managed on Proxmox "
+                f"node '{host}' ({_node_access_desc(host, user)}, needed for "
+                f"`pct set`): "
+                f"{err}\n"
+                f"  This is a node-side bookkeeping step only — the update "
+                f"itself continues. Until '{name}' carries the "
+                f"'{PROXMOX_MANAGED_TAG}' tag, a default `remo proxmox sync` "
+                f"will skip it; use `remo proxmox sync --all`, or add the tag "
+                f"in the Proxmox UI."
             )
     else:
         print_warning(

--- a/src/remo_cli/providers/proxmox_descriptor.py
+++ b/src/remo_cli/providers/proxmox_descriptor.py
@@ -109,6 +109,7 @@ DESCRIPTOR = ProviderDescriptor(
         replace(HOST, default=""),
         _NODE_USER,
     ),
+    supports_managed_marker=True,
     snapshot_region_scoped=False,
     extra_commands=(
         CommandSpec(

--- a/src/remo_cli/providers/proxmox_descriptor.py
+++ b/src/remo_cli/providers/proxmox_descriptor.py
@@ -27,6 +27,17 @@ from remo_cli.core.provider_registry import (
     ProviderDescriptor,
 )
 
+# The shared catalog's USER reads "SSH user for the remote host", which is
+# ambiguous here: for Proxmox it is the login on the *hypervisor node*, used to
+# run host-side `pct` commands -- NOT the account you land in inside the
+# container (that is always `remo`, set at create/sync time and not
+# configurable). Overridden so `--help` says which of the two machines it means.
+_NODE_USER = replace(
+    USER,
+    help="SSH user on the Proxmox node, for host-side pct commands "
+    "(default: root). Not the container login, which is always 'remo'.",
+)
+
 _NODE = OptionSpec(
     name="--node", param="node", default="", help="Proxmox cluster node name (default: --host)."
 )
@@ -65,7 +76,7 @@ DESCRIPTOR = ProviderDescriptor(
     sdk_extra=None,
     create_options=(
         replace(HOST, required=True, default=None),
-        USER,
+        _NODE_USER,
         _NODE,
         _BRIDGE,
         _STORAGE,
@@ -79,24 +90,24 @@ DESCRIPTOR = ProviderDescriptor(
     ),
     update_options=(
         replace(HOST, default=""),
-        USER,
+        _NODE_USER,
         CORES,
         MEMORY,
         DEVCONTAINER_RUNTIME,
     ),
     destroy_options=(
         replace(HOST, default=""),
-        USER,
+        _NODE_USER,
         _PURGE,
     ),
     sync_options=(
         replace(HOST, required=True, default=None),
-        USER,
+        _NODE_USER,
         USE_IP,
     ),
     info_options=(
         replace(HOST, default=""),
-        USER,
+        _NODE_USER,
     ),
     snapshot_region_scoped=False,
     extra_commands=(
@@ -106,7 +117,7 @@ DESCRIPTOR = ProviderDescriptor(
             impl="bootstrap",
             options=(
                 replace(HOST, required=True, default=None),
-                USER,
+                _NODE_USER,
                 _BRIDGE,
                 _STORAGE,
                 _TEMPLATE,

--- a/tests/unit/core/test_migration_tagging_notice.py
+++ b/tests/unit/core/test_migration_tagging_notice.py
@@ -1,0 +1,89 @@
+"""The one-time post-migration tagging notice (see
+core/known_hosts._print_tagging_notice).
+
+Managed tagging (feature 013) and registry v2 (feature 015) are unrelated
+features that ship in the same release, so every instance in a migrating
+registry predates tagging. Migration is the one event that reaches exactly
+that population exactly once, which is why the notice rides along there
+instead of being backfilled implicitly by `remo shell`.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+
+from remo_cli.core import known_hosts
+from remo_cli.core.registry import MigrationReport
+
+
+@pytest.fixture(autouse=True)
+def _reset_notice_latch():
+    """The notice is latched to fire once per process; unlatch per test."""
+    known_hosts._migration_notice_shown = False
+    yield
+    known_hosts._migration_notice_shown = False
+
+
+_ANSI = re.compile(r"\x1b\[[0-9;]*m")
+
+
+def _plain(captured) -> str:
+    """print_info colorizes; assertions are about wording, not escapes."""
+    return _ANSI.sub("", captured.out)
+
+
+def _report(*types: str) -> MigrationReport:
+    return MigrationReport(
+        migrated_count=len(types),
+        backup_path=Path("known_hosts.v1.bak"),
+        skipped_lines=[],
+        migrated_types=tuple(sorted(types)),
+    )
+
+
+def test_names_only_the_providers_present(capsys):
+    known_hosts._print_tagging_notice(_report("proxmox"))
+    out = _plain(capsys.readouterr())
+    assert "remo proxmox sync --host <host>" in out
+    # Not a menu of every provider -- only what the user actually has.
+    assert "incus" not in out
+    assert "hetzner" not in out
+
+
+def test_host_scoped_providers_get_the_host_flag(capsys):
+    known_hosts._print_tagging_notice(_report("incus", "hetzner"))
+    out = _plain(capsys.readouterr())
+    assert "remo incus sync --host <host>" in out
+    # hetzner is flat-named: suggesting --host there would be wrong.
+    assert "remo hetzner sync\n" in out
+
+
+def test_silent_when_no_provider_supports_tagging(capsys):
+    # aws has no managed-marker backfill; ssh is not a provider at all.
+    known_hosts._print_tagging_notice(_report("aws", "ssh"))
+    assert _plain(capsys.readouterr()) == ""
+
+
+def test_silent_on_an_empty_migration(capsys):
+    known_hosts._print_tagging_notice(_report())
+    assert _plain(capsys.readouterr()) == ""
+
+
+def test_hedges_because_tag_state_is_unknowable_offline(capsys):
+    """We cannot know an instance's tag state without reaching the provider --
+    which is the access this whole change removes. The wording must not claim
+    certainty it does not have."""
+    known_hosts._print_tagging_notice(_report("proxmox"))
+    out = _plain(capsys.readouterr())
+    assert "may not be tagged" in out
+    assert "are not tagged" not in out
+
+
+def test_rides_along_with_the_main_migration_notice(capsys):
+    known_hosts._print_migration_notice(_report("proxmox"))
+    out = _plain(capsys.readouterr())
+    assert "Migrated 1 registry entry" in out
+    assert "remo proxmox sync" in out

--- a/tests/unit/providers/test_hetzner_entry_adapters.py
+++ b/tests/unit/providers/test_hetzner_entry_adapters.py
@@ -35,12 +35,12 @@ class TestUpdateEntry:
         spy = mocker.patch("remo_cli.providers.hetzner.update", return_value=None)
         result = providers_hetzner.update_entry(_entry(), verbose=True)
         assert result is None
-        spy.assert_called_once_with(name="dev1", verbose=True)
+        spy.assert_called_once_with(name="dev1", verbose=True, apply_marker=False)
 
     def test_default_verbose_false(self, mocker):
         spy = mocker.patch("remo_cli.providers.hetzner.update", return_value=None)
         providers_hetzner.update_entry(_entry())
-        spy.assert_called_once_with(name="dev1", verbose=False)
+        spy.assert_called_once_with(name="dev1", verbose=False, apply_marker=False)
 
     def test_update_failure_propagates(self, mocker):
         mocker.patch(

--- a/tests/unit/providers/test_incus_entry_adapters.py
+++ b/tests/unit/providers/test_incus_entry_adapters.py
@@ -42,14 +42,14 @@ class TestUpdateEntry:
         result = providers_incus.update_entry(_entry(), verbose=True)
         assert result is None
         spy.assert_called_once_with(
-            name="dev1", host="lab1", user="root", verbose=True
+            name="dev1", host="lab1", user="root", verbose=True, apply_marker=False
         )
 
     def test_localhost_entry_parses_host_and_container(self, mocker):
         spy = mocker.patch("remo_cli.providers.incus.update", return_value=0)
         providers_incus.update_entry(_entry(name="localhost/dev2", instance_id=""))
         spy.assert_called_once_with(
-            name="dev2", host="localhost", user="", verbose=False
+            name="dev2", host="localhost", user="", verbose=False, apply_marker=False
         )
 
     def test_underlying_failure_propagates(self, mocker):

--- a/tests/unit/providers/test_incus_marker.py
+++ b/tests/unit/providers/test_incus_marker.py
@@ -15,6 +15,7 @@ import pytest
 
 from remo_cli.core.errors import OperationFailedError
 from remo_cli.providers import incus as providers_incus
+from remo_cli.models.host import KnownHost
 
 
 def _completed(rc: int, stdout: str = "", stderr: str = "") -> MagicMock:
@@ -136,3 +137,40 @@ class TestUpdateBackfill:
         )
         providers_incus.update(name="dev1", host="h", user="u")
         apply.assert_called_once_with("h", "u", "dev1")
+
+
+class TestUpdateEntryDoesNotTouchHost:
+    """`remo shell`'s tools-update path must not write host-side state."""
+
+    def _patch_update_internals(self, mocker):
+        mocker.patch(
+            "remo_cli.providers.incus._resolve_container_ip", return_value="10.0.0.9"
+        )
+        mocker.patch("remo_cli.providers.incus.run_playbook", return_value=0)
+        mocker.patch("remo_cli.core.ssh.detect_timezone", return_value="")
+        mocker.patch(
+            "remo_cli.core.version.get_current_version", return_value="unknown"
+        )
+        return mocker.patch(
+            "remo_cli.providers.incus._apply_managed_marker",
+            return_value=(True, ""),
+        )
+
+    def test_update_entry_skips_marker(self, mocker):
+        apply = self._patch_update_internals(mocker)
+        entry = KnownHost(
+            type="incus",
+            name="myhost/dev1",
+            host="10.0.0.9",
+            user="remo",
+            instance_id="paul",
+            access_mode="direct",
+            region="",
+        )
+        providers_incus.update_entry(entry)
+        apply.assert_not_called()
+
+    def test_explicit_update_still_backfills(self, mocker):
+        apply = self._patch_update_internals(mocker)
+        providers_incus.update(name="dev1", host="myhost", user="paul")
+        apply.assert_called_once_with("myhost", "paul", "dev1")

--- a/tests/unit/providers/test_provider_conformance.py
+++ b/tests/unit/providers/test_provider_conformance.py
@@ -101,6 +101,14 @@ def test_descriptor_signature_conformance(type_name: str, registered: None) -> N
         if verb == "create":
             # --yes is accepted (deprecated) but never forwarded to impl.
             click_params.discard("auto_confirm")
+        if verb == "update":
+            # `apply_marker` is deliberately internal: it gates the
+            # managed-marker backfill so `update_entry` (the `remo shell`
+            # tools-update path) can decline a provider-side write the user
+            # never asked for. Exposing it as a flag would be noise. Named
+            # explicitly rather than loosening the rule, so any *other*
+            # impl-only parameter still fails this gate.
+            sig_params.discard("apply_marker")
         assert click_params <= sig_params, (
             f"{type_name} {verb}: CLI declares params impl doesn't accept: {click_params - sig_params}"
         )

--- a/tests/unit/providers/test_proxmox_marker.py
+++ b/tests/unit/providers/test_proxmox_marker.py
@@ -13,6 +13,7 @@ import pytest
 
 from remo_cli.core.errors import OperationFailedError
 from remo_cli.providers import proxmox as providers_proxmox
+from remo_cli.models.host import KnownHost
 
 
 def _completed(rc: int, stdout: str = "", stderr: str = "") -> MagicMock:
@@ -165,6 +166,72 @@ class TestCreateUpdateWiring:
         )
         result = providers_proxmox.update(name="dev1", host="node", user="root")
         assert result is None
+        apply.assert_called_once_with("node", "root", "100")
+
+    def test_update_entry_does_not_touch_the_node(self, mocker):
+        """`remo shell`'s tools-update path must not write provider-side state.
+
+        update_entry is the ONLY caller of update() from `remo shell`
+        (cli/shell.py). Tagging is a node-side write over SSH to the
+        hypervisor -- a machine the user never named at the prompt -- so it is
+        gated off here and the post-migration notice points at `sync` instead.
+        """
+        resolve_vmid = mocker.patch(
+            "remo_cli.providers.proxmox._resolve_vmid", return_value="100"
+        )
+        mocker.patch(
+            "remo_cli.providers.proxmox._resolve_container_ip", return_value="10.0.0.9"
+        )
+        mocker.patch("remo_cli.providers.proxmox.run_playbook", return_value=0)
+        mocker.patch("remo_cli.core.ssh.detect_timezone", return_value="")
+        mocker.patch(
+            "remo_cli.core.version.get_current_version", return_value="unknown"
+        )
+        mocker.patch(
+            "remo_cli.providers.proxmox.resolve_devcontainer_runtime",
+            return_value="devcontainer",
+        )
+        apply = mocker.patch(
+            "remo_cli.providers.proxmox._apply_managed_marker",
+            return_value=(True, ""),
+        )
+
+        entry = KnownHost(
+            type="proxmox",
+            name="node/dev1",
+            host="10.0.0.9",
+            user="remo",
+            instance_id="100",
+            access_mode="direct",
+            region="root",
+        )
+        providers_proxmox.update_entry(entry)
+
+        apply.assert_not_called()
+        # The VMID is only needed for tagging or a resize; neither applies, so
+        # the SSH round-trip that resolves it must not happen either.
+        resolve_vmid.assert_not_called()
+
+    def test_explicit_update_still_backfills(self, mocker):
+        """The gate must not disarm the explicit `remo proxmox update` path."""
+        mocker.patch("remo_cli.providers.proxmox._resolve_vmid", return_value="100")
+        mocker.patch(
+            "remo_cli.providers.proxmox._resolve_container_ip", return_value="10.0.0.9"
+        )
+        mocker.patch("remo_cli.providers.proxmox.run_playbook", return_value=0)
+        mocker.patch("remo_cli.core.ssh.detect_timezone", return_value="")
+        mocker.patch(
+            "remo_cli.core.version.get_current_version", return_value="unknown"
+        )
+        mocker.patch(
+            "remo_cli.providers.proxmox.resolve_devcontainer_runtime",
+            return_value="devcontainer",
+        )
+        apply = mocker.patch(
+            "remo_cli.providers.proxmox._apply_managed_marker",
+            return_value=(True, ""),
+        )
+        providers_proxmox.update(name="dev1", host="node", user="root")
         apply.assert_called_once_with("node", "root", "100")
 
 

--- a/tests/unit/providers/test_proxmox_provider_protocol.py
+++ b/tests/unit/providers/test_proxmox_provider_protocol.py
@@ -53,7 +53,9 @@ class TestUpdateEntry:
         spy = mocker.patch("remo_cli.providers.proxmox.update", return_value=None)
         result = providers_proxmox.update_entry(_entry(), verbose=True)
         assert result is None
-        spy.assert_called_once_with(name="dev1", host="lab1", user="root", verbose=True)
+        spy.assert_called_once_with(
+            name="dev1", host="lab1", user="root", verbose=True, apply_marker=False
+        )
 
     def test_failure_raises_operation_failed_error(self, mocker):
         mocker.patch(


### PR DESCRIPTION
## Why

A `remo shell` update prompt warned it couldn't tag a container as remo-managed because a Tailscale SSH policy blocked `root`. The natural reading was *"why isn't it using the `remo` user?"* — but the SSH was to the **Proxmox node**, not the container. Two separate problems produced that confusion, and this PR fixes both.

## 1. `--user` never said which machine it meant — `edce970`

All four descriptors used the shared catalog's `USER` verbatim (`SSH user for the remote host.`); there was not a single `replace(USER, help=...)` in the tree. For incus/proxmox it's the login on the **hypervisor host**, while the container login is always `remo`, hardcoded and not configurable.

```
--user TEXT   SSH user on the Proxmox node, for host-side pct commands
              (default: root). Not the container login, which is always 'remo'.
```

Not an SC-002 concern: `--user` was never in the shared-uniformity set (only 2 of 4 providers take it), and `test_cli_uniformity.py` still passes.

All four managed-marker warnings now name the host, how it's reached, and which command needed it. New `_node_access_desc` / `_host_access_desc` render that destination the way `_run_on_node` / `_ssh_run_on_incus_host` actually build it — `"locally"` for a `localhost` host, and a bare host rather than `@host` when user is empty. A warning must never advertise a destination we didn't try.

Docs updated, including `docs/proxmox.md`'s create-table default, which claimed `(current user)` — true of the SSH `create` performs, but not of what it *records*.

## 2. `remo shell` silently wrote provider-side state — `20bf258`

The prompt promised a container-side tools update and also tagged the instance: incus/proxmox over SSH to the hypervisor, hetzner via API. You consented to one thing and got two.

The backfill exists for a real reason (FR-004: instances predating #76 carry no marker, so a default `sync` skips them). This **moves the message rather than dropping the capability**:

- `update()` on incus/proxmox/hetzner takes `apply_marker: bool = True`. `update_entry` — the only caller from `cli/shell.py` — passes `False`. Explicit `remo <type> update` and `sync` still tag, unchanged.
- A **one-time post-migration notice** names the providers actually present and the `sync` command that tags them.
- Proxmox also no longer resolves the VMID on the shell path — it cost an SSH round-trip to the node but is needed only for tagging or a resize.

### Why the migration is the right hook

Managed tagging (#76) and registry v2 (#85) both landed after `v2.2.0` and ship together in 3.0.0 — verified against the tag. So every migrating registry predates tagging, and migration is the one event that reaches exactly that population exactly once. The coupling isn't opportunistic; it's the same users at the same moment.

The notice hedges (*"may not be tagged"*) because tag state is unknowable without reaching the provider — the very access being removed. There's a test pinning that wording.

### Supporting changes

`MigrationReport` gains `migrated_types` so the notice names real providers instead of listing all four. `ProviderDescriptor` gains `supports_managed_marker`, keeping the incus/proxmox/hetzner-vs-aws distinction in descriptors rather than as type literals in `core/` (Principle II).

### The conformance gate pushed back, correctly

`test_descriptor_signature_conformance` asserts impl params ⊆ CLI-suppliable params, and rejected `apply_marker`. Rather than loosen the rule, it discards that one name on `update` with a comment, mirroring the existing `auto_confirm` exception — so any *other* impl-only parameter still fails.

## ⚠️ Behavior change for the 3.0.0 release notes

An instance created before tagging existed now stays unmarked until `sync` or an explicit `update` runs. Previously any `remo shell` would have quietly fixed it. `sync` already names unmarked instances and prints the remedy, so this is visible rather than silent — but it belongs in the changelog next to the `--yes` removal.

## Documented, deliberately not changed

Proxmox `create`/`sync` leave `--user` empty (so `ssh_config` decides who connects) yet **record `node_user: root`** via `region=user or "root"`. Later commands read that back, so a container created as *you* is reached as `root`. Incus stores the user verbatim and has no such fallback.

Separately, proxmox's probe never populates `DiscoveredHost.observed`, so `merge_entry` falls to legacy semantics and a `sync` overwrites a hand-edited `node_user` — a live instance of the #87 class that feature 018 added `observed` to prevent. Notably `merge_entry` already protects the *container* `user` field explicitly; `region` got no such guard.

Both are left for a separate change since they alter existing registry contents. Flagged in `docs/proxmox.md` with the workaround.

## Verification

Unit suite **1725 passed / 2 skipped**; ruff and mypy clean; rendered `--help` checked on all four providers.

The 8 remaining failures in `tests/integration` are Docker-based and **pre-existing** — reproduced on a clean `HEAD` via `git stash` (and flaky: 2 failures standalone vs 6 under full-suite load).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ER1fspJAScAo1o4jGdjuJE
