### PR TITLE
fix(ansible): stop provisioning failing when GitHub rate-limits the zellij lookup

### DIFF
--- a/ansible/roles/zellij/defaults/main.yml
+++ b/ansible/roles/zellij/defaults/main.yml
@@ -2,12 +2,26 @@
 # Zellij version to install (use 'latest' for most recent release)
 zellij_version: "latest"
 
+# Version installed when zellij_version is 'latest' but the release lookup
+# cannot be completed (no network, GitHub having a bad day). Provisioning must
+# not fail just because we could not discover the newest tag -- a slightly old
+# zellij is fine, no zellij is not. Bump this occasionally; it is only ever a
+# floor, since the lookup normally wins.
+zellij_fallback_version: "0.44.3"
+
 # Minimum required zellij version (apt version must be at least this)
 zellij_min_version: "0.40.0"
 
 # Installation method: 'auto' will try apt first, fall back to binary
 # Options: 'auto', 'apt', 'binary'
 zellij_install_method: "auto"
+
+# Where "latest" is resolved from. Deliberately github.com and NOT
+# api.github.com: the API caps unauthenticated callers at 60 requests/hour/IP,
+# while this redirect carries no such quota. Overridable so a mirror or an
+# air-gapped deployment can point it elsewhere (and so the failure paths are
+# testable).
+zellij_latest_release_url: "https://github.com/zellij-org/zellij/releases/latest"
 
 # Binary download location
 zellij_binary_path: "/usr/local/bin/zellij"

--- a/ansible/roles/zellij/tasks/main.yml
+++ b/ansible/roles/zellij/tasks/main.yml
@@ -68,19 +68,50 @@
 
     - name: Set architecture mapping
       ansible.builtin.set_fact:
-        zellij_arch: "{{ 'x86_64' if zellij_system_arch.stdout == 'x86_64' else 'aarch64' }}"
+        zellij_arch: "{{ 'x86_64' if (zellij_system_arch.stdout | default('')) == 'x86_64' else 'aarch64' }}"
 
-    - name: Get latest zellij release version from GitHub
+    # Resolve "latest" WITHOUT api.github.com. That API allows only 60
+    # unauthenticated requests per hour per IP -- a budget shared by everyone
+    # behind the same NAT and by CI runners -- and this lookup used to abort
+    # provisioning outright when it ran out (the 403 had no failure handling;
+    # it surfaced as "Failed to create Incus container ... playbook rc=2").
+    # github.com's own /releases/latest redirects to the tagged release and
+    # carries no such quota, so read the tag out of the Location header and keep
+    # the API off the provisioning path entirely.
+    - name: Resolve latest zellij release via the github.com redirect
       ansible.builtin.uri:
-        url: https://api.github.com/repos/zellij-org/zellij/releases/latest
-        return_content: true
-      register: zellij_latest_release
+        url: "{{ zellij_latest_release_url }}"
+        method: HEAD
+        follow_redirects: none
+        status_code: [301, 302, 303, 307, 308]
+      register: zellij_latest_redirect
+      retries: 3
+      delay: 5
+      until: zellij_latest_redirect.location | default('') is search('/tag/')
+      # Never fatal: a failed lookup falls back to the pinned version below.
+      failed_when: false
+      changed_when: false
       when: zellij_version == 'latest'
 
     - name: Set zellij download version
       ansible.builtin.set_fact:
+        # The Location must actually look like .../tag/v1.2.3 before we trust
+        # it; anything else (an error page, a redirect somewhere unexpected)
+        # falls back rather than turning junk into a download URL.
         zellij_download_version: >-
