### PR TITLE
fix(ansible): survive the SSM reconnect after the UID-1000 swap

### DIFF
--- a/ansible/roles/user_setup/tasks/main.yml
+++ b/ansible/roles/user_setup/tasks/main.yml
@@ -112,6 +112,24 @@
 - name: Reconnect after UID reassignment
   ansible.builtin.meta: reset_connection
 
+# The task above rewrites /etc/passwd to move the user Ansible is CURRENTLY
+# logged in as off UID 1000, which tears down the live session. Reconnecting is
+# therefore inherently racy, and the next task's first attempt can land before
+# the transport has settled -- on AWS (SSM) that surfaces as an UNREACHABLE
+# host, which no failed_when can rescue and which fails the whole provision:
+#
+#   Data could not be sent to remote host "i-0…": Connection closed by
+#   UNKNOWN port 65535
+#
+# Observed on both CI and main; it is intermittent, which is exactly why it
+# needs a retry rather than a fix somewhere else. wait_for_connection keeps
+# re-attempting until the transport is genuinely back, and returns as soon as
+# it is (so a fast local connection -- Incus, Proxmox -- pays only `delay`).
+- name: Wait for the connection to come back after the UID swap
+  ansible.builtin.wait_for_connection:
+    delay: 5
+    timeout: 120
+
 - name: Create remo user with UID 1000 (matches devcontainer vscode user)
   ansible.builtin.user:
     name: "{{ remo_user }}"


### PR DESCRIPTION
## The bug

`user_setup` rewrites `/etc/passwd` to move whichever user Ansible is **currently logged in as** off UID 1000 (so `remo` can take it and match the devcontainer's `vscode` user), then drops the connection with `meta: reset_connection`. Re-establishing it is inherently racy — and nothing retried. The very next task's first attempt could land before the transport had settled.

On AWS, where the transport is SSM, that surfaces as an `UNREACHABLE` host, which no `failed_when` can rescue, so it fails the entire provision:

```
TASK [user_setup : Reassign UID 1000 to remo user]      changed
TASK [user_setup : Reconnect after UID reassignment]
TASK [user_setup : Create remo user with UID 1000 …]
[ERROR]: Data could not be sent to remote host "i-08b422dac89e38aec".
Make sure this host can be reached over ssh: Connection closed by UNKNOWN port 65535

aws_server : ok=42  changed=15  unreachable=1  failed=0
```

## It's been costing real builds

| when | branch | result |
|---|---|---|
| 2026-08-02 18:05 | `main` (run 30760313802) | same file, same line, same message |
| 2026-08-03 11:45 | PR #132 | same, instance `i-01e6e0550ac964152` |
| 2026-08-03 11:54 | PR #132 re-run | same, instance `i-08b422dac89e38aec` |
| in between | `main` 09:50 | passed |

Different commits, different instances, identical failure — and passing in between. That intermittency is exactly why the answer is a retry rather than a change somewhere else.

## The fix

```yaml
 - name: Reconnect after UID reassignment
   ansible.builtin.meta: reset_connection

+- name: Wait for the connection to come back after the UID swap
+  ansible.builtin.wait_for_connection:
+    delay: 5
+    timeout: 120
```

`wait_for_connection` re-attempts until the transport is genuinely back and returns as soon as it is — so the fast local connections (Incus, Proxmox) pay only the 5s `delay`, while SSM gets up to 120s to recover.

## Verification

The task form runs clean against a live connection (~6s: the delay plus overhead) and all four provider `*_configure` playbooks pass `--syntax-check`. Unit tests green.

The real proof is **this PR's own aws smoke test** — the job that has been failing. If it goes green here, the fix is doing its job; if it fails again, the diagnosis was wrong and I'd rather find that out on this PR than by merging it.

## Context

This blocks #132 (the zellij rate-limit fix), which is green everywhere except this aws flake — proven unrelated there, since no zellij task ever executed before the play died. Landing this first lets #132 go green legitimately instead of being merged past a red check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011A2RNakq6mYPLA8as3pE1t