### PR TITLE
feat(web): give the console a light/dark mode and selectable terminal themes

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -117,8 +117,9 @@ frontend/                  # remo-web browser SPA (Vite + React + TypeScript)
 ├── src/
 │   ├── api/client.ts        # REST + WS terminal client (remo-terminal.v1 subprotocol)
 │   ├── components/          # Dashboard, InstanceGroup, TargetCard, GridView, TabView, TerminalCard
-│   ├── state/                # discovery.ts, workspace.ts (layout persisted to localStorage)
-│   └── terminal/              # RendererAdapter, GhosttyRenderer (default), XtermRenderer (fallback)
+│   ├── state/                # discovery.ts, workspace.ts (layout persisted to localStorage), settings.ts (display prefs: site light/dark mode, accent, fonts, terminal theme + per-target overrides)
+│   ├── terminal/              # RendererAdapter, GhosttyRenderer (default), XtermRenderer (fallback)
+│   └── theme/                 # tokens.css (light-dark() palette, one pair per token), fonts.ts, terminalThemes.ts (8 terminal color schemes: a token-derived Remo Dark/Light pair the default 'auto' selection tracks, plus 6 curated third-party)
 └── public/                    # Same-origin-served ghostty-web WASM asset
 
 docker/                    # remo-web container packaging (010-web-session-interface, US4)

--- a/docs/web-session-interface.md
+++ b/docs/web-session-interface.md
@@ -141,10 +141,27 @@ Git ahead/behind reflect the **last-known** upstream — discovery never runs `g
 they can be stale until something else fetches. Git glyphs only appear on instances running a
 `remo-host` new enough to report git status; see [Upgrade compatibility](#upgrade-compatibility).
 
-**Settings** (⚙, top bar; stored in this browser only, FR-034): accent color, terminal font, font
-size, program ligatures, grid display mode (actual-size vs scale-to-fit), **focus dwell** (how long the
-pointer rests before focus-follows-mouse fires), terminal engine, a **Nerd Font uploader**, and **Pair
-CLI to sync** (mint a re-sync pairing code). Because a browser can't read fonts installed on the
+**Settings** (⚙, top bar; stored in this browser only, FR-034): **appearance** (site light/dark mode),
+accent color, terminal font, **terminal theme**, font size, program ligatures, grid display mode
+(actual-size vs scale-to-fit), **focus dwell** (how long the pointer rests before focus-follows-mouse
+fires), terminal engine, a **Nerd Font uploader**, and **Pair CLI to sync** (mint a re-sync pairing
+code).
+
+**Appearance** is tri-state — `system` (the default, following the OS `prefers-color-scheme`),
+`light`, or `dark` — toggled from the ◐/☀/☾ button in the top bar as well as from Settings. The
+console's palette is a set of `light-dark()` CSS custom properties in `theme/tokens.css`; "system"
+therefore needs no JavaScript to render, and an explicit choice is applied as `data-theme` on `<html>`.
+**Terminal theme** defaults to **Follow site theme**, which tracks the site mode: a light console gets
+**Remo Light**, a dark one **Remo Dark**. Those two are derived from `theme/tokens.css` — terminal
+background is `--bg-term`, foreground `--text`, ANSI 1–6 the `--danger`/`--ok`/`--warn`/`--info`/`--mag`/
+`--cyan` ramp — so the terminal sits flush with the chrome around it. They are hand-derived *snapshots*
+(a terminal palette must be literal `#rrggbb`; ghostty-web's parser accepts neither `oklch()` nor
+`var()`), so editing a token does not update them. Six curated third-party schemes are also available —
+Catppuccin Mocha/Latte, Dracula, Gruvbox Dark/Light, Solarized Light — and any theme can be used under
+either site mode; picking one explicitly stops the terminal following the site. The Settings choice is
+the default for every terminal; an individual terminal can override it from the color swatch in its
+header, and clearing that override back to "Default" makes it follow the global choice again. Theme
+changes apply live — the terminal is recolored in place, keeping the connection and scrollback. Because a browser can't read fonts installed on the
 instance, uploading a patched Nerd Font once registers it via the `FontFace` API (persisted in
 IndexedDB) and offers it as a terminal font — that's how Powerline/Git/devicon glyphs in a prompt or
 Zellij status bar render. Font changes apply live to every open terminal. The top bar shows the

--- a/frontend/src/components/AppShell.tsx
+++ b/frontend/src/components/AppShell.tsx
@@ -9,7 +9,7 @@ import { exitBrowserFullscreen } from "../lib/fullscreen";
 import { useDiscovery } from "../state/discovery";
 import { useHealth } from "../state/health";
 import { useLatency } from "../state/latency";
-import { settingsActions, useSettings } from "../state/settings";
+import { resolvedSiteTheme, settingsActions, useSettings } from "../state/settings";
 import { useConsoleKeyboard } from "../state/useConsoleKeyboard";
 import { useWorkspace } from "../state/workspace";
 import { buildRailModel, type RailFilters } from "./railModel";
@@ -74,6 +74,18 @@ export function AppShell(): JSX.Element {
     document.addEventListener("fullscreenchange", onChange);
     return () => document.removeEventListener("fullscreenchange", onChange);
   }, [maximized, restore]);
