### PR TITLE
fix(release): keep uv.lock's version in step with the release bump

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -43,6 +43,7 @@ jobs:
           private-key: ${{ secrets.RELEASE_PLEASE_APP_KEY }}
 
       - uses: googleapis/release-please-action@v4
+        id: release
         with:
           # Token precedence:
           #   1. GitHub App installation token (recommended — see above).
@@ -55,3 +56,39 @@ jobs:
           token: ${{ steps.app-token.outputs.token || secrets.RELEASE_PLEASE_TOKEN || secrets.GITHUB_TOKEN }}
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json
+
+      # release-please bumps `pyproject.toml` but knows nothing about uv.lock,
+      # which records the project's own version in its `remo-cli` package entry.
+      # Left alone the two drift apart at every release (3.1.0 shipped with a
+      # lockfile still saying 3.0.0), and the drift then reappears as noise in
+      # the next unrelated PR, because any `uv run` regenerates it.
+      #
+      # Amend the sync onto the release PR itself. release-please force-pushes
+      # its branch whenever it refreshes the PR, which would drop this commit —
+      # but this job runs immediately after that refresh on every push to main,
+      # so the commit is simply re-made. `tests/unit/test_lockfile_version.py`
+      # is the backstop that keeps a drifted lockfile from merging at all.
+      - uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7
+        if: ${{ steps.release.outputs.pr }}
+
+      - name: Sync uv.lock onto the release PR
+        if: ${{ steps.release.outputs.pr }}
+        env:
+          RELEASE_BRANCH: ${{ fromJSON(steps.release.outputs.pr).headBranchName }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token || secrets.RELEASE_PLEASE_TOKEN || secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          git clone --branch "$RELEASE_BRANCH" --depth 1 \
+            "https://x-access-token:${GH_TOKEN}@github.com/${GITHUB_REPOSITORY}.git" release-pr
+          cd release-pr
+          # `uv lock` is not an upgrade: it re-resolves only what the manifest
+          # forces, so the sole change here is the bumped project version.
+          uv lock
+          if git diff --quiet -- uv.lock; then
+            echo "uv.lock already matches the bumped version; nothing to do."
+            exit 0
+          fi
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git commit -m "chore: sync uv.lock with the released version" -- uv.lock
+          git push origin "HEAD:${RELEASE_BRANCH}"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -148,9 +148,12 @@ curl -fsSL https://get2knowio.github.io/remo/install.sh | bash
 >
 > See `.github/workflows/release-please.yml`.
 >
-> **Note:** release-please does not run `uv lock`; if `uv.lock`'s recorded
-> project version matters to you, run `uv lock` and amend it onto the release PR
-> before merging.
+> **`uv.lock` is synced for you.** release-please bumps `pyproject.toml` but
+> knows nothing about `uv.lock`, which records the project's own version too.
+> The workflow now runs `uv lock` against the release branch and commits the
+> result onto the release PR, and `tests/unit/test_lockfile_version.py` fails
+> the build if the two ever disagree — so a drifted lockfile can't merge. If
+> that test does fire, the fix is `uv lock` plus a commit.
 
 ### Version Numbering
 

--- a/tests/unit/test_lockfile_version.py
+++ b/tests/unit/test_lockfile_version.py
@@ -1,0 +1,55 @@
+"""`uv.lock` must record the same project version as `pyproject.toml`.
+
+release-please bumps `pyproject.toml` (via `extra-files` in
+`release-please-config.json`) but knows nothing about `uv.lock`, which carries
+the project's own version in its `remo-cli` package entry. Nothing reconciled
+the two, so every release shipped a lockfile one version behind — 3.1.0 went
+out with a lockfile still saying 3.0.0 — and the drift then surfaced as an
+unrelated one-line diff in whichever PR next ran `uv`, since any `uv` command
+regenerates it.
+
+`.github/workflows/release-please.yml` now amends `uv lock` onto the release PR.
+This test is the backstop: it fails the build if the two ever disagree again,
+whether because that automation was skipped (no App token, a fork) or because
+someone hand-edited a version. The fix is always the same one command, named in
+the failure message.
+"""
+
+from __future__ import annotations
+
+import tomllib
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+PYPROJECT = REPO_ROOT / "pyproject.toml"
+UV_LOCK = REPO_ROOT / "uv.lock"
+
+PACKAGE_NAME = "remo-cli"
+
+
+def _pyproject_version() -> str:
+    return str(tomllib.loads(PYPROJECT.read_text())["project"]["version"])
+
+
+def _locked_version() -> str | None:
+    """The version `uv.lock` records for this project's own package entry."""
+    for package in tomllib.loads(UV_LOCK.read_text()).get("package", []):
+        if package.get("name") == PACKAGE_NAME:
+            version = package.get("version")
+            return None if version is None else str(version)
+    return None
+
+
+def test_lockfile_records_the_project_version() -> None:
+    declared = _pyproject_version()
+    locked = _locked_version()
+
+    assert locked is not None, (
+        f"uv.lock has no `{PACKAGE_NAME}` package entry — the lockfile is not for "
+        "this project. Regenerate it with `uv lock`."
+    )
+    assert locked == declared, (
+        f"uv.lock records {PACKAGE_NAME} {locked} but pyproject.toml declares "
+        f"{declared}. A release bumped one without the other; run `uv lock` and "
+        "commit the result."
+    )

--- a/uv.lock
+++ b/uv.lock
@@ -1038,7 +1038,7 @@ wheels = [
 
 [[package]]
 name = "remo-cli"
-version = "3.0.0"
+version = "3.1.0"
 source = { editable = "." }
 dependencies = [
     { name = "ansible-core" },


### PR DESCRIPTION
release-please bumps `pyproject.toml` via its `extra-files` config, but knows nothing about `uv.lock` — which records the project's own version in its `remo-cli` package entry. Nothing reconciled the two, so **every release ships a lockfile one version behind**: 3.1.0 went out with a lockfile still saying 3.0.0.

The drift doesn't stay put, either. Any `uv` command regenerates the lockfile, so it resurfaces as an unrelated one-line diff in whichever PR next runs one — it turned up in #123 and #124 on its own. `CONTRIBUTING.md` documented it as a manual step, which nobody was doing.

## Automate it

`release-please.yml` gains a step that clones the release branch, runs `uv lock`, and commits the result onto the release PR. `uv lock` is not an upgrade — it re-resolves only what the manifest forces, so the sole change is the bumped project version.

release-please force-pushes its branch whenever it refreshes the PR, which drops that commit. That's fine: the step runs immediately after the action on *every* push to main, so the commit is simply re-made, and the state at merge time is correct.

## Gate it

`tests/unit/test_lockfile_version.py` fails the build when `uv.lock` and `pyproject.toml` disagree, naming the one command that fixes it. That covers what the automation can't reach — no App token, a fork, a hand-edited version — and means a drifted lockfile can't merge even if the workflow step is skipped.

## Also

- Syncs the lockfile 3.1.0 left behind (the same one-line change already riding along in #123 and #124, so they merge cleanly in any order).
- Replaces the CONTRIBUTING.md manual-workaround note with a description of what now happens automatically.

`actionlint` clean on all workflows; full unit suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011A2RNakq6mYPLA8as3pE1t