### PR TITLE
fix(web): recover from an expired access-proxy session without a manual reload

### DIFF
--- a/docs/web-session-interface.md
+++ b/docs/web-session-interface.md
@@ -252,6 +252,20 @@ Two properties make this safe:
   unauthenticated at the proxy layer; those routes are authenticated by the pairing code alone. In
   short: gate `/api/v1/pairing/mint` with SSO, pass `/api/v1/setup/*` through.
 
+**When the proxy's session expires, the console re-authenticates itself.** A forward-auth proxy
+answers an expired-session request with a redirect to the IdP (or a bare `401`). A `fetch()` cannot
+complete that SSO round trip — and the service's own `connect-src 'self'` CSP blocks following a
+cross-origin redirect at all — so the only thing that restores a session is a **top-level
+navigation**. Every API call therefore goes through `apiFetch()` in `frontend/src/api/client.ts`,
+which sends `redirect: "manual"`, recognizes both challenge shapes, and reloads the document once.
+Concurrent challenges (returning to a backgrounded tab fires several polls at once) collapse into a
+single reload. If a completed reload is challenged *again* within 10s, the console stops navigating —
+permanently, for that document — and surfaces `auth_required`: sign in through the proxy and reload
+manually. That state means the proxy's session cookie genuinely isn't reaching the app, not that the
+service is down, and it is deliberately not retried on a timer (a page that reloads itself under you
+every ten seconds is worse than one that stops and says why). A challenge is never reported as a service outage: the health
+store ignores it rather than flashing the offline overlay.
+
 **Forward-auth trust boundary.** The service trusts the identity header only because the deployment
 guarantees the proxy sits in front and **sets/strips** that header — so a client cannot reach the app
 directly and spoof it. This is the standard forward-auth boundary; a deployment that exposes the app