+
+  // Per-terminal theme overrides are keyed by target id; drop the ones whose
+  // target no longer exists so the stored map can't grow without bound.
+  // Guarded on a non-empty snapshot: discovery keeps its last-known targets
+  // when a poll fails, and pruning against an empty list — the pre-first-poll
+  // state, or a failed one — would wipe live preferences.
+  useEffect(() => {
+    if (discovery.targets.length === 0) {
+      return;
+    }
+    settingsActions.pruneTermThemeOverrides(discovery.targets.map((t) => t.id));
+  }, [discovery.targets]);
 
   const filters: RailFilters = useMemo(
     () => ({ search, providerFilter, sessionOnly }),
@@ -218,6 +230,9 @@ export function AppShell(): JSX.Element {
         onRefresh={() => void discovery.refresh()}
         onSettings={() => setSettingsOpen(true)}
         onShortcuts={onToggleShortcuts}
+        themeMode={settings.themeMode}
+        resolvedDark={resolvedSiteTheme(settings) === "dark"}
+        onCycleTheme={() => settingsActions.cycleThemeMode()}
       />
 
       {discovery.isRefreshing && !maximized && (

--- a/frontend/src/components/OfflineOverlay.css
+++ b/frontend/src/components/OfflineOverlay.css
@@ -2,7 +2,7 @@
   position: absolute;
   inset: 0;
   z-index: 80;
-  background: oklch(0.13 0.01 255 / 0.93);
+  background: var(--overlay-scrim-strong);
   backdrop-filter: blur(3px);
   display: flex;
   align-items: center;
@@ -13,8 +13,8 @@
 .offline-card {
   max-width: 460px;
   text-align: center;
-  background: oklch(0.2 0.02 25);
-  border: 1px solid oklch(0.4 0.09 25);
+  background: var(--danger-surface);
+  border: 1px solid var(--danger-border);
   border-radius: 16px;
   padding: 38px 32px;
 }
@@ -28,14 +28,14 @@
 .offline-title {
   font-size: 18px;
   font-weight: 600;
-  color: oklch(0.85 0.08 25);
+  color: var(--danger-text);
   margin-bottom: 8px;
 }
 
 .offline-body {
   font-size: 13.5px;
   line-height: 1.6;
-  color: oklch(0.72 0.02 25);
+  color: var(--danger-text-2);
   margin: 0 0 20px;
 }
 
@@ -44,7 +44,7 @@
   border-radius: 8px;
   border: none;
   background: var(--ok);
-  color: oklch(0.16 0.05 150);
+  color: var(--on-ok);
   font-size: 13px;
   font-weight: 700;
   cursor: pointer;

--- a/frontend/src/components/SessionRail.css
+++ b/frontend/src/components/SessionRail.css
@@ -95,13 +95,13 @@
 .rail-toggle--active {
   border-color: var(--warn);
   background: color-mix(in oklch, var(--warn) 16%, var(--bg-btn));
-  color: oklch(0.9 0.08 88);
+  color: var(--warn-text);
 }
 .rail-openall {
   font-weight: 600;
   border-color: color-mix(in oklch, var(--accent) 45%, var(--border-strong));
   background: color-mix(in oklch, var(--accent) 15%, var(--bg-btn));
-  color: color-mix(in oklch, var(--accent) 80%, white);
+  color: var(--accent-strong);
 }
 .rail-openall:disabled {
   opacity: 0.5;
@@ -177,8 +177,8 @@
   margin: 2px 4px 6px;
   padding: 9px 10px;
   border-radius: 8px;
-  background: oklch(0.2 0.03 25);
-  border: 1px solid oklch(0.38 0.08 25);
+  background: var(--danger-surface);
+  border: 1px solid var(--danger-border);
 }
 .rail-inst-error-title {
   display: flex;
@@ -186,7 +186,7 @@
   gap: 7px;
   font-size: 12px;
   font-weight: 600;
-  color: oklch(0.82 0.1 25);
+  color: var(--danger-text);
 }
 .rail-inst-error-msg {
   font-size: 11px;
@@ -199,7 +199,7 @@
   margin-top: 7px;
   font-family: var(--font-mono);
   font-size: 10px;
-  color: oklch(0.74 0.05 80);
+  color: var(--warn-text-dim);
   background: var(--bg-term);
   border: 1px solid var(--border);
   border-radius: 5px;
@@ -241,7 +241,7 @@
   width: 10px;
   font-family: var(--font-mono);
   font-size: 12px;
-  color: var(--accent);
+  color: var(--accent-ink);
   flex: none;
 }
 .rail-row-name {
@@ -316,8 +316,8 @@
   margin: 12px 4px;
   padding: 14px;
   border-radius: 10px;
-  background: oklch(0.21 0.03 70);
-  border: 1px solid oklch(0.4 0.08 70);
+  background: var(--warn-surface);
+  border: 1px solid var(--warn-border);
   text-align: left;
 }
 .rail-notice-icon {

--- a/frontend/src/components/SettingsPage.css
+++ b/frontend/src/components/SettingsPage.css
@@ -121,7 +121,7 @@
   align-items: center;
   justify-content: center;
   font-size: 9px;
-  color: var(--accent);
+  color: var(--accent-ink);
   flex: none;
 }
 .settings-font--on .settings-radio,
@@ -153,6 +153,55 @@
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
+}
+
+/* terminal theme cards */
+.settings-termthemes {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(224px, 1fr));
+  gap: 10px;
+}
+.settings-termtheme {
+  text-align: left;
+  padding: 13px 14px;
+  border-radius: 10px;
+  cursor: pointer;
+  background: var(--bg-btn);
+  border: 1.5px solid var(--border);
+  display: flex;
+  flex-direction: column;
+  gap: 9px;
+  font-family: inherit;
+}
+.settings-termtheme:hover {
+  border-color: color-mix(in oklch, var(--accent) 55%, var(--border-strong));
+}
+.settings-termtheme--on {
+  border-color: color-mix(in oklch, var(--accent) 60%, var(--border-strong));
+  background: color-mix(in oklch, var(--accent) 9%, var(--bg-btn));
+}
+/* Colors here come from the theme data as inline styles — this is a sample of
+ * the palette, so it must NOT follow the console's own tokens. */
+.settings-termtheme-preview {
+  font-family: var(--font-mono);
+  font-size: 12px;
+  line-height: 1.5;
+  border: 1px solid;
+  border-radius: 7px;
+  padding: 8px 10px;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+.settings-termtheme-dots {
+  display: flex;
+  gap: 4px;
+  margin-bottom: 7px;
+}
+.settings-termtheme-dots span {
+  width: 9px;
+  height: 9px;
+  border-radius: 50%;
 }
 
 /* grid modes */
@@ -210,7 +259,7 @@
 .settings-value {
   font-family: var(--font-mono);
   font-size: 12px;
-  color: var(--accent);
+  color: var(--accent-ink);
 }
 .settings-range {
   width: 100%;
@@ -252,7 +301,7 @@
   width: 14px;
   height: 14px;
   border-radius: 50%;
-  background: oklch(0.96 0 0);
+  background: var(--knob);
   transition: left 0.15s;
 }
 .settings-liga--on .settings-liga-knob {

--- a/frontend/src/components/SettingsPage.tsx
+++ b/frontend/src/components/SettingsPage.tsx
@@ -1,6 +1,7 @@
-// Full-screen Settings page: terminal font, grid display mode, font size,
-// ligatures, accent color, and Nerd-Font upload. All preferences are stored in
-// this browser (FR-034) and applied live to every open terminal.
+// Full-screen Settings page: site light/dark mode, accent color, terminal font,
+// terminal color theme, grid display mode, font size, ligatures, and Nerd-Font
+// upload. All preferences are stored in this browser (FR-034) and applied live
+// to every open terminal.
 
 import { useEffect, useRef, useState, type ChangeEvent } from "react";
 import { listUploadedFonts, registerUploadedFont } from "../state/fonts";
@@ -12,16 +13,22 @@ import {
   MIN_FOCUS_DWELL_MS,
   MIN_TERM_SIZE,
   RENDERER_OPTIONS,
+  effectiveTerminalTheme,
   settingsActions,
+  SITE_THEME_OPTIONS,
   useSettings,
   type FontOption,
 } from "../state/settings";
+import { AUTO_TERMINAL_THEME, TERMINAL_THEMES } from "../theme/terminalThemes";
 import { PairToSync } from "./PairToSync";
 import "./SettingsPage.css";
 
 interface SettingsPageProps {
   onClose: () => void;
 }
+
+/** The six ANSI hues shown as dots in a theme preview. */
+const ANSI_PREVIEW_KEYS = ["red", "green", "yellow", "blue", "magenta", "cyan"] as const;
 
 const GRID_MODES = [
   {
@@ -41,6 +48,9 @@ export function SettingsPage({ onClose }: SettingsPageProps): JSX.Element {
   const fileInputRef = useRef<HTMLInputElement | null>(null);
   const [uploaded, setUploaded] = useState<string[]>([]);
   const [uploadError, setUploadError] = useState<string | null>(null);
+  const autoSelected = settings.termTheme === AUTO_TERMINAL_THEME;
+  // What "auto" resolves to for the site mode in effect — the preview subject.
+  const autoTheme = effectiveTerminalTheme({ ...settings, termTheme: AUTO_TERMINAL_THEME });
 
   useEffect(() => {
     void listUploadedFonts().then(setUploaded);
@@ -88,6 +98,36 @@ export function SettingsPage({ onClose }: SettingsPageProps): JSX.Element {
 
       <div className="settings-scroll">
         <div className="settings-inner">
+          {/* Appearance (site light/dark) */}
+          <section>
+            <div className="settings-heading">Appearance</div>
+            <p className="settings-sub">
+              The console&rsquo;s own light/dark theme. Terminal colors are set separately, below.
+            </p>
+            <div className="settings-gridmodes">
+              {SITE_THEME_OPTIONS.map((o) => {
+                const selected = settings.themeMode === o.value;
+                return (
+                  <button
+                    key={o.value}
+                    type="button"
+                    data-testid={`site-theme-${o.value}`}
+                    className={`settings-gridmode${selected ? " settings-gridmode--on" : ""}`}
+                    onClick={() => settingsActions.setThemeMode(o.value)}
+                  >
+                    <span className="settings-radio">{selected ? "✓" : ""}</span>
+                    <span>
+                      <span className="settings-gridmode-title">
+                        {o.icon} {o.label}
+                      </span>
+                      <span className="settings-gridmode-desc">{o.desc}</span>
+                    </span>
+                  </button>
+                );
+              })}
+            </div>
+          </section>
+
           {/* Accent */}
           <section>
             <div className="settings-heading">Accent color</div>
@@ -127,6 +167,87 @@ export function SettingsPage({ onClose }: SettingsPageProps): JSX.Element {
                     </div>
                     <div className="settings-font-preview" style={{ fontFamily: f.css }}>
                       $ git commit -m &quot;=&gt; fix&quot;
+                    </div>
+                  </button>
+                );
+              })}
+            </div>
+          </section>
+
+          {/* Terminal theme */}
+          <section>
+            <div className="settings-heading">Terminal theme</div>
+            <p className="settings-sub">
+              The color scheme inside every terminal. Applied live, without dropping the session.
+              Any individual terminal can override this from the swatch in its header.
+            </p>
+            <div className="settings-termthemes">
+              {/* "Follow site theme" is the default, and previews whichever of
+               * the two site-matched palettes is in effect right now. */}
+              <button
+                type="button"
+                data-testid="term-theme-auto"
+                className={`settings-termtheme${autoSelected ? " settings-termtheme--on" : ""}`}
+                onClick={() => settingsActions.setTermTheme(AUTO_TERMINAL_THEME)}
+              >
+                <div className="settings-font-head">
+                  <span className="settings-radio">{autoSelected ? "✓" : ""}</span>
+                  <span className="settings-font-label">Follow site theme</span>
+                  <span className="settings-font-tag">{autoTheme.variant === "dark" ? "Dark" : "Light"}</span>
+                </div>
+                <div
+                  className="settings-termtheme-preview"
+                  style={{
+                    background: autoTheme.colors.background,
+                    color: autoTheme.colors.foreground,
+                    borderColor: autoTheme.colors.brightBlack,
+                  }}
+                >
+                  <div className="settings-termtheme-dots">
+                    {ANSI_PREVIEW_KEYS.map((key) => (
+                      <span key={key} style={{ background: autoTheme.colors[key] }} />
+                    ))}
+                  </div>
+                  <span style={{ color: autoTheme.colors.green }}>$</span>{" "}
+                  <span style={{ color: autoTheme.colors.blue }}>remo</span> shell{" "}
+                  <span style={{ color: autoTheme.colors.yellow }}>web</span>
+                </div>
+              </button>
+              {TERMINAL_THEMES.map((th) => {
+                const selected = settings.termTheme === th.id;
+                return (
+                  <button
+                    key={th.id}
+                    type="button"
+                    data-testid={`term-theme-${th.id}`}
+                    className={`settings-termtheme${selected ? " settings-termtheme--on" : ""}`}
+                    onClick={() => settingsActions.setTermTheme(th.id)}
+                  >
+                    <div className="settings-font-head">
+                      <span className="settings-radio">{selected ? "✓" : ""}</span>
+                      <span className="settings-font-label">{th.label}</span>
+                      <span className="settings-font-tag">
+                        {th.variant === "dark" ? "Dark" : "Light"}
+                      </span>
+                    </div>
+                    {/* The preview is painted from the theme data itself, so a
+                     * palette edit can't drift from what it advertises. */}
+                    <div
+                      className="settings-termtheme-preview"
+                      style={{
+                        background: th.colors.background,
+                        color: th.colors.foreground,
+                        borderColor: th.colors.brightBlack,
+                      }}
+                    >
+                      <div className="settings-termtheme-dots">
+                        {ANSI_PREVIEW_KEYS.map((key) => (
+                          <span key={key} style={{ background: th.colors[key] }} />
+                        ))}
+                      </div>
+                      <span style={{ color: th.colors.green }}>$</span>{" "}
+                      <span style={{ color: th.colors.blue }}>remo</span> shell{" "}
+                      <span style={{ color: th.colors.yellow }}>web</span>
                     </div>
                   </button>
                 );

--- a/frontend/src/components/ShortcutsModal.css
+++ b/frontend/src/components/ShortcutsModal.css
@@ -2,7 +2,7 @@
   position: absolute;
   inset: 0;
   z-index: 70;
-  background: oklch(0.1 0.006 255 / 0.6);
+  background: var(--overlay-scrim);
   display: flex;
   align-items: center;
   justify-content: center;
@@ -15,7 +15,7 @@
   border: 1px solid var(--border-strong);
   border-radius: 14px;
   padding: 20px;
-  box-shadow: 0 24px 60px oklch(0 0 0 / 0.6);
+  box-shadow: 0 24px 60px var(--shadow-color-strong);
   animation: rpop 0.14s ease;
 }
 

--- a/frontend/src/components/TerminalCard.css
+++ b/frontend/src/components/TerminalCard.css
@@ -67,7 +67,7 @@
   opacity: 0.4;
 }
 .terminal-card--drop-target {
-  outline: 2px dashed color-mix(in oklch, var(--accent) 85%, white);
+  outline: 2px dashed var(--accent-strong);
   outline-offset: -3px;
   background: color-mix(in oklch, var(--accent) 12%, var(--bg-term));
 }
@@ -82,9 +82,9 @@
   display: flex;
   align-items: flex-start;
   border-radius: var(--radius-lg);
-  border: 2px dashed color-mix(in oklch, var(--accent) 80%, white);
+  border: 2px dashed var(--accent-strong);
   background: color-mix(in oklch, var(--accent) 16%, transparent);
-  box-shadow: 0 12px 30px oklch(0 0 0 / 0.35);
+  box-shadow: 0 12px 30px var(--shadow-color);
   cursor: grabbing;
   overflow: hidden;
 }
@@ -196,6 +196,102 @@
   background: var(--bg-btn-hover);
 }
 
+/* --- per-card terminal theme picker --- */
+.tc-theme {
+  position: relative;
+  display: flex;
+  align-items: center;
+}
+
+/* The swatch button paints itself in the card's terminal colors (set inline),
+ * so it reads as a live sample rather than a labelled control. */
+.tc-btn--swatch {
+  width: 26px;
+  height: 26px;
+  padding: 0;
+  border-radius: 50%;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  font-family: var(--font-mono);
+  font-size: 11px;
+  line-height: 1;
+}
+.terminal-card--grid .tc-btn--swatch {
+  width: 22px;
+  height: 22px;
+  font-size: 10px;
+}
+/* Keep the inline theme colors on hover — .tc-btn:hover would repaint it. */
+.tc-btn--swatch:hover {
+  background: inherit;
+  border-color: var(--accent-strong);
+}
+
+.tc-theme-menu {
+  position: absolute;
+  top: calc(100% + 6px);
+  right: 0;
+  z-index: 20;
+  min-width: 216px;
+  padding: 5px;
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  background: var(--bg-elev);
+  border: 1px solid var(--border-strong);
+  border-radius: 10px;
+  box-shadow: 0 14px 34px var(--shadow-color);
+  animation: rpop 0.12s ease;
+}
+
+.tc-theme-item {
+  display: flex;
+  align-items: center;
+  gap: 9px;
+  padding: 6px 8px;
+  border: 1px solid transparent;
+  border-radius: 7px;
+  background: transparent;
+  color: var(--text-1);
+  font-family: inherit;
+  font-size: 12px;
+  text-align: left;
+  cursor: pointer;
+}
+.tc-theme-item:hover {
+  background: var(--bg-row-hover);
+}
+.tc-theme-item--on {
+  border-color: color-mix(in oklch, var(--accent) 55%, var(--border-strong));
+  background: color-mix(in oklch, var(--accent) 12%, transparent);
+  color: var(--accent-strong);
+}
+
+/* Mini preview: the theme's background with three of its ANSI colors on top. */
+.tc-theme-swatch {
+  flex: none;
+  width: 34px;
+  height: 18px;
+  border-radius: 5px;
+  border: 1px solid;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 3px;
+}
+.tc-theme-swatch i {
+  width: 5px;
+  height: 5px;
+  border-radius: 50%;
+}
+
+.tc-theme-label {
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
 /* Window-control cluster: a tight row of square, icon-only mode buttons. */
 .tc-winctl {
   display: flex;
@@ -224,7 +320,7 @@
 .tc-btn--active {
   border-color: color-mix(in oklch, var(--accent) 55%, var(--border-strong));
   background: color-mix(in oklch, var(--accent) 18%, transparent);
-  color: color-mix(in oklch, var(--accent) 82%, white);
+  color: var(--accent-strong);
 }
 
 /* Unavailable modes (e.g. Grid with no grid to show) read as inert. */
@@ -244,21 +340,21 @@
 .tc-btn--accent {
   border-color: color-mix(in oklch, var(--accent) 45%, var(--border-strong));
   background: color-mix(in oklch, var(--accent) 15%, transparent);
-  color: color-mix(in oklch, var(--accent) 80%, white);
+  color: var(--accent-strong);
   font-weight: 600;
 }
 
 .tc-btn--close:hover {
-  background: oklch(0.3 0.05 25);
-  color: oklch(0.85 0.11 25);
+  background: var(--danger-surface-hover);
+  color: var(--danger-emph);
 }
 
 .terminal-card-error {
   flex: none;
   padding: 9px 12px;
-  background: oklch(0.2 0.03 25);
-  color: oklch(0.85 0.09 25);
-  border-bottom: 1px solid oklch(0.38 0.08 25);
+  background: var(--danger-surface);
+  color: var(--danger-text);
+  border-bottom: 1px solid var(--danger-border);
   font-size: 12px;
 }
 
@@ -287,11 +383,16 @@
     font-size: 13px;
   }
   .tc-btn--icon,
-  .terminal-card--grid .tc-btn--icon {
+  .terminal-card--grid .tc-btn--icon,
+  .tc-btn--swatch,
+  .terminal-card--grid .tc-btn--swatch {
     width: 34px;
     height: 34px;
     padding: 0;
     font-size: 15px;
+  }
+  .tc-theme-item {
+    padding: 10px 8px;
   }
   .tc-winctl {
     gap: 7px;

--- a/frontend/src/components/TerminalCard.test.tsx
+++ b/frontend/src/components/TerminalCard.test.tsx
@@ -1,0 +1,198 @@
+// Terminal-theme wiring for a card: the renderer is SEEDED with the effective
+// theme, later changes are applied to the LIVE terminal (never by remounting
+// it, which would drop the connection and scrollback), and a per-target
+// override takes precedence over the Settings-wide default.
+
+import { act, render, screen } from "@testing-library/react";
+import { DndContext } from "@dnd-kit/core";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { SessionTarget } from "../api/client";
+import type { RendererAdapter } from "../terminal/RendererAdapter";
+
+const adapters: RendererAdapter[] = [];
+
+function fakeAdapter(): RendererAdapter {
+  return {
+    open: vi.fn(),
+    write: vi.fn(),
+    onData: vi.fn().mockReturnValue(() => {}),
+    fit: vi.fn().mockReturnValue({ cols: 80, rows: 24 }),
+    resize: vi.fn(),
+    applyFont: vi.fn(),
+    applyTheme: vi.fn(),
+    focus: vi.fn(),
+    onTitleChange: vi.fn().mockReturnValue(() => {}),
+    onSelectionChange: vi.fn().mockReturnValue(() => {}),
+    getSelection: vi.fn().mockReturnValue(null),
+    copySelection: vi.fn().mockResolvedValue(false),
+    dispose: vi.fn(),
+  };
+}
+
+vi.mock("../terminal/defaultRenderer", () => ({
+  createDefaultRenderer: vi.fn((_font?: unknown, _choice?: unknown, theme?: unknown) => {
+    const adapter = fakeAdapter();
+    // Remember what the renderer was constructed with — the seeding contract.
+    (adapter as unknown as { seededTheme: unknown }).seededTheme = theme;
+    adapters.push(adapter);
+    return adapter;
+  }),
+}));
+
+vi.mock("../terminal/TerminalConnection", () => ({
+  TerminalConnection: class {
+    needsManualReconnect = false;
+    connect = vi.fn().mockResolvedValue(undefined);
+    close = vi.fn().mockResolvedValue(undefined);
+    sendInput = vi.fn();
+    sendResize = vi.fn();
+  },
+}));
+
+// jsdom has neither; TerminalCard observes its container and coalesces fits.
+class NoopResizeObserver {
+  observe(): void {}
+  unobserve(): void {}
+  disconnect(): void {}
+}
+globalThis.ResizeObserver = NoopResizeObserver as unknown as typeof ResizeObserver;
+
+const target = {
+  id: "t1",
+  project: "demo",
+  instance_type: "incus",
+  instance_name: "box",
+} as unknown as SessionTarget;
+
+async function mount(): Promise<{
+  settings: typeof import("../state/settings");
+  card: typeof import("./TerminalCard");
+}> {
+  vi.resetModules();
+  adapters.length = 0;
+  window.localStorage.clear();
+  const settings = await import("../state/settings");
+  const card = await import("./TerminalCard");
+  return { settings, card };
+}
+
+function renderCard(TerminalCard: typeof import("./TerminalCard").TerminalCard): void {
+  render(
+    <DndContext>
+      <TerminalCard
+        target={target}
+        mode="single"
+        isVisible
+        isFocused
+        viewState="normal"
+        onClose={() => {}}
+        onNormal={() => {}}
+        onToggleFullscreen={() => {}}
+      />
+    </DndContext>,
+  );
+}
+
+const seeded = (adapter: RendererAdapter): { background: string } =>
+  (adapter as unknown as { seededTheme: { background: string } }).seededTheme;
+
+beforeEach(() => {
+  window.localStorage.clear();
+});
+
+describe("TerminalCard terminal theme", () => {
+  it("seeds the renderer with the effective theme so the first frame is correct", async () => {
+    const { settings, card } = await mount();
+    settings.settingsActions.setTermTheme("dracula");
+    renderCard(card.TerminalCard);
+
+    expect(adapters).toHaveLength(1);
+    expect(seeded(adapters[0]).background).toBe("#282a36");
+  });
+
+  it("seeds the site-matched theme by default (no explicit choice)", async () => {
+    const { card } = await mount();
+    renderCard(card.TerminalCard);
+    // jsdom reports no OS preference, so the store's dark default stands.
+    expect(seeded(adapters[0]).background).toBe("#040608");
+  });
+
+  it("follows the site mode while the global choice is 'auto'", async () => {
+    const { settings, card } = await mount();
+    renderCard(card.TerminalCard);
+
+    act(() => settings.settingsActions.setThemeMode("light"));
+    expect(adapters[0].applyTheme).toHaveBeenLastCalledWith(
+      expect.objectContaining({ background: "#eff2f6" }),
+    );
+    expect(adapters).toHaveLength(1);
+  });
+
+  it("recolors the live terminal without rebuilding it", async () => {
+    const { settings, card } = await mount();
+    renderCard(card.TerminalCard);
+    expect(adapters).toHaveLength(1);
+
+    act(() => settings.settingsActions.setTermTheme("gruvbox-light"));
+
+    expect(adapters[0].applyTheme).toHaveBeenCalledWith(
+      expect.objectContaining({ background: "#fbf1c7", foreground: "#3c3836" }),
+    );
+    // The whole point: no second renderer, so the connection and scrollback of
+    // the first one survive the theme switch.
+    expect(adapters).toHaveLength(1);
+    expect(adapters[0].dispose).not.toHaveBeenCalled();
+  });
+
+  it("lets a per-target override win, and clearing it restores the global default", async () => {
+    const { settings, card } = await mount();
+    settings.settingsActions.setTermTheme("gruvbox-dark");
+    renderCard(card.TerminalCard);
+    expect(seeded(adapters[0]).background).toBe("#282828");
+
+    act(() => settings.settingsActions.setTermThemeOverride(target.id, "catppuccin-latte"));
+    expect(adapters[0].applyTheme).toHaveBeenLastCalledWith(
+      expect.objectContaining({ background: "#eff1f5" }),
+    );
+
+    act(() => settings.settingsActions.setTermThemeOverride(target.id, null));
+    expect(adapters[0].applyTheme).toHaveBeenLastCalledWith(
+      expect.objectContaining({ background: "#282828" }),
+    );
+  });
+
+  it("pins --bg-term to the card's theme so the surface gutter matches", async () => {
+    const { settings, card } = await mount();
+    settings.settingsActions.setTermTheme("solarized-light");
+    renderCard(card.TerminalCard);
+
+    const tile = screen.getByTestId(`terminal-card-${target.id}`);
+    expect(tile.style.getPropertyValue("--bg-term")).toBe("#fdf6e3");
+  });
+
+  it("offers the theme picker, selecting an override and clearing it back to default", async () => {
+    const { settings, card } = await mount();
+    renderCard(card.TerminalCard);
+
+    act(() => screen.getByTestId(`terminal-theme-${target.id}`).click());
+    act(() => screen.getByRole("menuitem", { name: /Dracula/ }).click());
+    expect(settings.getSettings().termThemeOverrides).toEqual({ [target.id]: "dracula" });
+
+    act(() => screen.getByTestId(`terminal-theme-${target.id}`).click());
+    act(() => screen.getByTestId(`terminal-theme-default-${target.id}`).click());
+    expect(settings.getSettings().termThemeOverrides).toEqual({});
+  });
+
+  it("closes the theme picker on Escape", async () => {
+    const { card } = await mount();
+    renderCard(card.TerminalCard);
+
+    act(() => screen.getByTestId(`terminal-theme-${target.id}`).click());
+    expect(screen.getByRole("menu")).toBeInTheDocument();
+
+    act(() => {
+      document.dispatchEvent(new KeyboardEvent("keydown", { key: "Escape" }));
+    });
+    expect(screen.queryByRole("menu")).not.toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/TerminalCard.tsx
+++ b/frontend/src/components/TerminalCard.tsx
@@ -9,16 +9,20 @@
 // single↔grid only re-renders the header chrome and never remounts the
 // terminal surface (which would tear down the live connection).
 
-import { useCallback, useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useRef, useState, type CSSProperties } from "react";
 import { useDraggable, useDroppable } from "@dnd-kit/core";
 import type { SessionTarget, TypedError } from "../api/client";
 import { providerMeta } from "./providerMeta";
 import {
+  effectiveTerminalTheme,
+  settingsActions,
+  terminalThemeLabel,
   terminalFontOptions,
   useSettings,
   type SettingsState,
   type TerminalFontOptions,
 } from "../state/settings";
+import { TERMINAL_THEMES, type TerminalThemeColors } from "../theme/terminalThemes";
 import { removeLatency, reportLatency } from "../state/latency";
 import type { RendererAdapter } from "../terminal/RendererAdapter";
 import { createDefaultRenderer } from "../terminal/defaultRenderer";
@@ -120,6 +124,7 @@ export function TerminalCard({
   const onEndedRef = useRef(onEnded);
   const onStartedRef = useRef(onStarted);
   const fontRef = useRef<TerminalFontOptions>(effectiveFont(settings, mode));
+  const themeRef = useRef<TerminalThemeColors>(effectiveTerminalTheme(settings, target.id).colors);
   // Coalesced-fit bookkeeping: a pending rAF handle, and the last dims we sent
   // (to skip redundant resize frames).
   const fitRafRef = useRef<number | null>(null);
@@ -135,6 +140,8 @@ export function TerminalCard({
   const [error, setError] = useState<TypedError | null>(null);
   const [hasSelection, setHasSelection] = useState(false);
   const [copied, setCopied] = useState(false);
+  const [themeMenuOpen, setThemeMenuOpen] = useState(false);
+  const themeMenuRef = useRef<HTMLDivElement | null>(null);
 
   // dnd-kit reorder: the tile is both a draggable (handle = header grip, below)
   // and a droppable (swap target). Disabled outside a reorderable grid. We use
@@ -218,6 +225,18 @@ export function TerminalCard({
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [font.fontFamily, font.fontSize, font.ligatures]);
 
+  // Apply a live terminal-theme change (global default or this card's
+  // override) to the open terminal. Deliberately NOT part of the mount effect's
+  // dep array: recoloring must never remount the terminal (that would drop the
+  // scrollback and reconnect). Colors don't alter cell metrics, so no re-fit.
+  const theme = effectiveTerminalTheme(settings, target.id);
+  useEffect(() => {
+    themeRef.current = theme.colors;
+    adapterRef.current?.applyTheme(theme.colors);
+    // theme is derived fresh each render; its id identifies the palette.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [theme.id]);
+
   useEffect(() => {
     if (createdRef.current) {
       return undefined;
@@ -228,7 +247,7 @@ export function TerminalCard({
     }
     createdRef.current = true;
 
-    const adapter = createDefaultRenderer(fontRef.current, settings.renderer);
+    const adapter = createDefaultRenderer(fontRef.current, settings.renderer, themeRef.current);
     adapterRef.current = adapter;
     adapter.open(container);
 
@@ -318,6 +337,29 @@ export function TerminalCard({
     }
   }, [isFocused, isVisible]);
 
+  // Dismiss the theme popup on Escape or a click anywhere outside it.
+  useEffect(() => {
+    if (!themeMenuOpen) {
+      return undefined;
+    }
+    const onPointerDown = (e: globalThis.PointerEvent): void => {
+      if (!themeMenuRef.current?.contains(e.target as Node)) {
+        setThemeMenuOpen(false);
+      }
+    };
+    const onKeyDown = (e: KeyboardEvent): void => {
+      if (e.key === "Escape") {
+        setThemeMenuOpen(false);
+      }
+    };
+    document.addEventListener("pointerdown", onPointerDown);
+    document.addEventListener("keydown", onKeyDown);
+    return () => {
+      document.removeEventListener("pointerdown", onPointerDown);
+      document.removeEventListener("keydown", onKeyDown);
+    };
+  }, [themeMenuOpen]);
+
   const handleReconnect = useCallback(() => {
     setError(null);
     void connectionRef.current?.reconnect();
@@ -371,6 +413,12 @@ export function TerminalCard({
   const prov = providerMeta(target.instance_type);
   const badge = [prov.label, target.instance_name, region].filter(Boolean).join(" · ");
 
+  // The Settings-wide choice, shown as the popup's "Default — …" entry. Under
+  // "auto" that resolves per site mode, so the entry names what it means now.
+  const globalTheme = effectiveTerminalTheme(settings);
+  const globalLabel = terminalThemeLabel(settings.termTheme, settings);
+  const hasThemeOverride = settings.termThemeOverrides[target.id] !== undefined;
+
   const isDragging = draggable.isDragging;
   // Highlight the tile the drop will land on (swap target) — but not the source.
   const isDropTarget = Boolean(reorderEnabled) && droppable.isOver && !isDragging;
@@ -383,7 +431,15 @@ export function TerminalCard({
       data-testid={`terminal-card-${target.id}`}
       data-focused={isFocused}
       data-connection-state={connectionState}
-      style={{ display: isVisible ? undefined : "none" }}
+      // --bg-term drives the card's own background and the surface's 2px/4px
+      // padding gutter; pinning it to this card's terminal theme keeps the
+      // gutter flush with what the emulator paints inside it.
+      style={
+        {
+          display: isVisible ? undefined : "none",
+          "--bg-term": theme.colors.background,
+        } as CSSProperties
+      }
       onMouseEnter={handleMouseEnter}
       onMouseLeave={clearHoverTimer}
     >
@@ -440,6 +496,74 @@ export function TerminalCard({
               ↻ Reconnect
             </button>
           )}
+          {/* Per-terminal color scheme. The swatch shows what this card is
+           * painted with; the popup sets an override, or clears back to
+           * "Default" so the card follows the Settings-wide choice again. */}
+          <div className="tc-theme" ref={themeMenuRef}>
+            <button
+              type="button"
+              className="tc-btn tc-btn--swatch"
+              data-testid={`terminal-theme-${target.id}`}
+              title={`Terminal theme: ${theme.label}${hasThemeOverride ? "" : " (default)"}`}
+              aria-label="Terminal theme"
+              aria-haspopup="menu"
+              aria-expanded={themeMenuOpen}
+              style={{ background: theme.colors.background, color: theme.colors.foreground }}
+              onClick={(e) => {
+                e.stopPropagation();
+                setThemeMenuOpen((v) => !v);
+              }}
+            >
+              A
+            </button>
+            {themeMenuOpen && (
+              <div className="tc-theme-menu" role="menu">
+                <button
+                  type="button"
+                  className={`tc-theme-item${hasThemeOverride ? "" : " tc-theme-item--on"}`}
+                  role="menuitem"
+                  data-testid={`terminal-theme-default-${target.id}`}
+                  onClick={(e) => {
+                    e.stopPropagation();
+                    settingsActions.setTermThemeOverride(target.id, null);
+                    setThemeMenuOpen(false);
+                  }}
+                >
+                  <span
+                    className="tc-theme-swatch"
+                    style={{
+                      background: globalTheme.colors.background,
+                      borderColor: globalTheme.colors.brightBlack,
+                    }}
+                  />
+                  <span className="tc-theme-label">Default — {globalLabel}</span>
+                </button>
+                {TERMINAL_THEMES.map((t) => (
+                  <button
+                    key={t.id}
+                    type="button"
+                    className={`tc-theme-item${hasThemeOverride && t.id === theme.id ? " tc-theme-item--on" : ""}`}
+                    role="menuitem"
+                    onClick={(e) => {
+                      e.stopPropagation();
+                      settingsActions.setTermThemeOverride(target.id, t.id);
+                      setThemeMenuOpen(false);
+                    }}
+                  >
+                    <span
+                      className="tc-theme-swatch"
+                      style={{ background: t.colors.background, borderColor: t.colors.brightBlack }}
+                    >
+                      <i style={{ background: t.colors.red }} />
+                      <i style={{ background: t.colors.green }} />
+                      <i style={{ background: t.colors.blue }} />
+                    </span>
+                    <span className="tc-theme-label">{t.label}</span>
+                  </button>
+                ))}
+              </div>
+            )}
+          </div>
           {/* Window-control cluster: mutually-exclusive display modes ordered
            * by how much space they take — Grid (smaller/tiled) → Normal (fills
            * the app's main pane) → Fullscreen (whole window) — plus close. The

--- a/frontend/src/components/TopBar.tsx
+++ b/frontend/src/components/TopBar.tsx
@@ -2,6 +2,7 @@
 // health indicator, refresh, settings, and shortcuts.
 
 import type { HealthStatus } from "../state/health";
+import type { SiteThemeMode } from "../state/settings";
 import "./TopBar.css";
 
 // "unconfigured" is included for Record exhaustiveness, but in practice the
@@ -23,6 +24,13 @@ const HEALTH_COLOR: Record<HealthStatus, string> = {
   offline: "var(--danger)",
 };
 
+/** Toggle glyph per mode: system reads as "half and half". */
+const THEME_ICON: Record<SiteThemeMode, string> = {
+  system: "◐",
+  light: "☀",
+  dark: "☾",
+};
+
 interface TopBarProps {
   showRailToggle: boolean;
   railCollapsed: boolean;
@@ -36,6 +44,13 @@ interface TopBarProps {
   onRefresh: () => void;
   onSettings: () => void;
   onShortcuts: () => void;
+  /** Site light/dark mode (this component stays pure-props; AppShell wires it
+   * to the settings store). */
+  themeMode: SiteThemeMode;
+  /** What the mode resolves to right now — only differs from `themeMode` under
+   * "system", where it reflects the OS preference. */
+  resolvedDark: boolean;
+  onCycleTheme: () => void;
 }
 
 /** Latency → dot color: good (green) / so-so (yellow) / poor (red). */
@@ -61,6 +76,9 @@ export function TopBar({
   onRefresh,
   onSettings,
   onShortcuts,
+  themeMode,
+  resolvedDark,
+  onCycleTheme,
 }: TopBarProps): JSX.Element {
   // Prefer live WS latency (the real data-path measure); fall back to the
   // health status when no terminal is connected to measure.
@@ -70,6 +88,10 @@ export function TopBar({
   const statusTitle = showLatency
     ? "WebSocket round-trip latency (median across open terminals)"
     : (healthDetail ?? HEALTH_LABEL[health]);
+  const themeTitle =
+    themeMode === "system"
+      ? `Theme: system (currently ${resolvedDark ? "dark" : "light"}) — click for light`
+      : `Theme: ${themeMode} — click for ${themeMode === "light" ? "dark" : "system"}`;
   return (
     <header className="topbar">
       {showRailToggle && (
@@ -112,6 +134,16 @@ export function TopBar({
         <span className={refreshing ? "rail-spin" : undefined}>⟳</span> Refresh
       </button>
 
+      <button
+        type="button"
+        className="topbar-icon-btn"
+        title={themeTitle}
+        aria-label={themeTitle}
+        data-testid="theme-toggle"
+        onClick={onCycleTheme}
+      >
+        {THEME_ICON[themeMode]}
+      </button>
       <button
         type="button"
         className="topbar-icon-btn"

--- a/frontend/src/state/settings.test.ts
+++ b/frontend/src/state/settings.test.ts
@@ -1,0 +1,281 @@
+import { act, renderHook } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const STORAGE_KEY = "remo-web:settings";
+
+// jsdom has no matchMedia, and the store treats it as optional (initSettings
+// bails out without it). Stub it so the "system" path is actually exercised,
+// and hand back an `emit` so a test can simulate the OS flipping theme.
+function stubMatchMedia(dark: boolean): { emit: (next: boolean) => void } {
+  const listeners = new Set<(e: MediaQueryListEvent) => void>();
+  const mql = {
+    matches: dark,
+    media: "(prefers-color-scheme: dark)",
+    onchange: null,
+    addEventListener: (_type: string, listener: (e: MediaQueryListEvent) => void) => {
+      listeners.add(listener);
+    },
+    removeEventListener: (_type: string, listener: (e: MediaQueryListEvent) => void) => {
+      listeners.delete(listener);
+    },
+    addListener: () => {},
+    removeListener: () => {},
+    dispatchEvent: () => false,
+  };
+  window.matchMedia = vi.fn().mockReturnValue(mql) as unknown as typeof window.matchMedia;
+  return {
+    emit(next: boolean) {
+      mql.matches = next;
+      for (const listener of listeners) {
+        listener({ matches: next } as MediaQueryListEvent);
+      }
+    },
+  };
+}
+
+// The store is a module singleton persisted to localStorage; reset the module
+// registry, storage, and the <html> attribute it writes so each test starts
+// from a genuinely cold app (workspace.test.ts pattern).
+async function load(): Promise<typeof import("./settings")> {
+  vi.resetModules();
+  return import("./settings");
+}
+
+beforeEach(() => {
+  window.localStorage.clear();
+  document.documentElement.removeAttribute("data-theme");
+  stubMatchMedia(true);
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("site theme mode", () => {
+  it("defaults to system and writes no data-theme attribute", async () => {
+    const settings = await load();
+    settings.initSettings();
+
+    expect(settings.getSettings().themeMode).toBe("system");
+    // No attribute at all: tokens.css's `color-scheme: light dark` resolves the
+    // OS preference itself, with no JS in the rendering path.
+    expect(document.documentElement.hasAttribute("data-theme")).toBe(false);
+  });
+
+  it("pins the attribute for an explicit choice and clears it back on system", async () => {
+    const settings = await load();
+    settings.initSettings();
+
+    act(() => settings.settingsActions.setThemeMode("dark"));
+    expect(document.documentElement.getAttribute("data-theme")).toBe("dark");
+
+    act(() => settings.settingsActions.setThemeMode("light"));
+    expect(document.documentElement.getAttribute("data-theme")).toBe("light");
+
+    act(() => settings.settingsActions.setThemeMode("system"));
+    expect(document.documentElement.hasAttribute("data-theme")).toBe(false);
+  });
+
+  it("round-trips the choice through localStorage", async () => {
+    const first = await load();
+    first.initSettings();
+    act(() => first.settingsActions.setThemeMode("light"));
+
+    document.documentElement.removeAttribute("data-theme");
+    const reloaded = await load();
+    reloaded.initSettings();
+
+    expect(reloaded.getSettings().themeMode).toBe("light");
+    expect(document.documentElement.getAttribute("data-theme")).toBe("light");
+  });
+
+  it("cycles system → light → dark → system", async () => {
+    const settings = await load();
+    settings.initSettings();
+
+    const seen: string[] = [];
+    for (let i = 0; i < 3; i += 1) {
+      act(() => settings.settingsActions.cycleThemeMode());
+      seen.push(settings.getSettings().themeMode);
+    }
+    expect(seen).toEqual(["light", "dark", "system"]);
+  });
+
+  it("resolves 'system' from the OS preference, live", async () => {
+    const media = stubMatchMedia(false);
+    const settings = await load();
+    settings.initSettings();
+
+    expect(settings.getSettings().systemPrefersDark).toBe(false);
+    expect(settings.resolvedSiteTheme()).toBe("light");
+
+    act(() => media.emit(true));
+    expect(settings.getSettings().systemPrefersDark).toBe(true);
+    expect(settings.resolvedSiteTheme()).toBe("dark");
+  });
+
+  it("ignores the OS preference once the user has chosen a mode", async () => {
+    const media = stubMatchMedia(true);
+    const settings = await load();
+    settings.initSettings();
+    act(() => settings.settingsActions.setThemeMode("light"));
+
+    act(() => media.emit(false));
+    expect(settings.resolvedSiteTheme()).toBe("light");
+    expect(document.documentElement.getAttribute("data-theme")).toBe("light");
+  });
+
+  it("never persists the derived OS preference", async () => {
+    const settings = await load();
+    settings.initSettings();
+    act(() => settings.settingsActions.setThemeMode("dark"));
+
+    const stored = JSON.parse(window.localStorage.getItem(STORAGE_KEY) ?? "{}") as Record<
+      string,
+      unknown
+    >;
+    expect(stored.themeMode).toBe("dark");
+    expect(stored).not.toHaveProperty("systemPrefersDark");
+  });
+
+  it("falls back to system when the persisted mode is garbage", async () => {
+    window.localStorage.setItem(STORAGE_KEY, JSON.stringify({ themeMode: "neon" }));
+    const settings = await load();
+    settings.initSettings();
+
+    expect(settings.getSettings().themeMode).toBe("system");
+    expect(document.documentElement.hasAttribute("data-theme")).toBe(false);
+  });
+});
+
+describe("terminal themes", () => {
+  it("defaults to following the site theme, with no overrides", async () => {
+    const settings = await load();
+    expect(settings.getSettings().termTheme).toBe("auto");
+    expect(settings.getSettings().termThemeOverrides).toEqual({});
+  });
+
+  // The point of the default: a light console never wraps a dark terminal.
+  it("resolves the default against the site mode, live", async () => {
+    const media = stubMatchMedia(true);
+    const settings = await load();
+    settings.initSettings();
+    expect(settings.effectiveTerminalTheme(settings.getSettings(), "a").id).toBe("remo-dark");
+
+    // Explicit light: the terminal follows immediately.
+    act(() => settings.settingsActions.setThemeMode("light"));
+    expect(settings.effectiveTerminalTheme(settings.getSettings(), "a").id).toBe("remo-light");
+
+    // Back to "system", and the OS itself flipping is enough to switch it.
+    act(() => settings.settingsActions.setThemeMode("system"));
+    expect(settings.effectiveTerminalTheme(settings.getSettings(), "a").id).toBe("remo-dark");
+    act(() => media.emit(false));
+    expect(settings.effectiveTerminalTheme(settings.getSettings(), "a").id).toBe("remo-light");
+  });
+
+  it("stops following the site once a concrete theme is chosen", async () => {
+    const settings = await load();
+    settings.initSettings();
+    act(() => settings.settingsActions.setTermTheme("dracula"));
+
+    act(() => settings.settingsActions.setThemeMode("light"));
+    expect(settings.effectiveTerminalTheme(settings.getSettings(), "a").id).toBe("dracula");
+  });
+
+  it("labels a selection, naming what 'auto' currently resolves to", async () => {
+    const settings = await load();
+    settings.initSettings();
+    act(() => settings.settingsActions.setThemeMode("dark"));
+    expect(settings.terminalThemeLabel("auto")).toBe("Follow site theme — Remo Dark");
+    act(() => settings.settingsActions.setThemeMode("light"));
+    expect(settings.terminalThemeLabel("auto")).toBe("Follow site theme — Remo Light");
+    expect(settings.terminalThemeLabel("dracula")).toBe("Dracula");
+  });
+
+  it("prefers a target's override over the global default", async () => {
+    const settings = await load();
+    act(() => settings.settingsActions.setTermTheme("gruvbox-dark"));
+    act(() => settings.settingsActions.setTermThemeOverride("a", "dracula"));
+
+    const state = settings.getSettings();
+    expect(settings.effectiveTerminalTheme(state, "a").id).toBe("dracula");
+    // A target without an override still follows the global choice.
+    expect(settings.effectiveTerminalTheme(state, "b").id).toBe("gruvbox-dark");
+  });
+
+  it("clearing an override deletes the key so the global default flows again", async () => {
+    const settings = await load();
+    act(() => settings.settingsActions.setTermThemeOverride("a", "dracula"));
+    act(() => settings.settingsActions.setTermThemeOverride("a", null));
+
+    expect(settings.getSettings().termThemeOverrides).toEqual({});
+
+    act(() => settings.settingsActions.setTermTheme("gruvbox-light"));
+    expect(settings.effectiveTerminalTheme(settings.getSettings(), "a").id).toBe("gruvbox-light");
+  });
+
+  it("prunes overrides for targets that no longer exist, keeping the live ones", async () => {
+    const settings = await load();
+    act(() => settings.settingsActions.setTermThemeOverride("a", "dracula"));
+    act(() => settings.settingsActions.setTermThemeOverride("gone", "gruvbox-dark"));
+
+    act(() => settings.settingsActions.pruneTermThemeOverrides(["a", "b"]));
+    expect(settings.getSettings().termThemeOverrides).toEqual({ a: "dracula" });
+  });
+
+  it("pruning against an unchanged set leaves the state object identical", async () => {
+    const settings = await load();
+    act(() => settings.settingsActions.setTermThemeOverride("a", "dracula"));
+    const before = settings.getSettings();
+
+    act(() => settings.settingsActions.pruneTermThemeOverrides(["a", "b"]));
+    expect(settings.getSettings()).toBe(before);
+  });
+
+  it("drops unknown persisted theme ids, globally and per target", async () => {
+    window.localStorage.setItem(
+      STORAGE_KEY,
+      JSON.stringify({
+        termTheme: "solarized-dark-which-we-do-not-ship",
+        termThemeOverrides: { a: "dracula", b: "nope", c: 7 },
+      }),
+    );
+    const settings = await load();
+
+    expect(settings.getSettings().termTheme).toBe("auto");
+    expect(settings.getSettings().termThemeOverrides).toEqual({ a: "dracula" });
+  });
+
+  // "auto" is a valid preference but NOT a theme id: it must survive a reload
+  // as the global choice, and must never be storable as a per-card override.
+  it("keeps 'auto' as a persisted global choice, but not as an override", async () => {
+    window.localStorage.setItem(
+      STORAGE_KEY,
+      JSON.stringify({ termTheme: "auto", termThemeOverrides: { a: "auto" } }),
+    );
+    const settings = await load();
+
+    expect(settings.getSettings().termTheme).toBe("auto");
+    expect(settings.getSettings().termThemeOverrides).toEqual({});
+  });
+
+  it("survives a non-object overrides blob", async () => {
+    window.localStorage.setItem(STORAGE_KEY, JSON.stringify({ termThemeOverrides: "nope" }));
+    const settings = await load();
+    expect(settings.getSettings().termThemeOverrides).toEqual({});
+  });
+});
+
+describe("useSettings", () => {
+  it("re-renders subscribers when the theme changes", async () => {
+    const settings = await load();
+    const { result } = renderHook(() => settings.useSettings());
+
+    expect(result.current.themeMode).toBe("system");
+    act(() => settings.settingsActions.setThemeMode("dark"));
+    expect(result.current.themeMode).toBe("dark");
+
+    act(() => settings.settingsActions.setTermTheme("dracula"));
+    expect(result.current.termTheme).toBe("dracula");
+  });
+});

--- a/frontend/src/state/settings.ts
+++ b/frontend/src/state/settings.ts
@@ -1,22 +1,61 @@
 // Settings store (console redesign).
 //
 // Same dependency-free `useSyncExternalStore` pattern as `workspace.ts` /
-// `discovery.ts`. Holds display preferences for the console: accent color,
-// terminal font/size/ligatures, grid fit mode, rail width, and the family
-// name of an uploaded Nerd Font (its bytes live in IndexedDB — see
-// state/fonts.ts). All preferences are browser-local (FR-034); nothing is
-// sent to the server.
+// `discovery.ts`. Holds display preferences for the console: site light/dark
+// mode, accent color, terminal font/size/ligatures, terminal color theme (with
+// per-target overrides), grid fit mode, rail width, and the family name of an
+// uploaded Nerd Font (its bytes live in IndexedDB — see state/fonts.ts). All
+// preferences are browser-local (FR-034); nothing is sent to the server.
 //
 // The terminal-affecting values are mirrored onto CSS custom properties on
 // <html> (`--accent`, `--term-font`, `--term-size`, `--term-liga`) so plain
 // CSS can react to them; the terminal renderers additionally read the derived
-// TerminalFontOptions (see terminalFontOptions()) to reconfigure live.
+// TerminalFontOptions (see terminalFontOptions()) and TerminalThemeColors (see
+// effectiveTerminalTheme()) to reconfigure live.
+//
+// Site mode is applied as `data-theme` on <html>, which theme/tokens.css turns
+// into a pinned `color-scheme` — "system" removes the attribute entirely and
+// lets the browser resolve `prefers-color-scheme` with no JS in the loop.
 
 import { useSyncExternalStore } from "react";
+import {
+  AUTO_TERMINAL_THEME,
+  DEFAULT_TERMINAL_SELECTION,
+  isTerminalThemeId,
+  isTerminalThemeSelection,
+  resolveTerminalTheme,
+  type TerminalTheme,
+} from "../theme/terminalThemes";
 
 const STORAGE_KEY = "remo-web:settings";
 
-export const ACCENT_OPTIONS = ["#38bdf8", "#4ade80", "#a78bfa", "#fb923c", "#e5e7eb"] as const;
+// The last entry is a mid-slate rather than a near-white: an off-white accent
+// is invisible against the light theme's surfaces, and the accent is used for
+// focus rings and borders in both modes.
+export const ACCENT_OPTIONS = ["#38bdf8", "#4ade80", "#a78bfa", "#fb923c", "#94a3b8"] as const;
+
+/** Site chrome theme. "system" follows the OS `prefers-color-scheme`. */
+export type SiteThemeMode = "system" | "light" | "dark";
+
+export interface SiteThemeOption {
+  value: SiteThemeMode;
+  label: string;
+  icon: string;
+  desc: string;
+}
+
+export const SITE_THEME_OPTIONS: SiteThemeOption[] = [
+  {
+    value: "system",
+    label: "System",
+    icon: "◐",
+    desc: "Follow this device's appearance setting, switching as it does.",
+  },
+  { value: "light", label: "Light", icon: "☀", desc: "Always use the light console theme." },
+  { value: "dark", label: "Dark", icon: "☾", desc: "Always use the dark console theme." },
+];
+
+const MEDIA_QUERY_DARK = "(prefers-color-scheme: dark)";
 
 /** Which browser terminal engine backs each terminal. xterm.js is the stable
  * default; ghostty-web is the opt-in WASM engine (falls back to xterm if its
@@ -75,7 +114,20 @@ export const MAX_FOCUS_DWELL_MS = 1000;
 const DEFAULT_FOCUS_DWELL_MS = 220;
 
 export interface SettingsState {
+  /** Site chrome theme; "system" defers to the OS. */
+  themeMode: SiteThemeMode;
+  /** Live OS preference. NOT persisted and NOT what drives rendering (CSS's
+   * `light-dark()` resolves "system" on its own) — it only lets the UI show
+   * which theme "system" currently resolves to. */
+  systemPrefersDark: boolean;
   accent: string;
+  /** Terminal color scheme applied to every terminal without an override —
+   * a theme id, or "auto" to track the site's light/dark mode. */
+  termTheme: string;
+  /** Per-target terminal theme overrides, keyed by `SessionTarget.id`. A target
+   * that should follow the global default is ABSENT here — "Default" is a
+   * deletion, never a stored id, so a later global change reaches it. */
+  termThemeOverrides: Record<string, string>;
   termFontCss: string;
   termSizeNum: number;
   termLiga: boolean;
@@ -98,7 +150,11 @@ export interface TerminalFontOptions {
 }
 
 const DEFAULTS: SettingsState = {
+  themeMode: "system",
+  systemPrefersDark: true,
   accent: ACCENT_OPTIONS[0],
+  termTheme: DEFAULT_TERMINAL_SELECTION,
+  termThemeOverrides: {},
   termFontCss: FONT_OPTIONS[0].css,
   termSizeNum: 13,
   termLiga: true,
@@ -114,6 +170,35 @@ function clamp(n: number, lo: number, hi: number): number {
   return Math.min(hi, Math.max(lo, n));
 }
 
+/** Current OS color preference; false wherever matchMedia is unavailable
+ * (jsdom without a stub, SSR). Only ever used for display — see the
+ * `systemPrefersDark` field comment. */
+function prefersDark(): boolean {
+  if (typeof window === "undefined" || typeof window.matchMedia !== "function") {
+    return DEFAULTS.systemPrefersDark;
+  }
+  return window.matchMedia(MEDIA_QUERY_DARK).matches;
+}
+
+/** Keep only entries whose value is a theme id this bundle knows. */
+function sanitizeOverrides(raw: unknown): Record<string, string> {
+  if (typeof raw !== "object" || raw === null) {
+    return {};
+  }
+  const out: Record<string, string> = {};
+  for (const [id, themeId] of Object.entries(raw as Record<string, unknown>)) {
+    if (isTerminalThemeId(themeId)) {
+      out[id] = themeId;
+    }
+  }
+  return out;
+}
+
+/** Pristine defaults, with the one derived (non-persisted) field filled in. */
+function freshDefaults(): SettingsState {
+  return { ...DEFAULTS, systemPrefersDark: prefersDark() };
+}
+
 function loadPersisted(): SettingsState {
   if (typeof window === "undefined" || !window.localStorage) {
     return { ...DEFAULTS };
@@ -121,15 +206,22 @@ function loadPersisted(): SettingsState {
   try {
     const raw = window.localStorage.getItem(STORAGE_KEY);
     if (!raw) {
-      return { ...DEFAULTS };
+      return freshDefaults();
     }
     const parsed: unknown = JSON.parse(raw);
     if (typeof parsed !== "object" || parsed === null) {
-      return { ...DEFAULTS };
+      return freshDefaults();
     }
     const c = parsed as Partial<SettingsState>;
     return {
+      themeMode:
+        c.themeMode === "light" || c.themeMode === "dark" || c.themeMode === "system"
+          ? c.themeMode
+          : DEFAULTS.themeMode,
+      systemPrefersDark: prefersDark(),
       accent: typeof c.accent === "string" ? c.accent : DEFAULTS.accent,
+      termTheme: isTerminalThemeSelection(c.termTheme) ? c.termTheme : DEFAULTS.termTheme,
+      termThemeOverrides: sanitizeOverrides(c.termThemeOverrides),
       termFontCss: typeof c.termFontCss === "string" ? c.termFontCss : DEFAULTS.termFontCss,
       termSizeNum:
         typeof c.termSizeNum === "number"
@@ -151,7 +243,7 @@ function loadPersisted(): SettingsState {
     };
   } catch (error) {
     console.error("settings: failed to restore from localStorage", error);
-    return { ...DEFAULTS };
+    return freshDefaults();
   }
 }
 
@@ -160,18 +252,28 @@ function persist(s: SettingsState): void {
     return;
   }
   try {
-    window.localStorage.setItem(STORAGE_KEY, JSON.stringify(s));
+    // systemPrefersDark is observed from the OS on every load, never restored.
+    const { systemPrefersDark: _derived, ...persistable } = s;
+    window.localStorage.setItem(STORAGE_KEY, JSON.stringify(persistable));
   } catch (error) {
     console.error("settings: failed to persist to localStorage", error);
   }
 }
 
-/** Push the terminal/accent vars onto <html> so CSS + renderers see them. */
+/** Push the site theme + terminal/accent vars onto <html> so CSS + renderers
+ * see them. */
 function applyToDom(s: SettingsState): void {
   if (typeof document === "undefined") {
     return;
   }
   const root = document.documentElement;
+  // "system" means "say nothing and let :root's `color-scheme: light dark`
+  // resolve prefers-color-scheme"; an explicit choice pins it (tokens.css).
+  if (s.themeMode === "system") {
+    root.removeAttribute("data-theme");
+  } else {
+    root.setAttribute("data-theme", s.themeMode);
+  }
   root.style.setProperty("--accent", s.accent);
   root.style.setProperty("--term-font", s.termFontCss);
   root.style.setProperty("--term-size", `${s.termSizeNum}px`);
@@ -200,9 +302,50 @@ function getSnapshot(): SettingsState {
   return state;
 }
 
-/** Apply persisted settings to the DOM once, at startup (before first paint). */
+/** Apply persisted settings to the DOM once, at startup (before first paint),
+ * and start tracking the OS color preference.
+ *
+ * Note the deliberate gap: a user whose explicit light/dark choice disagrees
+ * with the OS can see one OS-colored frame before this runs. Closing it would
+ * take an inline <script> in index.html, which the service's
+ * `default-src 'self'` CSP forbids. */
 export function initSettings(): void {
   applyToDom(state);
+  if (typeof window === "undefined" || typeof window.matchMedia !== "function") {
+    return;
+  }
+  const media = window.matchMedia(MEDIA_QUERY_DARK);
+  setState({ systemPrefersDark: media.matches });
+  // Rendering under "system" needs no listener (CSS resolves it live); this
+  // only keeps the top bar's icon/tooltip honest about what "system" means now.
+  media.addEventListener("change", (e) => setState({ systemPrefersDark: e.matches }));
+}
+
+/** Which of the two palettes is actually showing right now. */
+export function resolvedSiteTheme(s: SettingsState = state): "light" | "dark" {
+  if (s.themeMode === "system") {
+    return s.systemPrefersDark ? "dark" : "light";
+  }
+  return s.themeMode;
+}
+
+/** The terminal theme for `targetId`: its override if it has one, else the
+ * global choice. "auto" (the default) — and any unrecognized id — resolves to
+ * the site-matched theme for whichever mode is showing, so the terminal tracks
+ * the console until the user picks something specific. */
+export function effectiveTerminalTheme(
+  s: SettingsState = state,
+  targetId?: string,
+): TerminalTheme {
+  const override = targetId === undefined ? undefined : s.termThemeOverrides[targetId];
+  return resolveTerminalTheme(override ?? s.termTheme, resolvedSiteTheme(s) === "dark");
+}
+
+/** How a terminal-theme preference reads in the UI. "auto" names the theme it
+ * currently resolves to, so the label is never a dead end. */
+export function terminalThemeLabel(selection: string, s: SettingsState = state): string {
+  const theme = resolveTerminalTheme(selection, resolvedSiteTheme(s) === "dark");
+  return selection === AUTO_TERMINAL_THEME ? `Follow site theme — ${theme.label}` : theme.label;
 }
 
 export function getSettings(): SettingsState {
@@ -214,6 +357,38 @@ export function terminalFontOptions(s: SettingsState = state): TerminalFontOptio
 }
 
 export const settingsActions = {
+  setThemeMode: (themeMode: SiteThemeMode) => setState({ themeMode }),
+  /** Top-bar toggle: system → light → dark → system. */
+  cycleThemeMode: () => {
+    const order: SiteThemeMode[] = ["system", "light", "dark"];
+    const next = order[(order.indexOf(state.themeMode) + 1) % order.length];
+    setState({ themeMode: next });
+  },
+  setTermTheme: (termTheme: string) => setState({ termTheme }),
+  /** Set (or, with `null`, clear) one target's terminal-theme override.
+   * Clearing DELETES the key rather than storing the current global id, so the
+   * target keeps following the global default when that later changes. */
+  setTermThemeOverride: (targetId: string, themeId: string | null) => {
+    const next = { ...state.termThemeOverrides };
+    if (themeId === null) {
+      delete next[targetId];
+    } else {
+      next[targetId] = themeId;
+    }
+    setState({ termThemeOverrides: next });
+  },
+  /** Drop overrides for targets that no longer exist, so the stored map can't
+   * grow without bound. Callers must only pass a successful, non-empty
+   * discovery result — pruning against a failed snapshot would wipe live
+   * preferences. */
+  pruneTermThemeOverrides: (liveIds: readonly string[]) => {
+    const live = new Set(liveIds);
+    const entries = Object.entries(state.termThemeOverrides).filter(([id]) => live.has(id));
+    if (entries.length === Object.keys(state.termThemeOverrides).length) {
+      return; // nothing to drop — don't churn the store
+    }
+    setState({ termThemeOverrides: Object.fromEntries(entries) });
+  },
   setAccent: (accent: string) => setState({ accent }),
   setTermFont: (termFontCss: string) => setState({ termFontCss }),
   setTermSize: (termSizeNum: number) =>

--- a/frontend/src/terminal/GhosttyRenderer.ts
+++ b/frontend/src/terminal/GhosttyRenderer.ts
@@ -16,6 +16,7 @@ import type {
   RendererAdapter,
   TerminalDimensions,
   TerminalFontOptions,
+  TerminalThemeColors,
 } from "./RendererAdapter";
 
 /** Minimal shape of the disposable object xterm.js-compatible `on*` methods
@@ -39,13 +40,14 @@ export class GhosttyRenderer implements RendererAdapter {
    * plus synthesize Shift+Enter, through one path). */
   private readonly dataHandlers = new Set<(data: Uint8Array | string) => void>();
 
-  constructor(font: TerminalFontOptions = DEFAULT_FONT) {
+  constructor(font: TerminalFontOptions = DEFAULT_FONT, theme?: TerminalThemeColors) {
     this.font = font;
     this.terminal = new Terminal({
       cursorBlink: true,
       scrollback: 5000,
       fontFamily: font.fontFamily,
       fontSize: font.fontSize,
+      ...(theme ? { theme: { ...theme } } : {}),
     });
     this.terminal.onData((data: string | Uint8Array) => this.emit(data));
     // Best-effort Shift+Enter → ESC+CR (newline), matching XtermRenderer. Guarded
@@ -125,6 +127,16 @@ export class GhosttyRenderer implements RendererAdapter {
     if (opts) {
       opts.fontFamily = options.fontFamily;
       opts.fontSize = options.fontSize;
+    }
+  }
+
+  applyTheme(colors: TerminalThemeColors): void {
+    // Same defensive options-bag guard as applyFont: ghostty-web is pre-1.0 and
+    // a build without a writable `options` must degrade to "the theme applies
+    // on the next mount", never throw at a user switching themes.
+    const opts = (this.terminal as unknown as { options?: Record<string, unknown> }).options;
+    if (opts) {
+      opts.theme = { ...colors };
     }
   }
 

--- a/frontend/src/terminal/RendererAdapter.ts
+++ b/frontend/src/terminal/RendererAdapter.ts
@@ -34,6 +34,34 @@ export interface TerminalFontOptions {
   ligatures: boolean;
 }
 
+/** A terminal color scheme, in the `ITheme` shape both engines accept. The
+ * concrete palettes live in theme/terminalThemes.ts; this file stays
+ * import-free, so the shape is re-declared structurally here. */
+export interface TerminalThemeColors {
+  background: string;
+  foreground: string;
+  cursor: string;
+  cursorAccent: string;
+  selectionBackground: string;
+  selectionForeground: string;
+  black: string;
+  red: string;
+  green: string;
+  yellow: string;
+  blue: string;
+  magenta: string;
+  cyan: string;
+  white: string;
+  brightBlack: string;
+  brightRed: string;
+  brightGreen: string;
+  brightYellow: string;
+  brightBlue: string;
+  brightMagenta: string;
+  brightCyan: string;
+  brightWhite: string;
+}
+
 /**
  * A Remo-owned adapter over a concrete browser terminal renderer
  * (`ghostty-web` or `xterm`). Implementations translate this interface's
@@ -74,6 +102,14 @@ export interface RendererAdapter {
    * before `open()` (they cache the options for the eventual open).
    */
   applyFont(options: TerminalFontOptions): void;
+
+  /**
+   * Applies a new color scheme to a live terminal. Unlike `applyFont` this
+   * does not change the cell grid, so no `fit()` is needed afterwards.
+   * Implementations must be safe to call before `open()` (they cache the
+   * colors for the eventual open).
+   */
+  applyTheme(colors: TerminalThemeColors): void;
 
   /** Moves keyboard focus into the terminal. */
   focus(): void;

--- a/frontend/src/terminal/XtermRenderer.ts
+++ b/frontend/src/terminal/XtermRenderer.ts
@@ -31,6 +31,7 @@ import type {
   RendererAdapter,
   TerminalDimensions,
   TerminalFontOptions,
+  TerminalThemeColors,
 } from "./RendererAdapter";
 
 // OSC 52 handling: WRITE lets a remote app (e.g. Claude Code's copy-on-select)
@@ -65,13 +66,16 @@ export class XtermRenderer implements RendererAdapter {
    * remote PTY through the same path. */
   private readonly dataHandlers = new Set<(data: Uint8Array | string) => void>();
 
-  constructor(font: TerminalFontOptions = DEFAULT_FONT) {
+  constructor(font: TerminalFontOptions = DEFAULT_FONT, theme?: TerminalThemeColors) {
     this.terminal = new Terminal({
       cursorBlink: true,
       convertEol: false,
       scrollback: 5000,
       fontFamily: font.fontFamily,
       fontSize: font.fontSize,
+      // A copy: xterm keeps the object we hand it, and our caller's is shared
+      // across every terminal using this theme.
+      ...(theme ? { theme: { ...theme } } : {}),
       // @xterm/addon-ligatures registers a character joiner, which lives behind
       // xterm's "proposed API" guard; without this the addon throws on load.
       allowProposedApi: true,
@@ -204,6 +208,17 @@ export class XtermRenderer implements RendererAdapter {
     this.terminal.options.fontFamily = options.fontFamily;
     this.terminal.options.fontSize = options.fontSize;
     this.applyLigatures(options.ligatures);
+  }
+
+  applyTheme(colors: TerminalThemeColors): void {
+    // A FRESH object is required: xterm only reacts to the `theme` options
+    // setter, so mutating the existing one in place would change nothing.
+    this.terminal.options.theme = { ...colors };
+    // The WebGL renderer caches a glyph atlas keyed on the old colors; force a
+    // full repaint so no stale-colored cells survive the switch.
+    if (this.opened) {
+      this.terminal.refresh(0, this.terminal.rows - 1);
+    }
   }
 
   focus(): void {

--- a/frontend/src/terminal/defaultRenderer.ts
+++ b/frontend/src/terminal/defaultRenderer.ts
@@ -20,7 +20,11 @@
 
 import { init as ghosttyInit } from "ghostty-web";
 import type { RendererChoice } from "../state/settings";
-import type { RendererAdapter, TerminalFontOptions } from "./RendererAdapter";
+import type {
+  RendererAdapter,
+  TerminalFontOptions,
+  TerminalThemeColors,
+} from "./RendererAdapter";
 import { GhosttyRenderer } from "./GhosttyRenderer";
 import { XtermRenderer } from "./XtermRenderer";
 
@@ -55,11 +59,15 @@ export function isGhosttyReady(): boolean {
 
 /** Build the renderer `TerminalCard` uses. `choice` is the user's selected
  * engine (default "xterm"); ghostty is used only when explicitly chosen AND its
- * WASM init succeeded, else we fall back to xterm. `font` seeds the initial
- * family/size/ligatures from the settings store. */
+ * WASM init succeeded, else we fall back to xterm. `font` and `theme` seed the
+ * initial family/size/ligatures and color scheme from the settings store, so a
+ * freshly-mounted terminal paints correctly on its first frame. */
 export function createDefaultRenderer(
   font?: TerminalFontOptions,
   choice: RendererChoice = "xterm",
+  theme?: TerminalThemeColors,
 ): RendererAdapter {
-  return choice === "ghostty" && ghosttyReady ? new GhosttyRenderer(font) : new XtermRenderer(font);
+  return choice === "ghostty" && ghosttyReady
+    ? new GhosttyRenderer(font, theme)
+    : new XtermRenderer(font, theme);
 }

--- a/frontend/src/theme/terminalThemes.test.ts
+++ b/frontend/src/theme/terminalThemes.test.ts
@@ -1,0 +1,146 @@
+import { describe, expect, it } from "vitest";
+import {
+  AUTO_DARK_THEME_ID,
+  AUTO_LIGHT_THEME_ID,
+  AUTO_TERMINAL_THEME,
+  autoTerminalTheme,
+  DEFAULT_TERMINAL_SELECTION,
+  isTerminalThemeId,
+  isTerminalThemeSelection,
+  resolveTerminalTheme,
+  TERMINAL_THEMES,
+  type TerminalThemeColors,
+} from "./terminalThemes";
+
+const HEX = /^#[0-9a-fA-F]{6}$/;
+
+// The 22 fields both engines' ITheme accepts. Listed literally rather than
+// derived from a sample theme, so a field dropped from every palette at once
+// still fails here.
+const COLOR_KEYS: (keyof TerminalThemeColors)[] = [
+  "background",
+  "foreground",
+  "cursor",
+  "cursorAccent",
+  "selectionBackground",
+  "selectionForeground",
+  "black",
+  "red",
+  "green",
+  "yellow",
+  "blue",
+  "magenta",
+  "cyan",
+  "white",
+  "brightBlack",
+  "brightRed",
+  "brightGreen",
+  "brightYellow",
+  "brightBlue",
+  "brightMagenta",
+  "brightCyan",
+  "brightWhite",
+];
+
+describe("terminal themes", () => {
+  it("offers eight themes with unique ids", () => {
+    expect(TERMINAL_THEMES).toHaveLength(8);
+    expect(new Set(TERMINAL_THEMES.map((t) => t.id)).size).toBe(8);
+  });
+
+  it("balances four dark and four light schemes", () => {
+    const byVariant = (v: "dark" | "light") => TERMINAL_THEMES.filter((t) => t.variant === v);
+    expect(byVariant("dark")).toHaveLength(4);
+    expect(byVariant("light")).toHaveLength(4);
+  });
+
+  // The site-matched pair is what "auto" resolves to, so their variants must
+  // line up with the site mode they stand in for.
+  it("ships a site-matched pair, one per variant", () => {
+    expect(autoTerminalTheme(true).id).toBe(AUTO_DARK_THEME_ID);
+    expect(autoTerminalTheme(true).variant).toBe("dark");
+    expect(autoTerminalTheme(false).id).toBe(AUTO_LIGHT_THEME_ID);
+    expect(autoTerminalTheme(false).variant).toBe("light");
+  });
+
+  // The palette is a hand-derived snapshot of theme/tokens.css (it cannot
+  // reference the tokens live), so pin the anchors that make it "matching":
+  // the terminal background IS --bg-term, and the foreground IS --text.
+  it("anchors the site-matched pair to the console's own surface colors", () => {
+    expect(autoTerminalTheme(true).colors.background).toBe("#040608"); // --bg-term dark
+    expect(autoTerminalTheme(true).colors.foreground).toBe("#e2e5e9"); // --text dark
+    expect(autoTerminalTheme(false).colors.background).toBe("#eff2f6"); // --bg-term light
+    expect(autoTerminalTheme(false).colors.foreground).toBe("#242930"); // --text light
+  });
+
+  // ghostty-web's color parser is the strict one: no `#rgb`, no alpha, no
+  // oklch(). A palette typo that lands here would show up as a silently
+  // mis-rendered terminal, so pin the format.
+  it.each(TERMINAL_THEMES)("$label declares all 22 colors as #rrggbb", (theme) => {
+    for (const key of COLOR_KEYS) {
+      expect(theme.colors[key], `${theme.id}.${key}`).toMatch(HEX);
+    }
+    expect(Object.keys(theme.colors).sort()).toEqual([...COLOR_KEYS].sort());
+  });
+
+  it("has non-empty labels", () => {
+    for (const theme of TERMINAL_THEMES) {
+      expect(theme.label.length).toBeGreaterThan(0);
+    }
+  });
+
+  it("defaults to following the site theme", () => {
+    expect(DEFAULT_TERMINAL_SELECTION).toBe(AUTO_TERMINAL_THEME);
+  });
+
+  describe("resolveTerminalTheme", () => {
+    it("returns the requested theme regardless of site mode", () => {
+      expect(resolveTerminalTheme("dracula", true).label).toBe("Dracula");
+      expect(resolveTerminalTheme("dracula", false).label).toBe("Dracula");
+    });
+
+    it("follows the site mode for 'auto'", () => {
+      expect(resolveTerminalTheme(AUTO_TERMINAL_THEME, true).id).toBe(AUTO_DARK_THEME_ID);
+      expect(resolveTerminalTheme(AUTO_TERMINAL_THEME, false).id).toBe(AUTO_LIGHT_THEME_ID);
+    });
+
+    // An unknown id can only come from a newer bundle or a hand-edited store;
+    // resolving it like "auto" can never strand a dark terminal on a light page.
+    it("treats an unknown or missing id as 'auto'", () => {
+      expect(resolveTerminalTheme("nord-but-invented", false).id).toBe(AUTO_LIGHT_THEME_ID);
+      expect(resolveTerminalTheme(undefined, true).id).toBe(AUTO_DARK_THEME_ID);
+    });
+  });
+
+  describe("isTerminalThemeSelection", () => {
+    it("accepts 'auto' and every shipped id, and nothing else", () => {
+      expect(isTerminalThemeSelection(AUTO_TERMINAL_THEME)).toBe(true);
+      for (const theme of TERMINAL_THEMES) {
+        expect(isTerminalThemeSelection(theme.id)).toBe(true);
+      }
+      expect(isTerminalThemeSelection("system")).toBe(false);
+      expect(isTerminalThemeSelection(null)).toBe(false);
+    });
+
+    it("does not let 'auto' pass as a concrete theme id", () => {
+      expect(isTerminalThemeId(AUTO_TERMINAL_THEME)).toBe(false);
+    });
+  });
+
+  describe("isTerminalThemeId", () => {
+    it("accepts every shipped id", () => {
+      for (const theme of TERMINAL_THEMES) {
+        expect(isTerminalThemeId(theme.id)).toBe(true);
+      }
+    });
+
+    it("rejects non-ids", () => {
+      expect(isTerminalThemeId("solarized-dark")).toBe(false);
+      expect(isTerminalThemeId("")).toBe(false);
+      expect(isTerminalThemeId(undefined)).toBe(false);
+      expect(isTerminalThemeId(null)).toBe(false);
+      expect(isTerminalThemeId(3)).toBe(false);
+      expect(isTerminalThemeId({ id: "dracula" })).toBe(false);
+    });
+  });
+});

--- a/frontend/src/theme/terminalThemes.ts
+++ b/frontend/src/theme/terminalThemes.ts
@@ -1,0 +1,363 @@
+// Curated terminal color schemes for the browser terminals.
+//
+// Console-owned presentation data (no service shape involved), so this module
+// is hand-written rather than generated — see the frontend Code Style note in
+// CLAUDE.md. It is deliberately dependency-free: `state/settings.ts` imports it
+// to validate persisted ids, and the settings store must stay importable
+// without dragging in a renderer.
+//
+// Every color is plain `#rrggbb`. Both engines take an xterm.js-shaped `ITheme`
+// object, and ghostty-web's parser is the least forgiving of the two, so no
+// `oklch()`, no `#rgb` shorthand, and no alpha — an opaque selection color is
+// what both engines expect.
+//
+// Two of the schemes (Remo Dark/Light) are derived from the console's own
+// tokens so the terminal matches the chrome — see the block comment on them.
+// The rest are the official upstream ports: catppuccin.com/palette,
+// draculatheme.com, github.com/morhetz/gruvbox, github.com/altercation/solarized.
+
+/** The exact set of fields shared by xterm.js's and ghostty-web's `ITheme`. */
+export interface TerminalThemeColors {
+  background: string;
+  foreground: string;
+  cursor: string;
+  cursorAccent: string;
+  selectionBackground: string;
+  selectionForeground: string;
+  black: string;
+  red: string;
+  green: string;
+  yellow: string;
+  blue: string;
+  magenta: string;
+  cyan: string;
+  white: string;
+  brightBlack: string;
+  brightRed: string;
+  brightGreen: string;
+  brightYellow: string;
+  brightBlue: string;
+  brightMagenta: string;
+  brightCyan: string;
+  brightWhite: string;
+}
+
+export type TerminalThemeId =
+  | "remo-dark"
+  | "remo-light"
+  | "catppuccin-mocha"
+  | "dracula"
+  | "gruvbox-dark"
+  | "solarized-light"
+  | "catppuccin-latte"
+  | "gruvbox-light";
+
+export interface TerminalTheme {
+  id: TerminalThemeId;
+  label: string;
+  /** Whether the scheme is light-on-dark or dark-on-light. Shown as a tag in
+   * Settings; a theme of either variant is selectable in either site mode. */
+  variant: "dark" | "light";
+  colors: TerminalThemeColors;
+}
+
+/** The pseudo-selection meaning "track the console's own light/dark mode".
+ * It is not a theme id — it resolves to one at render time. */
+export const AUTO_TERMINAL_THEME = "auto";
+
+/** What a terminal-theme preference can be: a concrete theme, or "auto". */
+export type TerminalThemeSelection = TerminalThemeId | typeof AUTO_TERMINAL_THEME;
+
+/** Out of the box the terminal follows the console, so a light site doesn't
+ * wrap a dark terminal (and vice versa) until the user picks for themselves. */
+export const DEFAULT_TERMINAL_SELECTION: TerminalThemeSelection = AUTO_TERMINAL_THEME;
+
+/** The pair "auto" chooses between — the two site-matched themes. */
+export const AUTO_DARK_THEME_ID: TerminalThemeId = "remo-dark";
+export const AUTO_LIGHT_THEME_ID: TerminalThemeId = "remo-light";
+
+export const TERMINAL_THEMES: TerminalTheme[] = [
+  // --- Site-matched pair (first: these are what "auto" resolves to) ---------
+  //
+  // Snapshots of theme/tokens.css, converted oklch -> sRGB by the browser's own
+  // color pipeline, so a terminal sits flush with the chrome around it:
+  //   background   <- --bg-term          foreground  <- --text
+  //   ANSI 1-6     <- --danger/--ok/--warn/--info/--mag/--cyan
+  //   black/white  <- the --bg-elev/--text-2/--border steps
+  //   cursor       <- --info (NOT --accent: the accent is user-tunable, and a
+  //                   static palette could not follow it)
+  // These are SNAPSHOTS, not live references — a terminal palette has to be
+  // literal #rrggbb (ghostty-web's parser takes neither oklch() nor var()).
+  // Editing a token therefore does NOT update these; re-derive them by hand.
+  //
+  // One deliberate deviation: magenta is pulled to hue 330 (the token is 350),
+  // because --danger sits at hue 25 and 350 left red and magenta too close to
+  // tell apart in ls/diff output. Chrome keeps the original --mag.
+  {
+    id: "remo-dark",
+    label: "Remo Dark",
+    variant: "dark",
+    colors: {
+      background: "#040608",
+      foreground: "#e2e5e9",
+      cursor: "#74c2ee",
+      cursorAccent: "#040608",
+      selectionBackground: "#2c3136",
+      selectionForeground: "#e2e5e9",
+      black: "#15191e",
+      red: "#fd736d",
+      green: "#6ed889",
+      yellow: "#eac25a",
+      blue: "#74c2ee",
+      magenta: "#e175d9",
+      cyan: "#71d0d5",
+      white: "#a0a5ab",
+      brightBlack: "#5f646a",
+      brightRed: "#ff9188",
+      brightGreen: "#90f1a6",
+      brightYellow: "#ffda7c",
+      brightBlue: "#8ddcff",
+      brightMagenta: "#f695ee",
+      brightCyan: "#8beaef",
+      brightWhite: "#e2e5e9",
+    },
+  },
+  {
+    id: "remo-light",
+    label: "Remo Light",
+    variant: "light",
+    // On a light background the "bright" half goes DARKER, not lighter — the
+    // same inversion Solarized Light uses, so bold text stays legible.
+    colors: {
+      background: "#eff2f6",
+      foreground: "#242930",
+      cursor: "#007bb2",
+      cursorAccent: "#eff2f6",
+      selectionBackground: "#d5d8db",
+      selectionForeground: "#242930",
+      black: "#242930",
+      red: "#c2272d",
+      green: "#05893e",
+      yellow: "#9a7400",
+      blue: "#007bb2",
+      magenta: "#ad36a7",
+      cyan: "#008389",
+      white: "#d5d8db",
+      brightBlack: "#6c727a",
+      brightRed: "#a9000c",
+      brightGreen: "#007026",
+      brightYellow: "#825c00",
+      brightBlue: "#0064a1",
+      brightMagenta: "#950891",
+      brightCyan: "#006b71",
+      brightWhite: "#fbfcfd",
+    },
+  },
+  // --- Curated third-party schemes -----------------------------------------
+  {
+    id: "catppuccin-mocha",
+    label: "Catppuccin Mocha",
+    variant: "dark",
+    colors: {
+      background: "#1e1e2e",
+      foreground: "#cdd6f4",
+      cursor: "#f5e0dc",
+      cursorAccent: "#1e1e2e",
+      selectionBackground: "#585b70",
+      selectionForeground: "#cdd6f4",
+      black: "#45475a",
+      red: "#f38ba8",
+      green: "#a6e3a1",
+      yellow: "#f9e2af",
+      blue: "#89b4fa",
+      magenta: "#f5c2e7",
+      cyan: "#94e2d5",
+      white: "#bac2de",
+      brightBlack: "#585b70",
+      brightRed: "#f38ba8",
+      brightGreen: "#a6e3a1",
+      brightYellow: "#f9e2af",
+      brightBlue: "#89b4fa",
+      brightMagenta: "#f5c2e7",
+      brightCyan: "#94e2d5",
+      brightWhite: "#a6adc8",
+    },
+  },
+  {
+    id: "dracula",
+    label: "Dracula",
+    variant: "dark",
+    colors: {
+      background: "#282a36",
+      foreground: "#f8f8f2",
+      cursor: "#f8f8f2",
+      cursorAccent: "#282a36",
+      selectionBackground: "#44475a",
+      selectionForeground: "#f8f8f2",
+      black: "#21222c",
+      red: "#ff5555",
+      green: "#50fa7b",
+      yellow: "#f1fa8c",
+      blue: "#bd93f9",
+      magenta: "#ff79c6",
+      cyan: "#8be9fd",
+      white: "#f8f8f2",
+      brightBlack: "#6272a4",
+      brightRed: "#ff6e6e",
+      brightGreen: "#69ff94",
+      brightYellow: "#ffffa5",
+      brightBlue: "#d6acff",
+      brightMagenta: "#ff92df",
+      brightCyan: "#a4ffff",
+      brightWhite: "#ffffff",
+    },
+  },
+  {
+    id: "gruvbox-dark",
+    label: "Gruvbox Dark",
+    variant: "dark",
+    colors: {
+      background: "#282828",
+      foreground: "#ebdbb2",
+      cursor: "#ebdbb2",
+      cursorAccent: "#282828",
+      selectionBackground: "#504945",
+      selectionForeground: "#ebdbb2",
+      black: "#282828",
+      red: "#cc241d",
+      green: "#98971a",
+      yellow: "#d79921",
+      blue: "#458588",
+      magenta: "#b16286",
+      cyan: "#689d6a",
+      white: "#a89984",
+      brightBlack: "#928374",
+      brightRed: "#fb4934",
+      brightGreen: "#b8bb26",
+      brightYellow: "#fabd2f",
+      brightBlue: "#83a598",
+      brightMagenta: "#d3869b",
+      brightCyan: "#8ec07c",
+      brightWhite: "#ebdbb2",
+    },
+  },
+  {
+    id: "solarized-light",
+    label: "Solarized Light",
+    variant: "light",
+    colors: {
+      background: "#fdf6e3",
+      foreground: "#657b83",
+      cursor: "#657b83",
+      cursorAccent: "#fdf6e3",
+      selectionBackground: "#eee8d5",
+      selectionForeground: "#657b83",
+      black: "#073642",
+      red: "#dc322f",
+      green: "#859900",
+      yellow: "#b58900",
+      blue: "#268bd2",
+      magenta: "#d33682",
+      cyan: "#2aa198",
+      white: "#eee8d5",
+      brightBlack: "#002b36",
+      brightRed: "#cb4b16",
+      brightGreen: "#586e75",
+      brightYellow: "#657b83",
+      brightBlue: "#839496",
+      brightMagenta: "#6c71c4",
+      brightCyan: "#93a1a1",
+      brightWhite: "#fdf6e3",
+    },
+  },
+  {
+    id: "catppuccin-latte",
+    label: "Catppuccin Latte",
+    variant: "light",
+    colors: {
+      background: "#eff1f5",
+      foreground: "#4c4f69",
+      cursor: "#dc8a78",
+      cursorAccent: "#eff1f5",
+      selectionBackground: "#acb0be",
+      selectionForeground: "#4c4f69",
+      black: "#5c5f77",
+      red: "#d20f39",
+      green: "#40a02b",
+      yellow: "#df8e1d",
+      blue: "#1e66f5",
+      magenta: "#ea76cb",
+      cyan: "#179299",
+      white: "#acb0be",
+      brightBlack: "#6c6f85",
+      brightRed: "#d20f39",
+      brightGreen: "#40a02b",
+      brightYellow: "#df8e1d",
+      brightBlue: "#1e66f5",
+      brightMagenta: "#ea76cb",
+      brightCyan: "#179299",
+      brightWhite: "#bcc0cc",
+    },
+  },
+  {
+    id: "gruvbox-light",
+    label: "Gruvbox Light",
+    variant: "light",
+    colors: {
+      background: "#fbf1c7",
+      foreground: "#3c3836",
+      cursor: "#3c3836",
+      cursorAccent: "#fbf1c7",
+      selectionBackground: "#d5c4a1",
+      selectionForeground: "#3c3836",
+      black: "#fbf1c7",
+      red: "#cc241d",
+      green: "#98971a",
+      yellow: "#d79921",
+      blue: "#458588",
+      magenta: "#b16286",
+      cyan: "#689d6a",
+      white: "#7c6f64",
+      brightBlack: "#928374",
+      brightRed: "#9d0006",
+      brightGreen: "#79740e",
+      brightYellow: "#b57614",
+      brightBlue: "#076678",
+      brightMagenta: "#8f3f71",
+      brightCyan: "#427b58",
+      brightWhite: "#3c3836",
+    },
+  },
+];
+
+export function isTerminalThemeId(value: unknown): value is TerminalThemeId {
+  return typeof value === "string" && TERMINAL_THEMES.some((t) => t.id === value);
+}
+
+/** A persisted preference is valid if it is a known theme id, or "auto". */
+export function isTerminalThemeSelection(value: unknown): value is TerminalThemeSelection {
+  return value === AUTO_TERMINAL_THEME || isTerminalThemeId(value);
+}
+
+/** The site-matched theme for the mode currently showing. */
+export function autoTerminalTheme(siteIsDark: boolean): TerminalTheme {
+  return themeById(siteIsDark ? AUTO_DARK_THEME_ID : AUTO_LIGHT_THEME_ID);
+}
+
+/**
+ * The concrete theme a preference resolves to. "auto" — and anything
+ * unrecognized, e.g. an id written by a newer bundle or hand-edited into
+ * localStorage — follows the site's light/dark mode, which is the safe answer:
+ * it can never leave a light console wrapped around a dark terminal.
+ */
+export function resolveTerminalTheme(
+  selection: string | undefined,
+  siteIsDark: boolean,
+): TerminalTheme {
+  const found = TERMINAL_THEMES.find((t) => t.id === selection);
+  return found ?? autoTerminalTheme(siteIsDark);
+}
+
+function themeById(id: TerminalThemeId): TerminalTheme {
+  return TERMINAL_THEMES.find((t) => t.id === id)!;
+}

--- a/frontend/src/theme/tokens.css
+++ b/frontend/src/theme/tokens.css
@@ -3,11 +3,28 @@
  * Single source of truth for the console's oklch palette, the live-tunable
  * terminal font variables (driven by state/settings.ts), and the shared
  * keyframe animations. Every component .css references these vars instead of
- * repeating literals. The console commits to a dark theme (matching the
- * mockup); the terminal surface is dark regardless. */
+ * repeating literals.
+ *
+ * Light/dark: every color token is a `light-dark(<light>, <dark>)` pair, so the
+ * whole console follows `color-scheme`. `:root` declares `light dark`, which
+ * means "system" mode needs zero JavaScript — the browser resolves the OS
+ * preference live, with no flash of the wrong theme on first paint. An explicit
+ * user choice is applied by state/settings.ts as `data-theme="light" | "dark"`
+ * on <html>, which pins `color-scheme` and therefore which half of every
+ * `light-dark()` pair wins.
+ *
+ * The dark side of every pair is byte-identical to the console's original
+ * dark-only palette. The core surface/text vars additionally carry a plain
+ * dark declaration on the line before, so browsers without `light-dark()`
+ * (pre Chrome 123 / Firefox 120 / Safari 17.5) still get the original dark
+ * look rather than an unstyled page.
+ *
+ * The terminal surface itself is themed separately (theme/terminalThemes.ts):
+ * TerminalCard sets `--bg-term` inline from the terminal theme in effect for
+ * that card, so the card's padding gutter matches the emulator's background. */
 
 :root {
-  color-scheme: dark;
+  color-scheme: light dark;
 
   /* --- live, user-tunable (written to <html> by state/settings.ts) --- */
   --accent: #38bdf8;
@@ -22,50 +39,106 @@
 
   /* --- surfaces --- */
   --bg-app: oklch(0.17 0.012 255);
-  --bg-header: oklch(0.195 0.012 255);
-  --bg-rail: oklch(0.185 0.012 255);
-  --bg-pane: oklch(0.155 0.01 255);
+  --bg-app: light-dark(oklch(0.965 0.004 255), oklch(0.17 0.012 255));
+  --bg-header: light-dark(oklch(0.995 0.002 255), oklch(0.195 0.012 255));
+  --bg-rail: light-dark(oklch(0.985 0.003 255), oklch(0.185 0.012 255));
+  --bg-pane: light-dark(oklch(0.95 0.005 255), oklch(0.155 0.01 255));
   --bg-term: oklch(0.12 0.008 255);
-  --bg-elev: oklch(0.21 0.012 255);
-  --bg-input: oklch(0.155 0.01 255);
-  --bg-btn: oklch(0.23 0.012 255);
-  --bg-btn-hover: oklch(0.27 0.012 255);
-  --bg-row-hover: oklch(0.22 0.012 255);
+  --bg-term: light-dark(oklch(0.96 0.006 255), oklch(0.12 0.008 255));
+  --bg-elev: light-dark(oklch(1 0 0), oklch(0.21 0.012 255));
+  --bg-input: light-dark(oklch(1 0 0), oklch(0.155 0.01 255));
+  --bg-btn: light-dark(oklch(0.975 0.003 255), oklch(0.23 0.012 255));
+  --bg-btn-hover: light-dark(oklch(0.94 0.006 255), oklch(0.27 0.012 255));
+  --bg-row-hover: light-dark(oklch(0.945 0.006 255), oklch(0.22 0.012 255));
 
   /* --- borders --- */
-  --border: oklch(0.27 0.012 255);
-  --border-soft: oklch(0.25 0.012 255);
-  --border-strong: oklch(0.31 0.012 255);
+  --border: light-dark(oklch(0.88 0.006 255), oklch(0.27 0.012 255));
+  --border-soft: light-dark(oklch(0.91 0.005 255), oklch(0.25 0.012 255));
+  --border-strong: light-dark(oklch(0.83 0.008 255), oklch(0.31 0.012 255));
 
   /* --- text --- */
   --text: oklch(0.92 0.006 255);
-  --text-1: oklch(0.86 0.01 255);
-  --text-2: oklch(0.72 0.01 255);
-  --text-dim: oklch(0.62 0.012 255);
-  --text-faint: oklch(0.5 0.012 255);
+  --text: light-dark(oklch(0.28 0.015 255), oklch(0.92 0.006 255));
+  --text-1: light-dark(oklch(0.34 0.014 255), oklch(0.86 0.01 255));
+  --text-2: light-dark(oklch(0.46 0.014 255), oklch(0.72 0.01 255));
+  --text-dim: light-dark(oklch(0.55 0.014 255), oklch(0.62 0.012 255));
+  --text-faint: light-dark(oklch(0.64 0.012 255), oklch(0.5 0.012 255));
 
-  /* --- status --- */
-  --ok: oklch(0.8 0.15 150);
-  --warn: oklch(0.83 0.13 88);
-  --danger: oklch(0.72 0.17 25);
-  --info: oklch(0.78 0.1 235);
-  --mag: oklch(0.72 0.18 350);
-  --cyan: oklch(0.8 0.09 200);
+  /* --- status --- *
+   * The dark palette's pastels (L ≈ 0.72–0.85) are illegible on a light
+   * surface, and these are used as text and dot colors; the light side keeps
+   * the hue but drops to L ≈ 0.5–0.6. */
+  --ok: light-dark(oklch(0.55 0.15 150), oklch(0.8 0.15 150));
+  --warn: light-dark(oklch(0.58 0.13 88), oklch(0.83 0.13 88));
+  --danger: light-dark(oklch(0.53 0.19 25), oklch(0.72 0.17 25));
+  --info: light-dark(oklch(0.55 0.13 235), oklch(0.78 0.1 235));
+  --mag: light-dark(oklch(0.55 0.2 350), oklch(0.72 0.18 350));
+  --cyan: light-dark(oklch(0.55 0.1 200), oklch(0.8 0.09 200));
 
   /* --- git / session glyphs --- */
-  --git-changes: oklch(0.78 0.13 62);
-  --git-sync: oklch(0.72 0.11 12);
-  --git-active: oklch(0.85 0.14 92);
+  --git-changes: light-dark(oklch(0.58 0.14 62), oklch(0.78 0.13 62));
+  --git-sync: light-dark(oklch(0.55 0.14 12), oklch(0.72 0.11 12));
+  --git-active: light-dark(oklch(0.6 0.14 92), oklch(0.85 0.14 92));
 
   /* --- provider accents --- */
-  --prov-aws: oklch(0.78 0.13 70);
-  --prov-hetzner: oklch(0.72 0.16 25);
-  --prov-proxmox: oklch(0.72 0.13 300);
-  --prov-incus: oklch(0.78 0.11 200);
-  --prov-unknown: oklch(0.62 0.012 255);
+  --prov-aws: light-dark(oklch(0.58 0.14 70), oklch(0.78 0.13 70));
+  --prov-hetzner: light-dark(oklch(0.55 0.19 25), oklch(0.72 0.16 25));
+  --prov-proxmox: light-dark(oklch(0.52 0.16 300), oklch(0.72 0.13 300));
+  --prov-incus: light-dark(oklch(0.55 0.12 200), oklch(0.78 0.11 200));
+  --prov-unknown: light-dark(oklch(0.6 0.012 255), oklch(0.62 0.012 255));
+
+  /* --- accent derivatives --- *
+   * The accent is a user-chosen hue that has to stay legible in both modes.
+   * The dark theme lightened it toward white inline; doing that on a light
+   * surface washes it out, so each mode mixes toward its own extreme. */
+  /* Accent-colored text/glyphs on a NEUTRAL surface (a value readout, a radio
+   * check, the rail's focus caret). Dark keeps the accent as-is. */
+  --accent-ink: light-dark(color-mix(in oklch, var(--accent) 72%, black), var(--accent));
+  /* Accent on an accent-TINTED surface (active window control, "open all"), and
+   * accent outlines, which both need to separate from the tint behind them. */
+  --accent-strong: light-dark(
+    color-mix(in oklch, var(--accent) 78%, black),
+    color-mix(in oklch, var(--accent) 82%, white)
+  );
+
+  /* --- overlays / elevation --- */
+  --overlay-scrim: light-dark(oklch(0.55 0.006 255 / 0.35), oklch(0.1 0.006 255 / 0.6));
+  --overlay-scrim-strong: light-dark(oklch(0.97 0.005 255 / 0.9), oklch(0.13 0.01 255 / 0.93));
+  --shadow-color: light-dark(oklch(0.45 0.02 255 / 0.18), oklch(0 0 0 / 0.35));
+  --shadow-color-strong: light-dark(oklch(0.45 0.02 255 / 0.28), oklch(0 0 0 / 0.6));
+
+  /* --- danger surfaces (error banners, offline card, close-button hover) --- */
+  --danger-surface: light-dark(oklch(0.96 0.025 25), oklch(0.2 0.03 25));
+  --danger-surface-hover: light-dark(oklch(0.92 0.05 25), oklch(0.3 0.05 25));
+  --danger-border: light-dark(oklch(0.86 0.07 25), oklch(0.38 0.08 25));
+  --danger-text: light-dark(oklch(0.45 0.16 25), oklch(0.85 0.09 25));
+  --danger-text-2: light-dark(oklch(0.5 0.06 25), oklch(0.72 0.02 25));
+  --danger-emph: light-dark(oklch(0.42 0.18 25), oklch(0.85 0.11 25));
+
+  /* --- warn surfaces (rail notices, active filter toggle, hint chips) --- */
+  --warn-surface: light-dark(oklch(0.97 0.03 70), oklch(0.21 0.03 70));
+  --warn-border: light-dark(oklch(0.87 0.08 70), oklch(0.4 0.08 70));
+  --warn-text: light-dark(oklch(0.48 0.11 88), oklch(0.9 0.08 88));
+  --warn-text-dim: light-dark(oklch(0.5 0.07 80), oklch(0.74 0.05 80));
+
+  /* --- misc --- */
+  /* Readable ink on a filled --ok button. */
+  --on-ok: light-dark(oklch(0.99 0.02 150), oklch(0.16 0.05 150));
+  /* The sliding dot of a toggle switch. */
+  --knob: light-dark(oklch(1 0 0), oklch(0.96 0 0));
 
   --radius: 8px;
   --radius-lg: 11px;
+}
+
+/* An explicit site-theme choice pins color-scheme, which is what decides the
+ * winning half of every light-dark() pair above. No attribute = "system". */
+:root[data-theme="light"] {
+  color-scheme: light;
+}
+
+:root[data-theme="dark"] {
+  color-scheme: dark;
 }
 
 * {


### PR DESCRIPTION
## What

Two related additions to the browser console, both console-owned presentation state — no backend, OpenAPI, or registry change, and the generated-types drift gates are untouched.

**1. Site light/dark mode.** Tri-state `system` (default) / `light` / `dark`, from a new top-bar toggle (◐ / ☀ / ☾) or Settings → Appearance, persisted in localStorage.

- Every color token in `theme/tokens.css` is now a `light-dark()` pair, with the dark half **byte-identical to today** (verified by diffing all 40 pre-existing tokens against `HEAD`). Dark mode does not move.
- "System" needs **no JavaScript to render** — the browser resolves `prefers-color-scheme` itself, so there's no flash of the wrong theme on first paint. An explicit choice is applied as `data-theme` on `<html>`, which pins `color-scheme`.
- Core surface/text vars keep a plain dark declaration ahead of the pair, so browsers without `light-dark()` (pre Chrome 123 / FF 120 / Safari 17.5) still get the original look.
- The 33 hardcoded literals across five component stylesheets became tokens, since light mode has to reach them.

**2. Terminal themes.** Eight schemes in a new dependency-free `theme/terminalThemes.ts`.

- **Remo Dark / Remo Light** are derived from the console's own tokens — background is `--bg-term`, foreground `--text`, ANSI 1–6 the `--danger`/`--ok`/`--warn`/`--info`/`--mag`/`--cyan` ramp — so the terminal sits flush with the chrome around it.
- The default selection is **Follow site theme**: a light console gets Remo Light, a dark one Remo Dark, until the user picks something specific.
- Six curated third-party schemes (Catppuccin Mocha/Latte, Dracula, Gruvbox Dark/Light, Solarized Light) are selectable under either site mode.
- `RendererAdapter` gains `applyTheme`; both engines take a theme at construction and recolor a **live** terminal in place — no remount, so the connection and scrollback survive.
- Each card can override the global choice from the swatch in its header. Clearing an override deletes the key, so the card follows the global default again.

## Judgement calls worth reviewing

- **The palettes are snapshots, not live references.** A terminal palette must be literal `#rrggbb` (ghostty-web's parser accepts neither `oklch()` nor `var()`), so editing a token does *not* propagate. Tests pin the anchors that make them "matching", and the module says so loudly.
- **Terminal magenta sits at hue 330, not `--mag`'s 350.** `--danger` is at hue 25, and 350 left red and magenta hard to tell apart in `ls`/diff output. Chrome keeps the original `--mag`.
- **Two deliberate behavior changes beyond the feature:** the near-white accent swatch (`#e5e7eb`) becomes a mid-slate, being invisible on light surfaces; and an unrecognized persisted theme id now resolves like `"auto"` rather than to a fixed default, so a stale id can never strand a dark terminal on a light page.

## Verification

- `npm run lint`, 90 frontend tests (three new suites), `npm run build`, `npm run check:types-fresh`; `uv run pytest` (2007 passed), `ruff`, `mypy`.
- Driven in headless Chromium against a live `remo web serve`: under "system" the page renders dark with OS=dark and light with OS=light **with no `data-theme` attribute at all**; the toggle cycles and persists across reload.
- The site-matched palettes were checked against the running app — resolving each token live and comparing to the shipped hex gives an **exact match in both modes** (`--bg-term` → `#040608` / `#eff2f6`, `--danger` → `#fd736d` / `#c2272d`, etc.).

**Not verified by machine:** how the palettes read in a live terminal against real program output — that needs a reachable instance, which is the manual pass this PR is for.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011A2RNakq6mYPLA8as3pE1t