### PR TITLE
fix(web): make the console's background poll actually re-run discovery

### DIFF
--- a/docs/web-session-interface.md
+++ b/docs/web-session-interface.md
@@ -75,6 +75,10 @@ session-target IDs. Three protocol layers make this work, each documented in ful
   /api/v1/health`, `GET /api/v1/ready`, `GET /api/v1/hosts`, `GET /api/v1/sessions`, `POST
   /api/v1/discovery/refresh`, and `POST`/`GET`/`DELETE /api/v1/terminals`. Terminal creation returns
   an opaque terminal ID plus a short-lived WebSocket token — never a hostname or command.
+  `GET /hosts` and `GET /sessions` only **read** the service's discovery cache; `POST
+  /discovery/refresh` is the only call that repopulates it, which is why the console posts it on a
+  background cadence (with `force: false`, so the cache TTL decides when a run is really due)
+  rather than polling the GETs alone.
 - **Terminal WebSocket protocol** ([`terminal-websocket.md`](../specs/010-web-session-interface/contracts/terminal-websocket.md)) —
   `WS /api/v1/terminals/{terminal_id}`, subprotocol `remo-terminal.v1`. Binary frames carry raw PTY
   bytes in both directions; JSON text frames carry control messages (`resize`, `ready`, `exit`,
@@ -831,7 +835,7 @@ locally with zero configuration; a container overrides everything via env alone.
 | `REMO_WEB_BIND_PORT` | `8080` | Port the server binds to. `--port` on `remo web serve` overrides this per-invocation. |
 | `REMO_WEB_DISCOVERY_CONCURRENCY` | `8` | Maximum number of instances discovered concurrently. |
 | `REMO_WEB_DISCOVERY_TIMEOUT_S` | `10.0` | Per-instance timeout (seconds) for a discovery round-trip before it's classified `timeout`. |
-| `REMO_WEB_DISCOVERY_CACHE_TTL_S` | `30.0` | How long a discovery snapshot is served from cache before the next scheduled refresh; manual refresh (`POST /api/v1/discovery/refresh`) bypasses this. |
+| `REMO_WEB_DISCOVERY_CACHE_TTL_S` | `30.0` | How long a discovery snapshot is served from cache before the console's background poll is allowed to re-run discovery. This — not the console's poll interval, and not how many browser tabs are open — is what sets how often instances are actually contacted. An explicit refresh (`POST /api/v1/discovery/refresh` with the default `force: true`, which is what the Refresh button and the post-terminal-exit refresh send) bypasses it. |
 | `REMO_WEB_TERMINAL_CAP_GLOBAL` | `32` | Maximum concurrent terminal attachments across all clients. |
 | `REMO_WEB_TERMINAL_CAP_PER_CLIENT` | `16` | Maximum concurrent terminal attachments for a single client. |
 | `REMO_WEB_WS_TOKEN_TTL_S` | `30.0` | Seconds a single-use WebSocket terminal token remains valid between issuance and successful upgrade. |

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -198,10 +198,28 @@ export async function getSessions(): Promise<SessionsResponse> {
   return request<SessionsResponse>("/api/v1/sessions", { method: "GET" });
 }
 
-export async function refreshDiscovery(instanceId?: string): Promise<RefreshResponse> {
+/**
+ * Trigger a server-side discovery run. `GET /hosts` and `GET /sessions` only
+ * READ the service's cache — this is the only call that repopulates it.
+ *
+ * `force: false` asks for a TTL-gated run (no-op while the cache is fresh),
+ * which is what the background poll sends so a long-lived page stays current
+ * without every tick costing an SSH round trip to every instance.
+ */
+export async function refreshDiscovery(
+  instanceId?: string,
+  options?: { force?: boolean },
+): Promise<RefreshResponse> {
+  const body: { instance_id?: string; force?: boolean } = {};
+  if (instanceId) {
+    body.instance_id = instanceId;
+  }
+  if (options?.force === false) {
+    body.force = false;
+  }
   return request<RefreshResponse>("/api/v1/discovery/refresh", {
     method: "POST",
-    body: instanceId ? JSON.stringify({ instance_id: instanceId }) : undefined,
+    body: Object.keys(body).length > 0 ? JSON.stringify(body) : undefined,
   });
 }
 

--- a/frontend/src/api/generated/openapi.json
+++ b/frontend/src/api/generated/openapi.json
@@ -370,6 +370,11 @@
       },
       "RefreshRequest": {
         "properties": {
+          "force": {
+            "default": true,
+            "title": "Force",
+            "type": "boolean"
+          },
           "instance_id": {
             "anyOf": [
               {
@@ -749,7 +754,7 @@
   "paths": {
     "/api/v1/discovery/refresh": {
       "post": {
-        "description": "`POST /api/v1/discovery/refresh` -- kick off a fresh discovery run.\n\nNever blocks on the discovery run itself (FR-035): the refresh is\nscheduled as a `BackgroundTasks` job and results land in the cache\nincrementally, visible on subsequent `GET /hosts`/`GET /sessions` calls.",
+        "description": "`POST /api/v1/discovery/refresh` -- kick off a fresh discovery run.\n\nNever blocks on the discovery run itself (FR-035): the refresh is\nscheduled as a `BackgroundTasks` job and results land in the cache\nincrementally, visible on subsequent `GET /hosts`/`GET /sessions` calls.\n\n``force: false`` in the body makes the run TTL-gated \u2014 the console's\nbackground poll uses it so a long-lived page keeps its view fresh without\nevery tick costing an SSH round trip to every instance.",
         "operationId": "post_discovery_refresh_api_v1_discovery_refresh_post",
         "requestBody": {
           "content": {

--- a/frontend/src/api/generated/schema.d.ts
+++ b/frontend/src/api/generated/schema.d.ts
@@ -20,6 +20,10 @@ export interface paths {
          *     Never blocks on the discovery run itself (FR-035): the refresh is
          *     scheduled as a `BackgroundTasks` job and results land in the cache
          *     incrementally, visible on subsequent `GET /hosts`/`GET /sessions` calls.
+         *
+         *     ``force: false`` in the body makes the run TTL-gated — the console's
+         *     background poll uses it so a long-lived page keeps its view fresh without
+         *     every tick costing an SSH round trip to every instance.
          */
         post: operations["post_discovery_refresh_api_v1_discovery_refresh_post"];
         delete?: never;
@@ -451,6 +455,11 @@ export interface components {
         };
         /** RefreshRequest */
         RefreshRequest: {
+            /**
+             * Force
+             * @default true
+             */
+            force: boolean;
             /** Instance Id */
             instance_id?: string | null;
         };

--- a/frontend/src/components/AppShell.tsx
+++ b/frontend/src/components/AppShell.tsx
@@ -88,9 +88,15 @@ export function AppShell(): JSX.Element {
     return map;
   }, [discovery.targets]);
 
+  // Targets this console currently holds a connected terminal for. Discovery
+  // is a periodic snapshot, so a session started here is invisible to it until
+  // the next run lands; an open terminal is direct evidence the session exists.
+  // Feeding both into the rail is what makes the ⚡ appear on the spot.
+  const [liveTargetIds, setLiveTargetIds] = useState<ReadonlySet<string>>(() => new Set());
+
   const railModel = useMemo(
-    () => buildRailModel(discovery.instances, discovery.targets, filters),
-    [discovery.instances, discovery.targets, filters],
+    () => buildRailModel(discovery.instances, discovery.targets, filters, liveTargetIds),
+    [discovery.instances, discovery.targets, filters, liveTargetIds],
   );
 
   const regionByKey = useMemo(() => {
@@ -115,11 +121,24 @@ export function AppShell(): JSX.Element {
   const refresh = discovery.refresh;
   const onTerminalEnded = useCallback(
     (target: SessionTarget) => {
+      setLiveTargetIds((prev) => {
+        if (!prev.has(target.id)) {
+          return prev;
+        }
+        const next = new Set(prev);
+        next.delete(target.id);
+        return next;
+      });
       const id = instanceIdByKey.get(`${target.instance_type}::${target.instance_name}`);
       void refresh(id);
     },
     [instanceIdByKey, refresh],
   );
+
+  // A terminal connected: the target has a Zellij session as of now.
+  const onTerminalStarted = useCallback((target: SessionTarget) => {
+    setLiveTargetIds((prev) => (prev.has(target.id) ? prev : new Set(prev).add(target.id)));
+  }, []);
 
   const providers = useMemo(
     () => [...new Set(discovery.instances.map((i) => i.instance_type))],
@@ -256,6 +275,7 @@ export function AppShell(): JSX.Element {
             targetsById={targetsById}
             regionByKey={regionByKey}
             onTerminalEnded={onTerminalEnded}
+            onTerminalStarted={onTerminalStarted}
             narrow={narrow}
           />
         </div>

--- a/frontend/src/components/SessionRail.tsx
+++ b/frontend/src/components/SessionRail.tsx
@@ -229,6 +229,7 @@ function RailInstance({
           key={row.target.id}
           target={row.target}
           providerColor={meta.color}
+          active={row.active}
           attached={attached.includes(row.target.id)}
           visible={visible.includes(row.target.id)}
           focused={focusedId === row.target.id}
@@ -243,6 +244,8 @@ function RailInstance({
 interface RailSessionRowProps {
   target: SessionTarget;
   providerColor: string;
+  /** Has a live session — discovered, or one this console is attached to. */
+  active: boolean;
   attached: boolean;
   visible: boolean;
   focused: boolean;
@@ -252,6 +255,7 @@ interface RailSessionRowProps {
 
 function RailSessionRow({
   target,
+  active,
   attached,
   visible,
   focused,
@@ -296,7 +300,7 @@ function RailSessionRow({
             ⇣
           </span>
         )}
-        {target.zellij_state === "active" && (
+        {active && (
           <span title="Active Zellij session" style={{ color: "var(--git-active)" }}>
             ⚡
           </span>

--- a/frontend/src/components/TerminalCard.tsx
+++ b/frontend/src/components/TerminalCard.tsx
@@ -76,6 +76,8 @@ interface TerminalCardProps {
    * terminal is closed — the caller should re-run discovery for this instance
    * so the rail's live Zellij/git state stops being stale. */
   onEnded?: () => void;
+  /** The terminal reached `ready` — a Zellij session for this target now exists. */
+  onStarted?: () => void;
 }
 
 function effectiveFont(settings: SettingsState, mode: TerminalCardMode): TerminalFontOptions {
@@ -102,6 +104,7 @@ export function TerminalCard({
   onHoverFocus,
   onActivity,
   onEnded,
+  onStarted,
 }: TerminalCardProps): JSX.Element {
   const settings = useSettings();
 
@@ -115,6 +118,7 @@ export function TerminalCard({
   const isVisibleRef = useRef(isVisible);
   const onActivityRef = useRef(onActivity);
   const onEndedRef = useRef(onEnded);
+  const onStartedRef = useRef(onStarted);
   const fontRef = useRef<TerminalFontOptions>(effectiveFont(settings, mode));
   // Coalesced-fit bookkeeping: a pending rAF handle, and the last dims we sent
   // (to skip redundant resize frames).
@@ -159,7 +163,8 @@ export function TerminalCard({
   }, [onActivity]);
   useEffect(() => {
     onEndedRef.current = onEnded;
-  }, [onEnded]);
+    onStartedRef.current = onStarted;
+  }, [onEnded, onStarted]);
 
   // Coalesce fit()+resize into at most one per animation frame, and only send a
   // resize frame when the cell grid actually changed. A window drag fires the
@@ -234,7 +239,14 @@ export function TerminalCard({
           onActivityRef.current?.();
         }
       },
-      onReady: () => setError(null),
+      onReady: () => {
+        setError(null);
+        // Attaching creates-or-attaches the target's Zellij session, so the
+        // rail can light its ⚡ now rather than waiting for the next discovery
+        // run to notice (which is what made a freshly-started devcontainer look
+        // sessionless until a page reload).
+        onStartedRef.current?.();
+      },
       onExit: () => {
         // The remote process exited — the Zellij session may have ended (e.g.
         // the user quit Zellij). Re-run discovery so the rail's ⚡/git state

--- a/frontend/src/components/WorkspacePane.tsx
+++ b/frontend/src/components/WorkspacePane.tsx
@@ -33,6 +33,7 @@ interface WorkspacePaneProps {
   regionByKey: Map<string, string>;
   /** Re-run discovery for a target's instance (its terminal exited/closed). */
   onTerminalEnded: (target: SessionTarget) => void;
+  onTerminalStarted: (target: SessionTarget) => void;
   narrow: boolean;
 }
 
@@ -53,6 +54,7 @@ export function WorkspacePane({
   targetsById,
   regionByKey,
   onTerminalEnded,
+  onTerminalStarted,
   narrow,
 }: WorkspacePaneProps): JSX.Element {
   const workspace = useWorkspace();
@@ -193,6 +195,7 @@ export function WorkspacePane({
                 }
                 onActivity={() => workspace.markUnread(id)}
                 onEnded={() => onTerminalEnded(target)}
+                onStarted={() => onTerminalStarted(target)}
               />
             );
           })}

--- a/frontend/src/components/railModel.test.ts
+++ b/frontend/src/components/railModel.test.ts
@@ -1,0 +1,121 @@
+// The rail's ⚡ has two sources of truth, and they have to agree.
+//
+// `zellij_state` comes from discovery, which is a periodic snapshot: a session
+// started from this console isn't in it until the next run lands, so a
+// just-launched devcontainer showed no ⚡ until the page was reloaded. But the
+// console holds an open terminal on that project, and `remo-host sessions
+// attach` creates-or-attaches a Zellij session — so a live terminal IS an
+// active session, knowable immediately.
+//
+// Both feed `RailRow.active`, which drives the ⚡ *and* the "Active only"
+// filter, so a row can never show a bolt while being filtered out as inactive.
+
+import { describe, expect, it } from "vitest";
+import type { DiscoveryInstance, SessionTarget } from "../api/client";
+import { buildRailModel, type RailFilters } from "./railModel";
+
+const NO_FILTERS: RailFilters = { search: "", providerFilter: null, sessionOnly: false };
+
+function instance(overrides: Partial<DiscoveryInstance> = {}): DiscoveryInstance {
+  return {
+    instance_id: "inst-1",
+    instance_type: "incus",
+    instance_name: "lab/dev1",
+    status: "ok",
+    region: "",
+    capability: null,
+    targets: [],
+    error: null,
+    refreshed_at: "2026-08-02T00:00:00Z",
+    ...overrides,
+  } as DiscoveryInstance;
+}
+
+function target(overrides: Partial<SessionTarget> = {}): SessionTarget {
+  return {
+    id: "t-1",
+    instance_type: "incus",
+    instance_name: "lab/dev1",
+    project: "remo",
+    zellij_state: "absent",
+    devcontainer_running: "no",
+    git_dirty: false,
+    git_ahead: 0,
+    git_behind: 0,
+    ...overrides,
+  } as SessionTarget;
+}
+
+function rowsOf(
+  targets: SessionTarget[],
+  filters: RailFilters = NO_FILTERS,
+  live: ReadonlySet<string> = new Set(),
+) {
+  return buildRailModel([instance()], targets, filters, live).groups[0]?.rows ?? [];
+}
+
+describe("RailRow.active", () => {
+  it("is true when discovery reports an active Zellij session", () => {
+    const rows = rowsOf([target({ zellij_state: "active" })]);
+
+    expect(rows[0].active).toBe(true);
+  });
+
+  it("is false for a target with neither a discovered nor a live session", () => {
+    const rows = rowsOf([target()]);
+
+    expect(rows[0].active).toBe(false);
+  });
+
+  it("is true for a target this console holds a terminal on, before discovery catches up", () => {
+    // The reported bug: launching a devcontainer left zellij_state stale at
+    // "absent" until a full page reload, so no ⚡ appeared.
+    const rows = rowsOf([target({ zellij_state: "absent" })], NO_FILTERS, new Set(["t-1"]));
+
+    expect(rows[0].active).toBe(true);
+  });
+
+  it("only marks the target that is actually live", () => {
+    const rows = rowsOf(
+      [target({ id: "t-1" }), target({ id: "t-2", project: "other" })],
+      NO_FILTERS,
+      new Set(["t-1"]),
+    );
+
+    expect(rows.map((r) => [r.target.id, r.active])).toEqual([
+      ["t-1", true],
+      ["t-2", false],
+    ]);
+  });
+
+  it("defaults to discovery alone when no live set is supplied", () => {
+    const model = buildRailModel([instance()], [target({ zellij_state: "active" })], NO_FILTERS);
+
+    expect(model.groups[0].rows[0].active).toBe(true);
+  });
+});
+
+describe('"Active only" filter', () => {
+  const sessionOnly: RailFilters = { ...NO_FILTERS, sessionOnly: true };
+
+  it("keeps a discovered-active target", () => {
+    const rows = rowsOf([target({ zellij_state: "active" })], sessionOnly);
+
+    expect(rows).toHaveLength(1);
+  });
+
+  it("drops a target with no session at all", () => {
+    const rows = rowsOf([target()], sessionOnly);
+
+    expect(rows).toHaveLength(0);
+  });
+
+  it("keeps a live-terminal target discovery still calls inactive", () => {
+    // If the filter used zellij_state while the ⚡ used `active`, this row
+    // would vanish from the filtered rail while claiming to have a session.
+    const rows = rowsOf([target()], sessionOnly, new Set(["t-1"]));
+
+    expect(rows).toHaveLength(1);
+    expect(rows[0].active).toBe(true);
+  });
+});

