### PR TITLE
feat(cli): warn when fish won't autoload the completion we just wrote

### DIFF
--- a/src/remo_cli/cli/main.py
+++ b/src/remo_cli/cli/main.py
@@ -208,7 +208,11 @@ def completion_install(shell: str | None, yes: bool) -> None:
     fish needs no rc change — its completions directory is loaded
     automatically.
     """
-    from remo_cli.core.completion import detect_shell, install
+    from remo_cli.core.completion import (
+        detect_shell,
+        fish_autoload_problem,
+        install,
+    )
     from remo_cli.core.output import print_info, print_success, print_warning
 
     if shell is None:
@@ -237,6 +241,12 @@ def completion_install(shell: str | None, yes: bool) -> None:
         print_info(f"Completion script already current: {outcome.script_path}")
 
     if outcome.rc_path is None:
+        # fish needs no rc edit, but "wrote the file" is not the same as "fish
+        # will read it" — and when it won't, the failure is completely silent.
+        problem = fish_autoload_problem(outcome.script_path)
+        if problem:
+            print_warning(problem)
+            return
         print_info("Start a new shell (or run `exec fish`) to pick it up.")
         return
 

--- a/src/remo_cli/core/completion.py
+++ b/src/remo_cli/core/completion.py
@@ -191,6 +191,67 @@ def stale_shells(current_version: str, *, home: Path | None = None) -> list[str]
     return [s for s in SHELLS if is_stale(s, current_version, home=home)]
 
 
+def fish_autoload_problem(script_path: Path) -> str | None:
+    """Warn when fish will not autoload the script we just wrote.
+
+    A correct script in a directory fish does not read fails *identically* to a
+    broken script: fish silently completes filenames instead. There is no error,
+    and `remo completion install` otherwise reports success — so the user is
+    told everything worked while nothing does. Issue #116 was exactly this, and
+    took a day to find precisely because the failure is mute.
+
+    Asks fish what it actually reads rather than reasoning about it, so this
+    catches any cause — an exported `fish_complete_path`, a config that
+    overwrites it, a path we got wrong — not just the one that prompted it.
+
+    Returns None when everything is fine, or when fish is absent (nothing to
+    verify against, and installing for a shell you don't have is legitimate).
+    """
+    try:
+        proc = subprocess.run(
+            ["fish", "-c", r"printf '%s\n' $fish_complete_path"],
+            capture_output=True,
+            text=True,
+            timeout=5,
+        )
+    except (OSError, subprocess.SubprocessError):
+        return None
+    if proc.returncode != 0:
+        return None
+
+    entries = [line.strip() for line in proc.stdout.splitlines() if line.strip()]
+    if not entries or str(script_path.parent) in entries:
+        return None
+
+    # The specific cause behind #116, worth naming because the remedy is a
+    # one-character edit that is otherwise very hard to arrive at: fish
+    # colon-joins an exported list variable only when its name ends in
+    # uppercase PATH. `fish_complete_path` is lowercase, so an exported copy is
+    # space-joined and every child fish re-imports it as ONE nonexistent
+    # directory — silently losing every user completion at once.
+    exported = os.environ.get("fish_complete_path")
+    if exported and " " in exported:
+        return (
+            f"fish will not load completions from {script_path.parent}.\n"
+            "  `fish_complete_path` is exported in your environment as a single "
+            "space-joined\n"
+            "  string, so every child fish sees one nonexistent directory "
+            "instead of a list.\n"
+            "  Fix: in your fish config use `set -g fish_complete_path ...`, "
+            "not `set -gx`.\n"
+            "  The script itself is fine — completion will simply do nothing "
+            "until that changes."
+        )
+
+    return (
+        f"fish will not load completions from {script_path.parent} — "
+        "it is not in $fish_complete_path.\n"
+        "  The script itself is fine, but completion will silently do nothing.\n"
+        "  Check your fish config for anything that overwrites "
+        "`fish_complete_path`."
+    )
+
+
 def installed_version(shell: str, *, home: Path | None = None) -> str | None:
     """Return the remo version stamped into the installed script, if any.
 

--- a/tests/unit/core/test_completion.py
+++ b/tests/unit/core/test_completion.py
@@ -8,6 +8,7 @@ on never touching an rc file without consent.
 from __future__ import annotations
 
 import os
+import subprocess
 
 import pytest
 
@@ -15,6 +16,7 @@ from remo_cli.core import completion
 from remo_cli.core.completion import (
     SHELLS,
     detect_shell,
+    fish_autoload_problem,
     install,
     installed_version,
     is_stale,
@@ -259,6 +261,84 @@ class TestInstall:
 # ---------------------------------------------------------------------------
 # staleness
 # ---------------------------------------------------------------------------
+
+
+class TestFishAutoloadProblem:
+    """Guards issue #116: a correct script fish never reads fails identically
+    to a broken one — silent fallback to filename completion, with `install`
+    reporting success. The whole point of this check is that the failure is
+    otherwise mute.
+    """
+
+    @staticmethod
+    def _fish_returns(monkeypatch, stdout, returncode=0):
+        def fake_run(cmd, **kwargs):
+            return subprocess.CompletedProcess(cmd, returncode, stdout, "")
+
+        monkeypatch.setattr(subprocess, "run", fake_run)
+
+    def test_silent_when_directory_is_on_the_path(self, monkeypatch, tmp_path):
+        script = tmp_path / "completions" / "remo.fish"
+        self._fish_returns(monkeypatch, f"/other\n{script.parent}\n/more\n")
+        assert fish_autoload_problem(script) is None
+
+    def test_names_the_export_collapse_when_that_is_the_cause(
+        self, monkeypatch, tmp_path
+    ):
+        """fish colon-joins an exported list var only when the name ends in
+        uppercase PATH. `fish_complete_path` is lowercase, so an exported copy
+        is space-joined and every child fish re-imports it as ONE nonexistent
+        directory. The remedy is a one-character edit that is very hard to
+        arrive at unaided, so it is worth naming explicitly."""
+        script = tmp_path / "completions" / "remo.fish"
+        self._fish_returns(monkeypatch, "/collapsed /into /one\n")
+        monkeypatch.setenv("fish_complete_path", "/collapsed /into /one")
+        msg = fish_autoload_problem(script)
+        assert msg is not None
+        assert "set -g fish_complete_path" in msg
+        assert "not `set -gx`" in msg
+        # Must not leave the user thinking they need to reinstall.
+        assert "script itself is fine" in msg
+
+    def test_generic_message_when_not_an_export_problem(self, monkeypatch, tmp_path):
+        script = tmp_path / "completions" / "remo.fish"
+        self._fish_returns(monkeypatch, "/somewhere/else\n")
+        monkeypatch.delenv("fish_complete_path", raising=False)
+        msg = fish_autoload_problem(script)
+        assert msg is not None
+        assert "not in $fish_complete_path" in msg
+        assert "set -gx" not in msg
+
+    def test_single_exported_entry_is_not_flagged_as_collapsed(
+        self, monkeypatch, tmp_path
+    ):
+        """An exported path with one entry round-trips correctly — it is only
+        the space-joining of two or more that produces a bogus element."""
+        script = tmp_path / "completions" / "remo.fish"
+        self._fish_returns(monkeypatch, "/elsewhere\n")
+        monkeypatch.setenv("fish_complete_path", "/elsewhere")
+        msg = fish_autoload_problem(script)
+        assert msg is not None
+        assert "set -gx" not in msg
+
+    def test_missing_fish_is_not_a_problem(self, monkeypatch, tmp_path):
+        """Installing completion for a shell you do not have is legitimate;
+        there is simply nothing to verify against."""
+
+        def boom(cmd, **kwargs):
+            raise FileNotFoundError("fish")
+
+        monkeypatch.setattr(subprocess, "run", boom)
+        assert fish_autoload_problem(tmp_path / "completions" / "remo.fish") is None
+
+    def test_fish_error_is_not_a_problem(self, monkeypatch, tmp_path):
+        self._fish_returns(monkeypatch, "", returncode=127)
+        assert fish_autoload_problem(tmp_path / "completions" / "remo.fish") is None
+
+    def test_empty_output_is_not_a_problem(self, monkeypatch, tmp_path):
+        """Don't turn an unreadable answer into a confident accusation."""
+        self._fish_returns(monkeypatch, "\n")
+        assert fish_autoload_problem(tmp_path / "completions" / "remo.fish") is None
 
 
 class TestStaleness:


### PR DESCRIPTION
Follow-up to #116. That turned out to be an environment problem — `set -gx fish_complete_path` in the reporter's `config.fish` — and needed no remo change. But it took a day to find, and the reason is worth fixing.

## The problem this addresses

A correct script in a directory fish doesn't read fails **identically** to a broken script:

- fish silently completes filenames
- nothing errors
- `remo completion install` reports success

The user is told everything worked while nothing does, with no thread to pull. Every hypothesis in #116 — the script's content, its location, the remo version, the fish version, PATH, `XDG_CONFIG_HOME` — was consistent with the same symptom, because the symptom carries no information.

## What it does

After writing the fish script, ask fish what it actually reads and warn if the directory isn't there:

```
$ remo completion install fish
Wrote completion script: ~/.config/fish/completions/remo.fish
fish will not load completions from ~/.config/fish/completions.
  `fish_complete_path` is exported in your environment as a single space-joined
  string, so every child fish sees one nonexistent directory instead of a list.
  Fix: in your fish config use `set -g fish_complete_path ...`, not `set -gx`.
  The script itself is fine — completion will simply do nothing until that changes.
```

**Asking rather than reasoning** is deliberate: it catches any cause — an exported variable, a config that overwrites it, a path remo got wrong — not just the one that prompted it. Had this existed, #116 would have been one line of output instead of a day.

The export-collapse case gets named specifically because the remedy is close to unfindable unaided: fish colon-joins an exported list variable only when its name ends in uppercase `PATH`. `fish_complete_path` is lowercase, so an exported copy is space-joined and every child fish re-imports it as **one nonexistent directory**, losing every user completion at once. The fix is one character.

## Staying quiet when it should

Silent when fish is absent (installing for a shell you don't have is legitimate), when fish errors, and when it returns nothing — an unreadable answer must not become a confident accusation. Also doesn't flag a single exported entry, which round-trips correctly; only two or more collapse.

fish-only. bash and zsh use an explicit `source` line that `install` already verifies.

## Verification

Reproduced #116's exact condition locally (exported space-joined path → child fish sees 1 element) and confirmed the warning fires with the right remedy. The fish integration suite still passes, which is the false-positive check — the warning must not fire on a healthy setup.

1912 passed / 17 skipped, ruff and mypy clean. Seven unit tests cover the on-path, collapsed-export, generic, single-entry, fish-missing, fish-error, and empty-output branches.

🤖 Generated with [Claude Code](https://claude.com/claude-code)