--- a/frontend/src/api/client.test.ts
+++ b/frontend/src/api/client.test.ts
@@ -1,0 +1,182 @@
+// Forward-auth (SSO proxy) challenge handling.
+//
+// Regression coverage for the field report: after leaving the console and
+// coming back, an expired access-proxy session produced
+//   - "Fetch API cannot load https://auth…/application/authorize/…" (a plain
+//     fetch following the IdP redirect into the CSP wall), and
+//   - a "remo couldn't connect" overlay (that CSP failure read as network_error),
+//   - plus "the access proxy did not restore a session" from a SECOND
+//     concurrent request racing the first one's re-auth,
+// and the page only recovered on a manual browser refresh.
+
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const REAUTH_KEY = "remo:last-reauth";
+
+/** jsdom won't let `location.reload` be spied on directly ("Cannot redefine
+ * property"), but the whole `location` object can be replaced. */
+function stubLocation(): { reload: ReturnType<typeof vi.fn> } {
+  const reload = vi.fn();
+  Object.defineProperty(window, "location", {
+    configurable: true,
+    value: { href: "http://console.example/", assign: vi.fn(), reload },
+  });
+  return { reload };
+}
+
+/** A proxy 302 to a cross-origin IdP, as `redirect: "manual"` surfaces it. */
+function opaqueRedirect(): Response {
+  return { type: "opaqueredirect", status: 0, ok: false } as unknown as Response;
+}
+
+function jsonResponse(body: unknown, status = 200): Response {
+  return {
+    type: "basic",
+    status,
+    ok: status >= 200 && status < 300,
+    json: async () => body,
+  } as unknown as Response;
+}
+
+async function load(): Promise<typeof import("./client")> {
+  vi.resetModules();
+  return import("./client");
+}
+
+beforeEach(() => {
+  sessionStorage.clear();
+  vi.restoreAllMocks();
+});
+
+describe("forward-auth challenge", () => {
+  it("reloads the document on an opaque redirect instead of reporting a network error", async () => {
+    const { reload } = stubLocation();
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue(opaqueRedirect()));
+    const client = await load();
+
+    await expect(client.getHosts()).rejects.toMatchObject({ code: "auth_challenge" });
+    expect(reload).toHaveBeenCalledTimes(1);
+  });
+
+  it("treats a bare 401 as a proxy challenge (the service never issues one)", async () => {
+    const { reload } = stubLocation();
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue(jsonResponse({}, 401)));
+    const client = await load();
+
+    await expect(client.getHosts()).rejects.toMatchObject({ code: "auth_challenge" });
+    expect(reload).toHaveBeenCalledTimes(1);
+  });
+
+  // The reported "did not restore a session" error: returning to a tab fires
+  // several requests at once, and all of them get challenged.
+  it("navigates once for concurrent challenges, and never cries misconfiguration", async () => {
+    const { reload } = stubLocation();
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue(opaqueRedirect()));
+    const client = await load();
+
+    const results = await Promise.allSettled([
+      client.getHosts(),
+      client.getSessions(),
+      client.getReady(),
+    ]);
+
+    expect(reload).toHaveBeenCalledTimes(1);
+    for (const r of results) {
+      expect(r.status).toBe("rejected");
+      const code = (r as PromiseRejectedResult).reason.code;
+      // Every one of them is the benign "a reload is coming" error...
+      expect(code).toBe("auth_challenge");
+      // ...and specifically NOT the alarming one, which claims re-auth already
+      // ran and failed.
+      expect(code).not.toBe("auth_required");
+    }
+  });
+
+  // The cooldown's real job: we already reloaded once and got challenged again.
+  it("stops looping when a completed reload is challenged again", async () => {
+    const { reload } = stubLocation();
+    sessionStorage.setItem(REAUTH_KEY, String(Date.now()));
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue(opaqueRedirect()));
+    const client = await load();
+
+    await expect(client.getHosts()).rejects.toMatchObject({
+      code: "auth_required",
+      message: "Sign-in is required, but the access proxy did not restore a session.",
+    });
+    expect(reload).not.toHaveBeenCalled();
+  });
+
+  // A permanently broken proxy must not reload the page every 10 seconds.
+  it("gives up for good once re-auth has failed, rather than looping on a timer", async () => {
+    const { reload } = stubLocation();
+    sessionStorage.setItem(REAUTH_KEY, String(Date.now()));
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue(opaqueRedirect()));
+    const client = await load();
+
+    await expect(client.getHosts()).rejects.toMatchObject({ code: "auth_required" });
+
+    // Even after the cooldown window passes, this document stays put.
+    sessionStorage.setItem(REAUTH_KEY, String(Date.now() - 11_000));
+    await expect(client.getHosts()).rejects.toMatchObject({ code: "auth_required" });
+    expect(reload).not.toHaveBeenCalled();
+  });
+
+  it("re-auths again once the cooldown has elapsed (no prior failure)", async () => {
+    const { reload } = stubLocation();
+    sessionStorage.setItem(REAUTH_KEY, String(Date.now() - 11_000));
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue(opaqueRedirect()));
+    const client = await load();
+
+    await expect(client.getHosts()).rejects.toMatchObject({ code: "auth_challenge" });
+    expect(reload).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("getReady", () => {
+  // The specific defect: /ready used a bare fetch, so the browser followed the
+  // proxy's cross-origin 302 and CSP killed it — which the health store then
+  // showed as "the Remo web service is unreachable".
+  it("sends redirect:manual so the IdP redirect is never followed into the CSP", async () => {
+    stubLocation();
+    const fetchMock = vi.fn().mockResolvedValue(jsonResponse({ status: "ready", checks: {} }));
+    vi.stubGlobal("fetch", fetchMock);
+    const client = await load();
+
+    await client.getReady();
+    expect(fetchMock).toHaveBeenCalledWith("/api/v1/ready", expect.objectContaining({
+      redirect: "manual",
+    }));
+  });
+
+  it("re-auths on a challenge rather than reporting the service unreachable", async () => {
+    const { reload } = stubLocation();
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue(opaqueRedirect()));
+    const client = await load();
+
+    await expect(client.getReady()).rejects.toMatchObject({ code: "auth_challenge" });
+    expect(reload).toHaveBeenCalledTimes(1);
+  });
+
+  it("still reports a genuine transport failure as network_error", async () => {
+    stubLocation();
+    vi.stubGlobal("fetch", vi.fn().mockRejectedValue(new TypeError("Failed to fetch")));
+    const client = await load();
+
+    await expect(client.getReady()).rejects.toMatchObject({ code: "network_error" });
+  });
+});
+
+describe("isAuthChallenge", () => {
+  it("matches both challenge codes and nothing else", async () => {
+    stubLocation();
+    const client = await load();
+    const err = (code: string) =>
+      new client.ApiError({ code, message: "", retryable: false, remediation: "" });
+
+    expect(client.isAuthChallenge(err("auth_challenge"))).toBe(true);
+    expect(client.isAuthChallenge(err("auth_required"))).toBe(true);
+    expect(client.isAuthChallenge(err("network_error"))).toBe(false);
+    expect(client.isAuthChallenge(new Error("boom"))).toBe(false);
+    expect(client.isAuthChallenge(undefined)).toBe(false);
+  });
+});

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -83,14 +83,59 @@ type ErrorEnvelope = components["schemas"]["ErrorEnvelope"];
 const _REAUTH_KEY = "remo:last-reauth";
 const _REAUTH_COOLDOWN_MS = 10_000;
 