--- a/frontend/src/components/railModel.ts
+++ b/frontend/src/components/railModel.ts
@@ -15,6 +15,18 @@ export interface RailRow {
   target: SessionTarget;
   /** 1–9 when among the first nine openable targets, else null. */
   num: number | null;
+  /**
+   * Whether to show this row as having a live session (the ⚡).
+   *
+   * Discovery's `zellij_state` is a snapshot, and a session this console just
+   * started is not in it until the next discovery run lands. But the console
+   * knows something discovery doesn't: it is holding an open terminal on that
+   * project, and `remo-host sessions attach` creates-or-attaches a Zellij
+   * session — so a live terminal IS an active session, immediately and by
+   * construction. Both sources feed this one flag so the ⚡ and the
+   * "Active only" filter can never disagree about a row.
+   */
+  active: boolean;
 }
 
 export interface RailErrorInfo {
@@ -63,8 +75,12 @@ export function buildRailModel(
   instances: DiscoveryInstance[],
   targets: SessionTarget[],
   filters: RailFilters,
+  /** Target ids this console currently holds a connected terminal for. */
+  liveTargetIds: ReadonlySet<string> = new Set(),
 ): RailModel {
   const q = filters.search.trim().toLowerCase();
+  const isActive = (t: SessionTarget): boolean =>
+    t.zellij_state === "active" || liveTargetIds.has(t.id);
   const byInstance = new Map<string, SessionTarget[]>();
   for (const t of targets) {
     const key = `${t.instance_type}::${t.instance_name}`;
@@ -87,8 +103,7 @@ export function buildRailModel(
     const openable = instance.status === "ok";
 
     const filtered = instTargets.filter(
-      (t) =>
-        matchesSearch(instance, t, q) && (!filters.sessionOnly || t.zellij_state === "active"),
+      (t) => matchesSearch(instance, t, q) && (!filters.sessionOnly || isActive(t)),
     );
 
     const instMatches =
@@ -104,7 +119,7 @@ export function buildRailModel(
         availCount += 1;
         num = flatOpenable.length <= 9 ? flatOpenable.length : null;
       }
-      return { target, num };
+      return { target, num, active: isActive(target) };
     });
 
     const isError = instance.status !== "ok" && instance.error != null;

--- a/frontend/src/state/discovery.test.ts
+++ b/frontend/src/state/discovery.test.ts
@@ -1,0 +1,105 @@
+// The background poll has to TRIGGER discovery, not just re-read its result.
+//
+// `GET /hosts` and `GET /sessions` are cache reads on the service side — only
+// `POST /discovery/refresh` re-runs discovery. When the interval tick called
+// nothing but the two GETs, the console re-rendered the identical snapshot
+// forever: a Zellij session started after page load never lit its ⚡, git
+// ahead/behind counts never moved, and a newly-created project never appeared,
+// until the user reloaded the whole page.
+//
+// These tests pin the fix at the seam that broke: what the tick actually sends.
+
+import { act, renderHook } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const refreshDiscovery = vi.fn(async () => ({ refreshing: true }));
+const getHosts = vi.fn(async () => ({ instances: [] }));
+const getSessions = vi.fn(async () => ({ targets: [] }));
+
+vi.mock("../api/client", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../api/client")>();
+  return {
+    ...actual,
+    refreshDiscovery,
+    getHosts,
+    getSessions,
+  };
+});
+
+const INTERVAL_MS = 15_000;
+
+/** Advance timers inside `act` so the store's async state updates settle. */
+async function advance(ms: number): Promise<void> {
+  await act(async () => {
+    await vi.advanceTimersByTimeAsync(ms);
+  });
+}
+
+describe("discovery auto-refresh", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.useFakeTimers();
+    refreshDiscovery.mockClear();
+    getHosts.mockClear();
+    getSessions.mockClear();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("mounts with a forced run, then ticks trigger TTL-gated ones", async () => {
+    const { useDiscovery } = await import("./discovery");
+    const { unmount } = renderHook(() => useDiscovery(INTERVAL_MS));
+
+    // Mount: a forced run, so a cold cache is populated without the user
+    // having to click Refresh.
+    await advance(0);
+    expect(refreshDiscovery).toHaveBeenCalledTimes(1);
+    expect(refreshDiscovery.mock.calls[0]).toEqual([undefined]);
+
+    // Let the mount refresh finish its follow-up polls before judging ticks.
+    await advance(10_000);
+    refreshDiscovery.mockClear();
+
+    // The regression: a tick used to trigger no discovery at all, so the cache
+    // it then read back was the same one page load produced — forever.
+    await advance(INTERVAL_MS + 1);
+    expect(refreshDiscovery).toHaveBeenCalled();
+    expect(refreshDiscovery.mock.calls[0]).toEqual([undefined, { force: false }]);
+
+    unmount();
+  });
+
+  it("a tick reads the cache after triggering the run, not before", async () => {
+    const { useDiscovery } = await import("./discovery");
+    const { unmount } = renderHook(() => useDiscovery(INTERVAL_MS));
+    await advance(10_000);
+    refreshDiscovery.mockClear();
+    getHosts.mockClear();
+
+    await advance(INTERVAL_MS + 1);
+    // The tick awaits the POST before polling, so let that continuation land.
+    await advance(100);
+
+    expect(refreshDiscovery).toHaveBeenCalled();
+    expect(getHosts).toHaveBeenCalled();
+    expect(refreshDiscovery.mock.invocationCallOrder[0]).toBeLessThan(
+      getHosts.mock.invocationCallOrder[0],
+    );
+
+    unmount();
+  });
+
+  it("stops triggering discovery once the last subscriber unmounts", async () => {
+    const { useDiscovery } = await import("./discovery");
+    const { unmount } = renderHook(() => useDiscovery(INTERVAL_MS));
+    await advance(10_000);
+
+    unmount();
+    refreshDiscovery.mockClear();
+    await advance(INTERVAL_MS * 3);
+
+    expect(refreshDiscovery).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/src/state/discovery.ts
+++ b/frontend/src/state/discovery.ts
@@ -112,11 +112,20 @@ function startAutoRefresh(intervalMs: number): void {
   // First launch: the backend discovery cache is empty until a discovery run
   // happens (GET /hosts only READS the cache). Trigger a full refresh — POST
   // /discovery/refresh + follow-up polls — so the registry is discovered
-  // automatically without the user having to click "Refresh". Subsequent
-  // interval ticks just poll the now-populated cache.
+  // automatically without the user having to click "Refresh".
   void manualRefresh();
+  // Every tick must trigger a discovery run too, not just re-read the cache.
+  // GET /hosts and GET /sessions are cache reads: a tick that only polls them
+  // re-renders the SAME snapshot forever, so the whole rail freezes at whatever
+  // page load found — ⚡ session state, git ahead/behind, newly-created
+  // projects, instance status. The user sees a session they just started never
+  // light up until they reload the page.
+  //
+  // The POST is TTL-gated (`force: false`), so it is the service's
+  // DISCOVERY_CACHE_TTL_S — not this interval, and not the number of open
+  // browser tabs — that decides how often discovery actually runs.
   autoRefreshHandle = setInterval(() => {
-    void pollOnce();
+    void tick();
   }, intervalMs);
 }
 
@@ -158,6 +167,28 @@ async function manualRefresh(instanceId?: string): Promise<void> {
   } finally {
     setState({ isRefreshing: false });
   }
+}
+
+/**
+ * One background tick: ask the service for a TTL-gated discovery run, then read
+ * the cache. Deliberately does NOT set `isRefreshing` — that flag drives the
+ * "Refreshing…" affordance next to the user's own Refresh button, and a
+ * background tick flickering it every interval would be noise.
+ *
+ * A failed POST is swallowed for the same reason `manualRefresh` swallows it:
+ * the following GETs may still land useful data, and a transient blip on a
+ * background tick is not worth surfacing.
+ */
+async function tick(): Promise<void> {
+  try {
+    await refreshDiscoveryRequest(undefined, { force: false });
+  } catch (error) {
+    if (!(error instanceof ApiError)) {
+      throw error;
+    }
+    console.error("discovery: background POST /discovery/refresh failed", error);
+  }
+  await pollOnce();
 }
 
 export interface UseDiscoveryResult {

--- a/src/remo_cli/web/api/hosts.py
+++ b/src/remo_cli/web/api/hosts.py
@@ -108,6 +108,13 @@ class SessionsResponse(BaseModel):
 
 class RefreshRequest(BaseModel):
     instance_id: str | None = None
+    #: ``False`` asks for a TTL-gated refresh: run discovery only if the cache
+    #: is older than ``discovery_cache_ttl_s``, otherwise no-op. That is what
+    #: the console's background poll sends, so N open browsers cost at most one
+    #: discovery run per TTL instead of one per tick per browser. Defaults to
+    #: ``True`` (always run) so an explicit "Refresh" — and any older client
+    #: that omits the field — behaves exactly as before.
+    force: bool = True
 
 
 class RefreshResponse(BaseModel):
@@ -206,8 +213,13 @@ async def post_discovery_refresh(
     Never blocks on the discovery run itself (FR-035): the refresh is
     scheduled as a `BackgroundTasks` job and results land in the cache
     incrementally, visible on subsequent `GET /hosts`/`GET /sessions` calls.
+
+    ``force: false`` in the body makes the run TTL-gated — the console's
+    background poll uses it so a long-lived page keeps its view fresh without
+    every tick costing an SSH round trip to every instance.
     """
     service = get_discovery_service(request)
     instance_id = body.instance_id if body is not None else None
-    background_tasks.add_task(service.refresh, instance_id)
+    force = body.force if body is not None else True
+    background_tasks.add_task(service.refresh, instance_id, force=force)
     return RefreshResponse(refreshing=True)

--- a/tests/unit/web/test_discovery_refresh_force.py
+++ b/tests/unit/web/test_discovery_refresh_force.py
@@ -1,0 +1,92 @@
+"""`POST /api/v1/discovery/refresh` honours the request's `force` flag.
+
+`GET /hosts` and `GET /sessions` only READ the discovery cache — this endpoint
+is the only thing that repopulates it. The browser console therefore has to hit
+it on a background cadence or its whole view freezes at whatever page load
+found (the ⚡ on a session started after load never appears, git counts go
+stale, new projects never show up).
+
+Hitting it unconditionally on every tick would mean one full SSH sweep of every
+instance per tick per open tab, so the console sends `force: false` and lets the
+service's own `discovery_cache_ttl_s` decide when a run is actually due. These
+tests pin that passthrough — including the default, since an older console omits
+the field entirely and must keep its always-run behaviour.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from remo_cli.web.api.hosts import router
+
+
+class _RecordingDiscoveryService:
+    """Stands in for DiscoveryService, recording how `refresh` was called."""
+
+    def __init__(self) -> None:
+        self.calls: list[tuple[str | None, bool]] = []
+
+    async def refresh(self, instance_id: str | None = None, *, force: bool = True) -> None:
+        self.calls.append((instance_id, force))
+
+    def get_snapshot(self) -> list[Any]:
+        return []
+
+    def get_targets(self) -> list[Any]:
+        return []
+
+
+@pytest.fixture
+def client() -> tuple[TestClient, _RecordingDiscoveryService]:
+    app = FastAPI()
+    app.include_router(router, prefix="/api/v1")
+    service = _RecordingDiscoveryService()
+    app.state.discovery_service = service
+    return TestClient(app), service
+
+
+def test_no_body_forces_a_run(client) -> None:
+    """An older console posts no body at all; it must still force a run."""
+    http, service = client
+
+    assert http.post("/api/v1/discovery/refresh").status_code == 202
+
+    assert service.calls == [(None, True)]
+
+
+def test_explicit_refresh_forces_a_run(client) -> None:
+    http, service = client
+
+    http.post("/api/v1/discovery/refresh", json={})
+
+    assert service.calls == [(None, True)]
+
+
+def test_background_tick_asks_for_a_ttl_gated_run(client) -> None:
+    """The whole point: cheap enough to run on an interval, from every tab."""
+    http, service = client
+
+    http.post("/api/v1/discovery/refresh", json={"force": False})
+
+    assert service.calls == [(None, False)]
+
+
+def test_targeted_refresh_still_forces_by_default(client) -> None:
+    """`onTerminalEnded` refreshes one instance and wants it to actually run."""
+    http, service = client
+
+    http.post("/api/v1/discovery/refresh", json={"instance_id": "abc123"})
+
+    assert service.calls == [("abc123", True)]
+
+
+def test_force_and_instance_id_compose(client) -> None:
+    http, service = client
+
+    http.post("/api/v1/discovery/refresh", json={"instance_id": "abc123", "force": False})
+
+    assert service.calls == [("abc123", False)]


### PR DESCRIPTION
Starting a devcontainer from the console spins it up correctly but never lights the rail's ⚡ for it; only a full page reload does.

## The ⚡ was the small visible piece of a much bigger freeze

`GET /hosts` and `GET /sessions` are **cache reads** on the service side — `DiscoveryService.get_snapshot()` is explicitly non-blocking and does no I/O. `POST /discovery/refresh` is the only call that re-runs discovery.

The console's 15s tick called `pollOnce()`, which is the two GETs and nothing else. So it re-rendered *the same snapshot* forever. Everything discovery supplies was frozen at whatever page load found — session state, git ahead/behind, newly-created projects, instance status. The only things that ever triggered a real run were mounting the app, the Refresh button, and a terminal exiting (`onTerminalEnded`, added precisely so the ⚡ would *clear* on exit — the mirror case of this bug).

## Fix

**1. The tick triggers a run.** It now posts `/discovery/refresh` before reading the cache, with a new `force: false` on `RefreshRequest`, so the run is TTL-gated: `DISCOVERY_CACHE_TTL_S` (30s) — not the poll interval, and not the number of open tabs — decides how often instances are actually contacted. The field defaults to `true`, so an explicit Refresh, the post-exit refresh, and any older console keep their always-run behavior.

`DiscoveryService.refresh` already had the `force=False` branch, with a comment anticipating "a future interval scheduler, T052". It had simply never been wired to a caller.

**2. The ⚡ doesn't wait for a TTL.** Even a correct poll leaves it up to 30s behind the moment you start a session. So the rail also derives it from what the console can see directly: it is holding a connected terminal on that target, and `remo-host sessions attach` creates-or-attaches a Zellij session — so a live terminal *is* an active session, knowable immediately and by construction.

`RailRow` gains `active` (discovered **or** live), which drives both the ⚡ and the "Active only" filter — so a row can never show a bolt while being filtered out as inactive. `TerminalCard` reports `onStarted` at `ready`, mirroring the existing `onEnded`; `AppShell` keeps the live-target set, adding on start and removing on exit.

Note the two halves are complementary, not redundant: the derived flag covers *this* console's sessions instantly, and the poll covers everything else — a session started from another tab, from `remo shell`, or directly on the box.

## Testing

- `tests/unit/web/test_discovery_refresh_force.py` (5) — `force` passthrough including the no-body and no-field defaults, since an older console must keep forcing.
- `frontend/src/state/discovery.test.ts` (3) — the regression guard: a tick triggers a TTL-gated run and *then* reads the cache, and stops on unmount.
- `frontend/src/components/railModel.test.ts` (8) — the `active` derivation from either source, and that the "Active only" filter agrees with the ⚡.

Full Python suite green (2007 passed), frontend 41 passed, `tsc` clean, build clean, and both schema-drift gates pass with the four regenerated artifacts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011A2RNakq6mYPLA8as3pE1t