-          {{ zellij_latest_release.json.tag_name | regex_replace('^v', '') if zellij_version == 'latest' else zellij_version }}
+          {{ zellij_version if zellij_version != 'latest'
+             else ((zellij_latest_redirect.location | default('') | regex_replace('^.*/tag/v?', ''))
+                   if (zellij_latest_redirect.location | default('')) is search('/tag/v?[0-9]+\.[0-9]+\.[0-9]+$')
+                   else zellij_fallback_version) }}
+
+    - name: Note that the pinned fallback version is being used
+      ansible.builtin.debug:
+        msg: >-
+          Could not resolve the latest zellij release from github.com; installing the
+          pinned fallback {{ zellij_fallback_version }} instead. This is not fatal.
+      when:
+        - zellij_version == 'latest'
+        - (zellij_latest_redirect.location | default('')) is not search('/tag/v?[0-9]+\.[0-9]+\.[0-9]+$')
 
     - name: Check if we need to install/upgrade
       ansible.builtin.set_fact:
@@ -125,7 +156,7 @@
 
 - name: Display zellij version
   ansible.builtin.debug:
-    msg: "{{ zellij_final_version.stdout }}"
+    msg: "{{ zellij_final_version.stdout | default('unknown') }}"
 
 - name: Create zellij config directory for user
   ansible.builtin.file:


### PR DESCRIPTION
## The bug

The zellij role resolved `latest` through **api.github.com**, which allows only **60 unauthenticated requests per hour per IP**. The task had no failure handling, so exhausting that budget aborted the entire play:

```
url: https://api.github.com/repos/zellij-org/zellij/releases/latest
status: 403 — API rate limit exceeded for 52.225.29.101
x_ratelimit_remaining: '0'
...
Error: Failed to create Incus container 'ci-test' (playbook rc=2).
```

That's a real CI failure from #130 — on a commit that touched neither Ansible nor provisioning. It re-ran green on a different runner, which is the tell: the code was never the problem, the shared egress IP was.

This is **not just a CI problem.** The same lookup runs during `remo <provider> create` on a user's machine, and the quota is per IP shared by everyone behind the NAT. A busy office, a VPN exit, or a CGNAT address can break provisioning for a user who has made zero GitHub requests themselves.

## The fix

Resolve the version through **github.com's own `/releases/latest` redirect** and read the tag from the `Location` header. Same information, no credentials, and no API rate-limit quota:

```
$ curl -sI https://github.com/zellij-org/zellij/releases/latest | grep -i location
location: https://github.com/zellij-org/zellij/releases/tag/v0.44.3

$ curl -sI https://api.github.com/repos/zellij-org/zellij/releases/latest | grep -i x-ratelimit-limit
x-ratelimit-limit: 60          # <- the thing that broke the build
```

I considered passing `${{ github.token }}` instead, but that only fixes CI — it does nothing for a rate-limited user, and it would mean plumbing a secret from the controller into a task that runs on the target host. Removing the dependency on the rate-limited endpoint fixes both cases with less machinery.

**Failure is also no longer fatal.** The lookup retries 3×, is `failed_when: false`, and anything that doesn't yield a plausible `.../tag/vX.Y.Z` falls back to a pinned `zellij_fallback_version` with a printed notice. A slightly stale zellij beats a failed provision. The `Location` is validated against a semver-shaped pattern before use, so a redirect to a login or error page can't be turned into a bogus download URL.

## Verification

The lookup URL is now a role variable (also useful for mirrors/air-gapped installs), which made the failure paths testable. All five were exercised with a real `ansible-playbook` run, loading this role's **actual** `defaults/main.yml`:

| path | result |
|---|---|
| happy path, live github.com | resolved `0.44.3` |
| explicit version pin | honored, lookup skipped entirely |
| lookup host unreachable | fallback, play continued (`failed=0`) |
| redirect to a non-release page | fallback, no junk download URL |
| **403 rate limit (the reported bug)** | fallback, play continued (`failed=0`) |

Paths 4 and 5 ran against local stub servers reproducing a junk redirect and GitHub's exact rate-limit 403.

Also: `uv run pytest` (2007 passed), and `ansible-playbook --syntax-check` on the playbooks that use this role. Guarded the file's two remaining registered-variable accesses with `| default()` (Constitution principle V — the repo's pre-commit checklist asks for that in any file being touched).

## Note

`zellij_fallback_version` is pinned at `0.44.3` (today's latest). It's only ever a floor — the lookup normally wins — but it's worth bumping occasionally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011A2RNakq6mYPLA8as3pE1t