+/** True once this document has committed to a re-auth navigation. Concurrent
+ * challenges are the NORM, not the exception — returning to a backgrounded tab
+ * fires the discovery poll, the sessions fetch and the readiness poll at once,
+ * and a lapsed proxy session challenges all of them. Only the first may
+ * navigate; without this flag the others hit the sessionStorage cooldown below
+ * and wrongly report that re-auth had already failed. */
+let _reauthNavigating = false;
+
+/** Set once a COMPLETED reload has been challenged again. The cooldown alone
+ * only suppresses re-auth for 10s, so a genuinely broken proxy would reload the
+ * page every 10 seconds forever — a page that reloads under the operator is
+ * worse than one that stops and says why. After giving up, this document never
+ * navigates again; the error's remediation asks for a manual reload, and this
+ * makes that true. */
+let _reauthGaveUp = false;
+
+/** A challenge arriving while a re-auth navigation is already under way. Benign:
+ * the document is about to be replaced. */
+function _reauthInFlightError(): ApiError {
+  return new ApiError({
+    code: "auth_challenge",
+    message: "Re-authenticating…",
+    retryable: false,
+    remediation: "",
+  });
+}
+
+/** Re-auth ran and did not produce a usable session. */
+function _reauthFailedError(): ApiError {
+  return new ApiError({
+    code: "auth_required",
+    message: "Sign-in is required, but the access proxy did not restore a session.",
+    retryable: false,
+    remediation:
+      "Sign in through your access proxy, then reload this page. If it repeats, the " +
+      "forward-auth proxy may be misconfigured (its session cookie is not reaching this app).",
+  });
+}
+
 /**
  * Handle a forward-auth challenge on an XHR by re-authenticating through a
- * top-level navigation. Never returns normally: it either navigates the whole
- * document (throwing to halt the caller before the navigation lands) or, if we
- * already tried to re-auth within the cooldown, throws a clear `auth_required`
- * ApiError instead of looping.
+ * top-level navigation. Never returns normally: it either reloads the whole
+ * document (throwing to halt the caller before the navigation lands), reports
+ * that a reload is already under way, or — if a previous reload was already
+ * challenged again — throws a clear `auth_required` ApiError instead of looping.
  */
 function reauthenticate(): never {
+  if (_reauthNavigating) {
+    throw _reauthInFlightError();
+  }
+  if (_reauthGaveUp) {
+    throw _reauthFailedError();
+  }
   let last = 0;
   try {
     last = Number(sessionStorage.getItem(_REAUTH_KEY) ?? 0) || 0;
@@ -99,54 +144,52 @@ function reauthenticate(): never {
   }
   const now = Date.now();
   if (now - last < _REAUTH_COOLDOWN_MS) {
-    // We just reloaded to re-auth and are being challenged again — the SSO
-    // round-trip isn't restoring a usable session. Stop reloading; surface a
-    // clear error rather than looping.
-    throw new ApiError({
-      code: "auth_required",
-      message: "Sign-in is required, but the access proxy did not restore a session.",
-      retryable: false,
-      remediation:
-        "Sign in through your access proxy and reload. If this repeats, the " +
-        "forward-auth proxy may be misconfigured (its session cookie is not reaching this app).",
-    });
+    // We reloaded to re-auth and are being challenged again — the SSO round
+    // trip isn't restoring a usable session. Stop reloading, for good.
+    _reauthGaveUp = true;
+    throw _reauthFailedError();
   }
   try {
     sessionStorage.setItem(_REAUTH_KEY, String(now));
   } catch {
     // sessionStorage unavailable — navigate anyway.
   }
+  _reauthNavigating = true;
   // A full document request re-runs the proxy's SSO redirect chain (IdP round
   // trip), unlike a fetch which cannot. The SPA reloads authenticated and
-  // subsequent XHRs return 200.
-  window.location.assign(window.location.href);
-  // location.assign() schedules the navigation asynchronously and lets sync
-  // code keep running; throw so the caller never treats this as data.
-  throw new ApiError({
-    code: "auth_challenge",
-    message: "Re-authenticating…",
-    retryable: false,
-    remediation: "",
-  });
+  // subsequent XHRs return 200. reload() rather than assign(location.href):
+  // assigning the CURRENT url is a same-document navigation when it carries a
+  // fragment, which would silently skip the network round trip we need.
+  window.location.reload();
+  // reload() schedules the navigation asynchronously and lets sync code keep
+  // running; throw so the caller never treats this as data.
+  throw _reauthInFlightError();
 }
 
-async function request<T>(path: string, init?: RequestInit): Promise<T> {
+/**
+ * `fetch` for same-origin API calls, with forward-auth challenge detection.
+ *
+ * EVERY call to this app's API must go through here. A plain `fetch()` follows
+ * the proxy's cross-origin 302 to the IdP, which the strict `connect-src 'self'`
+ * CSP then blocks — surfacing as an opaque "Failed to fetch" that callers
+ * misread as "the service is down" (it presented as a bogus offline overlay
+ * when the readiness poll did exactly this).
+ *
+ * Two shapes of challenge are recognized, because forward-auth proxies differ:
+ *   - a 3xx to the IdP, seen as `type: "opaqueredirect"` thanks to
+ *     `redirect: "manual"`. This is unambiguous only because the API itself
+ *     never issues a redirect of any kind — every route is an exact path, so a
+ *     3xx on an API call always came from something in front of us;
+ *   - a bare 401. The service itself never issues one (web/api/setup.py is
+ *     explicit: a dormant surface answers 404, "never a distinguishable 401"),
+ *     so a 401 reaching the browser came from the proxy in front of it.
+ */
+async function apiFetch(path: string, init?: RequestInit): Promise<Response> {
   let response: Response;
   try {
-    response = await fetch(path, {
-      ...init,
-      // Catch a forward-auth proxy's cross-origin SSO redirect as an opaque
-      // response instead of a thrown CSP-blocked follow (see reauthenticate()).
-      redirect: "manual",
-      headers: {
-        "Content-Type": "application/json",
-        ...(init?.headers ?? {}),
-      },
-    });
+    response = await fetch(path, { ...init, redirect: "manual" });
   } catch (cause) {
-    // Network-level failure (offline, connection refused, etc.) — surface it
-    // through the same ApiError shape as HTTP-level errors so callers only
-    // ever handle one error type.
+    // Network-level failure (offline, connection refused, etc.).
     throw new ApiError({
       code: "network_error",
       message: cause instanceof Error ? cause.message : "Network request failed",
@@ -154,14 +197,28 @@ async function request<T>(path: string, init?: RequestInit): Promise<T> {
       remediation: "Check your network connection and that the Remo web service is reachable.",
     });
   }
-
-  // A forward-auth session lapse: the proxy answered with a cross-origin 3xx,
-  // now an opaque redirect. Re-authenticate via a top-level navigation rather
-  // than surfacing a bogus "network_error"/CSP failure. The API itself never
-  // issues same-origin redirects, so this is unambiguously a proxy challenge.
-  if (response.type === "opaqueredirect") {
+  if (response.type === "opaqueredirect" || response.status === 401) {
     reauthenticate();
   }
+  return response;
+}
+
+/** True for the two error codes that mean "a re-auth is happening / needed",
+ * so callers can avoid reporting a proxy challenge as a service outage. */
+export function isAuthChallenge(error: unknown): boolean {
+  return (
+    error instanceof ApiError && (error.code === "auth_challenge" || error.code === "auth_required")
+  );
+}
+
+async function request<T>(path: string, init?: RequestInit): Promise<T> {
+  const response = await apiFetch(path, {
+    ...init,
+    headers: {
+      "Content-Type": "application/json",
+      ...(init?.headers ?? {}),
+    },
+  });
 
   if (!response.ok) {
     let envelope: ErrorEnvelope | undefined;
@@ -253,17 +310,9 @@ export interface ReadinessResponse {
  * `ApiError{code:"network_error"}` so callers can show the offline overlay.
  */
 export async function getReady(): Promise<ReadinessResponse> {
-  let response: Response;
-  try {
-    response = await fetch("/api/v1/ready", { method: "GET" });
-  } catch (cause) {
-    throw new ApiError({
-      code: "network_error",
-      message: cause instanceof Error ? cause.message : "Network request failed",
-      retryable: true,
-      remediation: "Check that the Remo web service is reachable.",
-    });
-  }
+  // Via apiFetch, not a bare fetch: a lapsed forward-auth session must trigger
+  // re-auth, not masquerade as an unreachable service (the offline overlay).
+  const response = await apiFetch("/api/v1/ready", { method: "GET" });
   let body: { status?: string; checks?: Record<string, string>; detail?: string } = {};
   try {
     body = (await response.json()) as typeof body;
@@ -298,19 +347,9 @@ export type MintPairingResponse = components["schemas"]["MintPairingResponse"];
 export async function mintPairingCode(
   origin: "adopt" | "resync" = "adopt",
 ): Promise<MintPairingResponse> {
-  let response: Response;
-  try {
-    response = await fetch(`/api/v1/pairing/mint?origin=${encodeURIComponent(origin)}`, {
-      method: "POST",
-    });
-  } catch (cause) {
-    throw new ApiError({
-      code: "network_error",
-      message: cause instanceof Error ? cause.message : "Network request failed",
-      retryable: true,
-      remediation: "Check that the Remo web service is reachable.",
-    });
-  }
+  const response = await apiFetch(`/api/v1/pairing/mint?origin=${encodeURIComponent(origin)}`, {
+    method: "POST",
+  });
   if (response.status === 403) {
     // Operator authentication required / not configured — surface a distinct
     // code so the adopt page can prompt to sign in rather than showing a code.
@@ -346,7 +385,10 @@ export function endPairing(): void {
   } catch {
     // fall through to fetch
   }
-  // keepalive lets the request outlive the page during unload.
+  // keepalive lets the request outlive the page during unload. Deliberately a
+  // bare fetch, not apiFetch: this fires as the page goes away, where a re-auth
+  // navigation would be both futile and destructive. The server's idle TTL is
+  // the backstop if the challenge eats it.
   void fetch(path, { method: "POST", keepalive: true }).catch(() => undefined);
 }
 

--- a/frontend/src/state/discovery.ts
+++ b/frontend/src/state/discovery.ts
@@ -19,6 +19,7 @@ import {
   ApiError,
   getHosts,
   getSessions,
+  isAuthChallenge,
   refreshDiscovery as refreshDiscoveryRequest,
   type DiscoveryInstance,
   type SessionTarget,
@@ -67,6 +68,18 @@ function sleep(ms: number): Promise<void> {
 // Only one poll runs at a time; overlapping interval ticks / manual refreshes
 // are no-ops while a poll is already in flight, so responses can never race
 // each other and clobber newer state with a stale one.
+/** Log a failed poll, EXCEPT a forward-auth challenge. Returning to a
+ * backgrounded tab with a lapsed SSO session challenges every in-flight
+ * request at once; the client is already re-authenticating via a top-level
+ * reload, and shouting about it fills the console with alarming errors for a
+ * condition that resolves itself. */
+function logPollFailure(what: string, error: unknown): void {
+  if (isAuthChallenge(error)) {
+    return;
+  }
+  console.error(`discovery: ${what} failed`, error);
+}
+
 let pollInFlight = false;
 
 async function pollOnce(): Promise<void> {
@@ -84,7 +97,7 @@ async function pollOnce(): Promise<void> {
       .catch((error: unknown) => {
         // Keep the last-known instances rather than blanking the dashboard
         // on a transient poll failure.
-        console.error("discovery: GET /hosts failed", error);
+        logPollFailure("GET /hosts", error);
       });
 
     const sessionsPoll = getSessions()
@@ -92,7 +105,7 @@ async function pollOnce(): Promise<void> {
         setState({ targets: response.targets });
       })
       .catch((error: unknown) => {
-        console.error("discovery: GET /sessions failed", error);
+        logPollFailure("GET /sessions", error);
       });
 
     await Promise.all([hostsPoll, sessionsPoll]);
@@ -155,7 +168,7 @@ async function manualRefresh(instanceId?: string): Promise<void> {
       if (!(error instanceof ApiError)) {
         throw error;
       }
-      console.error("discovery: POST /discovery/refresh failed", error);
+      logPollFailure("POST /discovery/refresh", error);
     }
 
     for (let i = 0; i < POST_REFRESH_POLL_COUNT; i += 1) {
@@ -186,7 +199,7 @@ async function tick(): Promise<void> {
     if (!(error instanceof ApiError)) {
       throw error;
     }
-    console.error("discovery: background POST /discovery/refresh failed", error);
+    logPollFailure("background POST /discovery/refresh", error);
   }
   await pollOnce();
 }

--- a/frontend/src/state/health.test.ts
+++ b/frontend/src/state/health.test.ts
@@ -1,0 +1,77 @@
+// The health store's reaction to a forward-auth challenge.
+//
+// Field report: returning to the console after the access-proxy session lapsed
+// showed "remo couldn't connect". The readiness poll's challenge had surfaced
+// as a network error, and this store turned that into the offline overlay —
+// over a service that was perfectly healthy and a page that was one re-auth
+// navigation away from working.
+
+import { act, renderHook, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const getReady = vi.fn();
+
+vi.mock("../api/client", async () => {
+  const actual = await vi.importActual<typeof import("../api/client")>("../api/client");
+  return { ...actual, getReady };
+});
+
+// `ApiError` identity matters: both the store's `instanceof` check and
+// `isAuthChallenge` compare against the class from THEIR module registry, and
+// vi.resetModules() makes a fresh one. So the test builds its errors from the
+// very same registry the store under test is using, never from importActual.
+async function load(): Promise<{
+  health: typeof import("./health");
+  apiError: (code: string) => Error;
+}> {
+  vi.resetModules();
+  const client = await import("../api/client");
+  const health = await import("./health");
+  return {
+    health,
+    apiError: (code: string) =>
+      new client.ApiError({ code, message: `test ${code}`, retryable: false, remediation: "" }),
+  };
+}
+
+beforeEach(() => {
+  getReady.mockReset();
+});
+
+describe("health store", () => {
+  it("reports offline for a genuine transport failure", async () => {
+    const { health, apiError } = await load();
+    getReady.mockRejectedValue(apiError("network_error"));
+    const { result } = renderHook(() => health.useHealth());
+
+    await waitFor(() => expect(result.current.status).toBe("offline"));
+  });
+
+  it.each(["auth_challenge", "auth_required"])(
+    "does not claim an outage on a %s challenge",
+    async (code) => {
+      const { health, apiError } = await load();
+      getReady.mockResolvedValueOnce({ ready: true, status: "ready", checks: {} });
+      const { result } = renderHook(() => health.useHealth());
+      await waitFor(() => expect(result.current.status).toBe("healthy"));
+
+      // The proxy session lapses; the next poll is challenged.
+      getReady.mockRejectedValue(apiError(code));
+      await act(async () => {
+        await result.current.retry();
+      });
+
+      // Still "healthy": the service never said otherwise, and the client is
+      // handling re-auth. The offline overlay must not flash here.
+      expect(result.current.status).toBe("healthy");
+    },
+  );
+
+  it("still degrades on an unexpected error shape", async () => {
+    const { health } = await load();
+    getReady.mockRejectedValue(new Error("something else"));
+    const { result } = renderHook(() => health.useHealth());
+
+    await waitFor(() => expect(result.current.status).toBe("degraded"));
+  });
+});

--- a/frontend/src/state/health.ts
+++ b/frontend/src/state/health.ts
@@ -16,9 +16,15 @@
 //                     explain it.
 //   - "offline"       the request failed at the network level (service down /
 //                     restarting). Drives the offline overlay.
+//
+// A forward-auth challenge (expired SSO session behind an access proxy) is NOT
+// any of these: the service is fine, the browser just needs to re-auth. The
+// client turns it into a top-level reload and an `auth_challenge` error, which
+// this store deliberately ignores so the offline overlay never flashes over a
+// page that is one navigation away from working again.
 
 import { useCallback, useEffect, useSyncExternalStore } from "react";
-import { ApiError, getReady, type ReadinessResponse } from "../api/client";
+import { ApiError, getReady, isAuthChallenge, type ReadinessResponse } from "../api/client";
 
 const DEFAULT_POLL_INTERVAL_MS = 10_000;
 
@@ -71,6 +77,13 @@ async function pollOnce(): Promise<void> {
       detail: ready.detail ?? null,
     });
   } catch (error) {
+    if (isAuthChallenge(error)) {
+      // A re-auth navigation is under way (auth_challenge), or re-auth already
+      // failed once and the client has stopped looping (auth_required). Either
+      // way the service's own health is unknown, not bad — leave the last known
+      // status alone rather than claiming an outage we haven't observed.
+      return;
+    }
     if (error instanceof ApiError && error.code === "network_error") {
       setState({ status: "offline", detail: "The Remo web service is unreachable." });
     } else {


### PR DESCRIPTION
## The report

Leaving the console and coming back showed **"remo couldn't connect"**, with these in the dev console:

```
ApiError: Sign-in is required, but the access proxy did not restore a session.
Fetch API cannot load https://auth.hola.get2know.io/application/authorize/…
```

Only a manual browser refresh recovered. The service was healthy the entire time — this is purely a client-side handling bug when the forward-auth (SSO proxy) session lapses.

## Three defects, compounding

**1. The readiness poll bypassed the redirect handling.** `getReady()` used a bare `fetch()` while `request()` used `redirect: "manual"`. So the browser *followed* the proxy's cross-origin 302 to the IdP, `connect-src 'self'` blocked it, and the resulting `TypeError` became `network_error` — which the health store renders as the offline overlay. That is both console errors and the visible symptom, from one missing option. `mintPairingCode()` had the same bug.

**2. Concurrent challenges cried wolf.** `reauthenticate()` couldn't distinguish "another request was challenged while the first one's reload is in flight" from "we reloaded and got challenged again". Returning to a backgrounded tab fires discovery + sessions + readiness *at once*, so the concurrent case is the normal one — and every request but the first reported a misconfigured proxy.

**3. The navigation could be a no-op.** `location.assign(location.href)` is a *same-document* navigation when the URL carries a fragment, silently skipping the network round trip re-auth depends on.

## The fix

Every API call now goes through one `apiFetch()` that sends `redirect: "manual"` and recognizes both challenge shapes: an opaque redirect, and a bare **401** — the service never issues one (`web/api/setup.py` is explicit that a dormant surface answers 404, *"never a distinguishable 401"*), so a 401 reaching the browser came from the proxy in front of it.

The first challenge reloads via `location.reload()`; concurrent ones collapse into that single navigation. The sessionStorage cooldown now means only what it was designed to mean: a *completed* reload was challenged again.

**Giving up is now permanent for the document.** The old cooldown only suppressed re-auth for 10 seconds, so a genuinely misconfigured proxy would reload the page every 10s forever. A page that reloads under the operator is worse than one that stops and explains itself — which is what `auth_required`'s remediation text already promised.

A challenge is no longer reported as an outage: the health store leaves its last known status alone, and the discovery poll stops logging challenges as failures.

`endPairing()` deliberately keeps its bare keepalive fetch — it fires as the page unloads, where a re-auth navigation would be futile and destructive.

## Verification

Driven in a real browser against a live `remo web serve`, with every `/api/v1/**` call stubbed to a 302 to a cross-origin IdP — i.e. the reported condition, reproduced.

| | pre-fix bundle | fixed bundle |
|---|---|---|
| top-level navigations | 1, then another every 10s | **1** |
| offline overlay | **shown** | not shown |
| console | `…did not restore a session`, `Connecting to 'https://auth.hola.get2know.io/…' violates … Content Security Policy` | **clean** |

Also: 14 new unit tests (`client.test.ts`, `health.test.ts`). Three of them fail against the pre-fix code with precisely the three reported symptoms — I checked by reverting the fix and re-running. Full gates green: `lint`, 104 frontend tests, `build`, `check:types-fresh`, `uv run pytest` (2007 passed).

## Note for the deployment

If you ever see `auth_required` now, it is a real signal rather than noise: the proxy completed an SSO round trip and the app still wasn't authenticated, which usually means its session cookie isn't reaching the app (path/domain scope, or `/api/v1/setup/*` not being passed through). The page will stay put and say so instead of reloading in a loop.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011A2RNakq6mYPLA8as3pE1t