### PR TITLE
feat(web): tile a terminal to a pane edge as a master area

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -117,6 +117,7 @@ frontend/                  # remo-web browser SPA (Vite + React + TypeScript)
 ├── src/
 │   ├── api/client.ts        # REST + WS terminal client (remo-terminal.v1 subprotocol)
 │   ├── components/          # Dashboard, InstanceGroup, TargetCard, GridView, TabView, TerminalCard
+│   │                        #   + masterLayout.ts (pure pane geometry: uniform grid + master/stack tiling)
 │   ├── state/                # discovery.ts, workspace.ts (layout persisted to localStorage)
 │   └── terminal/              # RendererAdapter (seam), XtermRenderer (the one engine), TerminalConnection, keymap
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -117,6 +117,7 @@ frontend/                  # remo-web browser SPA (Vite + React + TypeScript)
 ├── src/
 │   ├── api/client.ts        # REST + WS terminal client (remo-terminal.v1 subprotocol)
 │   ├── components/          # Dashboard, InstanceGroup, TargetCard, GridView, TabView, TerminalCard
+│   │                        #   + masterLayout.ts (pure pane geometry: uniform grid + master/stack tiling)
 │   ├── state/                # discovery.ts, workspace.ts (layout persisted to localStorage), settings.ts (display prefs: site light/dark mode, accent, fonts, terminal theme + per-target overrides)
 │   ├── terminal/              # RendererAdapter (seam), XtermRenderer (the one engine), TerminalConnection, keymap
 │   └── theme/                 # tokens.css (light-dark() palette, one pair per token), fonts.ts, terminalThemes.ts (8 terminal color schemes: a token-derived Remo Dark/Light pair the default 'auto' selection tracks, plus 6 curated third-party)

--- a/docs/web-session-interface.md
+++ b/docs/web-session-interface.md
@@ -108,7 +108,16 @@ The SPA is a two-pane **web console**:
   row (or its `+` button) **adds** it to a responsive grid (1/2/3 columns by count). In a grid, **drag
   a tile's header onto another to swap their positions** — a window outline follows the cursor and the
   swap target shows a dashed outline (mouse or touch press-and-hold; keyboard-accessible via the
-  handle); the arrangement persists until the grid is rebuilt. In a grid, **resting the pointer on a
+  handle); the arrangement persists until the grid is rebuilt. **Drag a tile to a pane edge instead of
+  onto another tile** and it takes that whole side as a *master area* — full height on the left/right,
+  full width on the top/bottom — with the remaining tiles tiling the leftover strip (the dwm/xmonad
+  master+stack model). A translucent band marks each edge while dragging and fills in when the drop
+  would land there. The **▦** control in a tile's header cycles the same thing without a drag
+  (▌ left → ▀ top → ▐ right → ▄ bottom → back to the even grid), which is the practical path on a touch
+  device. The master takes 60% by default, closing it promotes the head of the stack rather than
+  un-tiling everything, and the arrangement persists across reload alongside the tile order. This is
+  what lets three terminals fill the pane without the empty fourth cell a 2x2 grid would leave. In a
+  grid, **resting the pointer on a
   tile focuses it** (focus-follows-mouse, with a short dwell so passing through tiles doesn't steal
   focus) — keystrokes go where the pointer is, no click needed. The **◻** control solos a tile; **Esc**
   collapses the grid back to the focused terminal;

--- a/frontend/src/components/TerminalCard.tsx
+++ b/frontend/src/components/TerminalCard.tsx
@@ -30,6 +30,7 @@ import {
   type TerminalFontOptions,
 } from "../state/settings";
 import { TERMINAL_THEMES, type TerminalThemeColors } from "../theme/terminalThemes";
+import type { MasterSide } from "../state/workspace";
 import { removeLatency, reportLatency } from "../state/latency";
 import type { RendererAdapter } from "../terminal/RendererAdapter";
 import { createDefaultRenderer } from "../terminal/defaultRenderer";
@@ -40,6 +41,16 @@ const DEFAULT_COLS = 80;
 const DEFAULT_ROWS = 24;
 /** How much to shrink the terminal font in a grid tile when "scale to fit". */
 const GRID_FIT_SCALE = 0.8;
+
+/** Glyph + label per tiling state. The glyph is a half block drawing where the
+ * master area sits, so the button reads as a picture of the layout. */
+const MASTER_GLYPH: Record<MasterSide | "grid", { glyph: string; title: string }> = {
+  grid: { glyph: "▦", title: "Tile this terminal to the left" },
+  left: { glyph: "▌", title: "Mastering the left — tile to the top" },
+  top: { glyph: "▀", title: "Mastering the top — tile to the right" },
+  right: { glyph: "▐", title: "Mastering the right — tile to the bottom" },
+  bottom: { glyph: "▄", title: "Mastering the bottom — back to the even grid" },
+};
 
 const STATE_LABELS: Record<TerminalConnectionState, string> = {
   connecting: "Connecting…",
@@ -70,6 +81,16 @@ interface TerminalCardProps {
   /** When true, the header acts as a dnd-kit drag handle and the tile is a drop
    * target (grid reorder). The DndContext + swap live in WorkspacePane. */
   reorderEnabled?: boolean;
+  /** This tile's slot in a master/stack tiling, as a CSS `grid-area`. Undefined
+   * in the uniform grid, where tiles auto-place exactly as they always have.
+   * Applied to the card's OWN root element — never a wrapper, see WorkspacePane. */
+  gridArea?: string;
+  /** Which side this tile masters, or null when it is a plain stack tile.
+   * Undefined hides the tiling control entirely (single view, fullscreen). */
+  masterSide?: MasterSide | null;
+  /** Advance this tile through the tiling cycle (left -> top -> right -> bottom
+   * -> uniform grid). */
+  onCycleTile?: () => void;
   /** Window-control "Normal": solo this terminal into the single view. */
   onNormal: () => void;
   /** Window-control "Grid": show the grid — omitted when none is available. */
@@ -173,6 +194,9 @@ export function TerminalCard({
   viewState,
   onClose,
   reorderEnabled,
+  gridArea,
+  masterSide,
+  onCycleTile,
   onNormal,
   onGrid,
   onToggleFullscreen,
@@ -544,6 +568,7 @@ export function TerminalCard({
       style={
         {
           display: isVisible ? undefined : "none",
+          gridArea,
           "--bg-term": theme.colors.background,
         } as CSSProperties
       }
@@ -672,6 +697,26 @@ export function TerminalCard({
               </div>
             )}
           </div>
+          {/* Tiling control. Cycles rather than opening a menu: it is one tap on
+           * a touch device, where dragging to a 64px edge band with a thumb is
+           * the awkward path. The half-block glyphs draw where the master area
+           * lands, so the current state is legible without the tooltip. */}
+          {onCycleTile && (
+            <button
+              type="button"
+              className={`tc-btn tc-btn--icon${masterSide ? " tc-btn--active" : ""}`}
+              data-testid={`terminal-tile-${target.id}`}
+              title={MASTER_GLYPH[masterSide ?? "grid"].title}
+              aria-label={MASTER_GLYPH[masterSide ?? "grid"].title}
+              aria-pressed={Boolean(masterSide)}
+              onClick={(e) => {
+                e.stopPropagation();
+                onCycleTile();
+              }}
+            >
+              {MASTER_GLYPH[masterSide ?? "grid"].glyph}
+            </button>
+          )}
           {/* Window-control cluster: mutually-exclusive display modes ordered
            * by how much space they take — Grid (smaller/tiled) → Normal (fills
            * the app's main pane) → Fullscreen (whole window) — plus close. The

--- a/frontend/src/components/WorkspacePane.css
+++ b/frontend/src/components/WorkspacePane.css
@@ -23,6 +23,75 @@
   display: grid;
 }
 
+/* Containing block for the snap zones below, and a stop for touch scroll
+ * chaining while dragging a tile around. */
+.workspace-body {
+  position: relative;
+  overscroll-behavior: contain;
+}
+
+/* --- edge drop targets (master/stack tiling) ---
+ *
+ * `pointer-events: none` is load-bearing, not a tidy-up: dnd-kit resolves drops
+ * from measured rects rather than hit-testing, so these can blanket the pane
+ * edges without intercepting anything — including the rail's resize handle,
+ * which overhangs 3px into this pane's left edge.
+ *
+ * z-index 20 sits in the free band between the rail divider (8) and the terminal
+ * theme popup (60). */
+.workspace-snap {
+  position: absolute;
+  z-index: 20;
+  pointer-events: none;
+  opacity: 0;
+  border-radius: var(--radius-lg);
+  border: 2px dashed transparent;
+  background: color-mix(in oklch, var(--accent) 14%, transparent);
+}
+@media (prefers-reduced-motion: no-preference) {
+  .workspace-snap {
+    transition: opacity 120ms ease;
+  }
+}
+/* Visible but quiet while a drag is in flight, solid once it would land here. */
+.workspace-snap--armed {
+  opacity: 0.4;
+}
+.workspace-snap--over {
+  opacity: 1;
+  border-color: var(--accent-strong);
+  background: color-mix(in oklch, var(--accent) 28%, transparent);
+}
+
+.workspace-snap--left,
+.workspace-snap--right {
+  top: 0;
+  bottom: 0;
+  width: min(64px, 18%);
+}
+.workspace-snap--left {
+  left: 0;
+}
+.workspace-snap--right {
+  right: 0;
+}
+
+/* Inset horizontally by the same band, so the CORNERS belong unambiguously to
+ * left/right — the vertical split is what this feature is for, and an overlap
+ * would resolve a corner by centre distance, i.e. arbitrarily. */
+.workspace-snap--top,
+.workspace-snap--bottom {
+  left: min(64px, 18%);
+  right: min(64px, 18%);
+  height: min(64px, 18%);
+}
+.workspace-snap--top {
+  top: 0;
+}
+.workspace-snap--bottom {
+  bottom: 0;
+}
+
 /* Empty state */
 .workspace-empty {
   flex: 1;

--- a/frontend/src/components/WorkspacePane.test.tsx
+++ b/frontend/src/components/WorkspacePane.test.tsx
@@ -1,0 +1,175 @@
+// WorkspacePane's wiring: does the computed layout actually reach the DOM, and
+// — the one that matters — can a layout change ever remount a TerminalCard?
+//
+// A remount re-runs the card's [target.id] effect, whose cleanup calls
+// connection.close() and adapter.dispose(): the SSH connection drops and the
+// scrollback goes with it. Master/stack changes which slot a tile occupies on
+// every mastership change, so this is the feature's central structural risk.
+// The guarantee is "one flat keyed child list; slots are grid-area styles on
+// each card's own root, never wrapper elements", and the test below is what
+// proves it rather than merely documenting it.
+
+import { act, render, screen } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { SessionTarget } from "../api/client";
+
+const adapters: { dispose: ReturnType<typeof vi.fn> }[] = [];
+
+vi.mock("../terminal/defaultRenderer", () => ({
+  createDefaultRenderer: vi.fn(() => {
+    const adapter = {
+      open: vi.fn(),
+      write: vi.fn(),
+      onData: vi.fn().mockReturnValue(() => {}),
+      fit: vi.fn().mockReturnValue({ cols: 80, rows: 24 }),
+      resize: vi.fn(),
+      applyFont: vi.fn(),
+      applyTheme: vi.fn(),
+      focus: vi.fn(),
+      onTitleChange: vi.fn().mockReturnValue(() => {}),
+      onSelectionChange: vi.fn().mockReturnValue(() => {}),
+      getSelection: vi.fn().mockReturnValue(null),
+      copySelection: vi.fn().mockResolvedValue(false),
+      dispose: vi.fn(),
+    };
+    adapters.push(adapter);
+    return adapter;
+  }),
+}));
+
+vi.mock("../terminal/TerminalConnection", () => ({
+  TerminalConnection: class {
+    needsManualReconnect = false;
+    connect = vi.fn().mockResolvedValue(undefined);
+    close = vi.fn().mockResolvedValue(undefined);
+    sendInput = vi.fn();
+    sendResize = vi.fn();
+  },
+}));
+
+// jsdom has neither; useDroppable and TerminalCard both observe their nodes.
+class NoopResizeObserver {
+  observe(): void {}
+  unobserve(): void {}
+  disconnect(): void {}
+}
+globalThis.ResizeObserver = NoopResizeObserver as unknown as typeof ResizeObserver;
+
+const target = (id: string): SessionTarget =>
+  ({ id, project: id, instance_type: "incus", instance_name: "box" }) as unknown as SessionTarget;
+
+async function mount(ids: string[]) {
+  vi.resetModules();
+  window.localStorage.clear();
+  adapters.length = 0;
+  const workspaceMod = await import("../state/workspace");
+  const { WorkspacePane } = await import("./WorkspacePane");
+  const targetsById = new Map(ids.map((id) => [id, target(id)]));
+
+  const view = render(
+    <WorkspacePane
+      targetsById={targetsById}
+      regionByKey={new Map()}
+      onTerminalEnded={() => {}}
+      onTerminalStarted={() => {}}
+      narrow={false}
+    />,
+  );
+  // Drive the store directly: the rail isn't mounted here.
+  const store = renderStore(workspaceMod);
+  act(() => store.openMany(ids.map(target)));
+  return { view, store };
+}
+
+/** The store's actions, outside React. `useWorkspace` returns them, but this
+ * file never renders a consumer of its own. */
+function renderStore(mod: typeof import("../state/workspace")) {
+  let api!: ReturnType<typeof mod.useWorkspace>;
+  function Probe(): null {
+    api = mod.useWorkspace();
+    return null;
+  }
+  render(<Probe />);
+  return new Proxy({} as ReturnType<typeof mod.useWorkspace>, {
+    get: (_t, key) => api[key as keyof typeof api],
+  });
+}
+
+const body = (): HTMLElement => screen.getByTestId("workspace").querySelector(".workspace-body")!;
+
+beforeEach(() => {
+  window.localStorage.clear();
+});
+
+describe("WorkspacePane layout wiring", () => {
+  it("renders the uniform grid exactly as before when nothing is tiled", async () => {
+    await mount(["a", "b", "c"]);
+    expect(body().style.gridTemplateColumns).toBe("repeat(2, minmax(0, 1fr))");
+    expect(body().style.gridTemplateRows).toBe("repeat(2, minmax(0, 1fr))");
+    // No explicit placement: tiles auto-place, as they always have.
+    expect(screen.getByTestId("terminal-card-a").style.gridArea).toBe("");
+  });
+
+  it("pushes the master template and every tile's slot into the DOM", async () => {
+    const { store } = await mount(["a", "b", "c"]);
+    act(() => store.setMaster("c", "right"));
+
+    expect(body().style.gridTemplateColumns).toBe("repeat(1, minmax(0, 40fr)) minmax(0, 60fr)");
+    expect(screen.getByTestId("terminal-card-c").style.gridArea).toBe("1 / 2 / 3 / 3");
+    expect(screen.getByTestId("terminal-card-a").style.gridArea).toBe("1 / 1 / 2 / 2");
+    expect(screen.getByTestId("terminal-card-b").style.gridArea).toBe("2 / 1 / 3 / 2");
+  });
+
+  it("offers the four edge zones only while a reorder is possible", async () => {
+    const { store } = await mount(["a", "b", "c"]);
+    expect(screen.getAllByTestId(/^snap-zone-/)).toHaveLength(4);
+
+    // Single view: nothing to reorder, nothing to snap onto.
+    act(() => store.selectOnly(target("a")));
+    expect(screen.queryAllByTestId(/^snap-zone-/)).toHaveLength(0);
+  });
+
+  it("hides the edge zones while a terminal is fullscreen", async () => {
+    const { store } = await mount(["a", "b"]);
+    act(() => store.maximize("a"));
+    expect(screen.queryAllByTestId(/^snap-zone-/)).toHaveLength(0);
+  });
+
+  // THE structural guarantee. Mutation: wrap the master (or the stack) in a
+  // slot <div> in WorkspacePane and this must fail — a card changing parent
+  // remounts, dropping its SSH connection and scrollback.
+  it("never remounts a terminal across layout changes", async () => {
+    const { store } = await mount(["a", "b", "c"]);
+    const surfaceBefore = screen.getByTestId("terminal-surface-a");
+    const buildsBefore = adapters.length;
+
+    act(() => store.setMaster("a", "left"));
+    act(() => store.setMaster("a", "top"));
+    act(() => store.setMaster("b", "right"));
+    act(() => store.clearMaster());
+
+    expect(Object.is(screen.getByTestId("terminal-surface-a"), surfaceBefore)).toBe(true);
+    expect(adapters).toHaveLength(buildsBefore);
+    for (const adapter of adapters) {
+      expect(adapter.dispose).not.toHaveBeenCalled();
+    }
+  });
+
+  it("cycles a tile through the sides from its header control", async () => {
+    const { store } = await mount(["a", "b"]);
+    const button = (): HTMLElement => screen.getByTestId("terminal-tile-a");
+
+    act(() => button().click());
+    expect(store.layout).toMatchObject({ kind: "master", id: "a", side: "left" });
+    expect(button().getAttribute("aria-pressed")).toBe("true");
+
+    act(() => button().click());
+    expect(store.layout).toMatchObject({ side: "top" });
+
+    act(() => button().click());
+    act(() => button().click());
+    act(() => button().click());
+    expect(store.layout).toEqual({ kind: "grid" });
+    expect(button().getAttribute("aria-pressed")).toBe("false");
+  });
+});

--- a/frontend/src/components/WorkspacePane.tsx
+++ b/frontend/src/components/WorkspacePane.tsx
@@ -2,7 +2,7 @@
 // terminal (each mounted for its lifetime so hidden ones stay connected),
 // laid out as a single view (one visible) or a responsive grid (two-plus).
 
-import { useMemo, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import {
   DndContext,
   DragOverlay,
@@ -10,14 +10,18 @@ import {
   PointerSensor,
   TouchSensor,
   closestCenter,
+  pointerWithin,
+  useDroppable,
   useSensor,
   useSensors,
+  type CollisionDetection,
   type DragEndEvent,
   type DragStartEvent,
 } from "@dnd-kit/core";
 import type { SessionTarget } from "../api/client";
 import { requestBrowserFullscreen } from "../lib/fullscreen";
-import { useWorkspace } from "../state/workspace";
+import { MASTER_SIDES, useWorkspace, type MasterSide } from "../state/workspace";
+import { dropIntent, nextMasterSide, paneLayout } from "./masterLayout";
 import { TerminalCard } from "./TerminalCard";
 import "./WorkspacePane.css";
 
@@ -25,6 +29,66 @@ const REMO_ASCII = `   ____ ___ _ __ ___   ___
   | __// _ \\  _ \` _ \\ / _ \\
   | | |  __/ | | | | | (_) |
   |_|  \\___|_| |_| |_|\\___/`;
+
+/** How long hover-focus stays suppressed after tiles reflow. */
+const LAYOUT_SETTLE_MS = 250;
+
+/**
+ * Edge zones win outright when the pointer is inside one — dragging to the
+ * border is unambiguous intent, and `closestCenter` would otherwise keep
+ * choosing whichever tile sits under the band (a thin strip's centre is almost
+ * never the closest). `pointerWithin` returns [] when there are no pointer
+ * coordinates, which is exactly the fallback we want: a KeyboardSensor drag
+ * keeps today's swap-only behaviour.
+ */
+const snapAwareCollision: CollisionDetection = (args) => {
+  const isZone = (c: (typeof args.droppableContainers)[number]): boolean =>
+    c.data.current?.snapSide !== undefined;
+  const zones = args.droppableContainers.filter(isZone);
+  if (zones.length > 0) {
+    const hits = pointerWithin({ ...args, droppableContainers: zones });
+    if (hits.length > 0) {
+      return hits;
+    }
+  }
+  return closestCenter({
+    ...args,
+    droppableContainers: args.droppableContainers.filter((c) => !isZone(c)),
+  });
+};
+
+/** Read a drop target as either an edge zone or a plain tile. Zones are told
+ * apart by their `data` payload, never an id prefix — target ids come from the
+ * server and must not be assumed prefix-free. */
+function snapTargetOf(over: {
+  id: string | number;
+  data: { current?: { snapSide?: MasterSide } };
+}): { id: string; snapSide?: MasterSide } {
+  return { id: String(over.id), snapSide: over.data.current?.snapSide };
+}
+
+/** A drop target hugging one border of the pane.
+ *
+ * Deliberately `pointer-events: none` (see the CSS): dnd-kit resolves collisions
+ * from measured RECTS, never DOM hit-testing, so a zone can overlay the pane
+ * without stealing the pointer. That also leaves the rail's resize handle —
+ * which overhangs 3px into this pane's left edge — owning pointerdown there. */
+function SnapZone({ side, armed }: { side: MasterSide; armed: boolean }): JSX.Element {
+  const { setNodeRef, isOver } = useDroppable({
+    id: `remo-snap:${side}`,
+    data: { snapSide: side },
+  });
+  return (
+    <div
+      ref={setNodeRef}
+      aria-hidden="true"
+      data-testid={`snap-zone-${side}`}
+      className={`workspace-snap workspace-snap--${side}${armed ? " workspace-snap--armed" : ""}${
+        isOver ? " workspace-snap--over" : ""
+      }`}
+    />
+  );
+}
 
 interface WorkspacePaneProps {
   /** id -> SessionTarget resolved from live discovery. */
@@ -37,19 +101,6 @@ interface WorkspacePaneProps {
   narrow: boolean;
 }
 
-function gridColumns(visibleCount: number, narrow: boolean): number {
-  if (narrow) {
-    return 1;
-  }
-  if (visibleCount >= 5) {
-    return 3;
-  }
-  if (visibleCount >= 2) {
-    return 2;
-  }
-  return 1;
-}
-
 export function WorkspacePane({
   targetsById,
   regionByKey,
@@ -58,7 +109,18 @@ export function WorkspacePane({
   narrow,
 }: WorkspacePaneProps): JSX.Element {
   const workspace = useWorkspace();
-  const { attached, visible, focusedId, prevGrid, maximizedId } = workspace;
+  const { attached, visible, focusedId, prevGrid, maximizedId, layout } = workspace;
+
+  // A layout change reflows tiles under a stationary pointer, and the browser
+  // then fires mouseenter for whatever landed there — arming focus-follows-mouse
+  // and silently moving focus a beat later. Suppress hover-focus briefly after
+  // any change. (WorkspacePane's activeId guard can't help: the drag has ended.)
+  const [settling, setSettling] = useState(false);
+  useEffect(() => {
+    setSettling(true);
+    const timer = setTimeout(() => setSettling(false), LAYOUT_SETTLE_MS);
+    return () => clearTimeout(timer);
+  }, [layout, visible]);
 
   // dnd-kit reorder: `activeId` is the tile currently being dragged (drives the
   // floating DragOverlay ghost). Only the resulting order (`visible`) persists.
@@ -110,9 +172,10 @@ export function WorkspacePane({
 
   // Cards render as single (full-bleed) while a card is maximized; otherwise the
   // usual single↔grid split by how many are visible.
-  const mode = maximized || visible.length <= 1 ? "single" : "grid";
-  const cols = gridColumns(visible.length, narrow);
-  const rows = Math.max(1, Math.ceil(visible.length / cols));
+  // `paneMode` is the single-vs-grid axis; `layout.kind` is the separate
+  // uniform-vs-tiled axis. Two different "grid"s, hence the distinct name.
+  const paneMode = maximized || visible.length <= 1 ? "single" : "grid";
+  const pane = paneMode === "grid" ? paneLayout(layout, visible, narrow) : null;
   // The Grid control is available when a grid can be shown — either the visible
   // set is already a grid (fullscreen opened over one) or a grid was remembered.
   const canGrid =
@@ -130,15 +193,30 @@ export function WorkspacePane({
   };
 
   // Reordering is possible only within a real grid (two-plus visible tiles).
-  const reorderable = !maximized && mode === "grid" && visible.length > 1;
+  const reorderable = !maximized && paneMode === "grid" && visible.length > 1;
   const activeTarget = activeId ? targetsById.get(activeId) : undefined;
+
+  const cycleTile = (id: string): void => {
+    const side = nextMasterSide(layout, id);
+    if (side) {
+      workspace.setMaster(id, side);
+    } else {
+      workspace.clearMaster();
+    }
+  };
 
   const onDragStart = (e: DragStartEvent): void => setActiveId(String(e.active.id));
   const onDragEnd = (e: DragEndEvent): void => {
     const { active, over } = e;
     setActiveId(null);
-    if (over && active.id !== over.id) {
-      workspace.swapVisible(String(active.id), String(over.id));
+    // The branchy part is a pure function: jsdom reports every element as 0x0,
+    // so a real dnd-kit drop cannot be simulated and this is the only place the
+    // decision can actually be tested. See masterLayout.test.ts.
+    const intent = dropIntent(String(active.id), over ? snapTargetOf(over) : null);
+    if (intent?.kind === "master") {
+      workspace.setMaster(intent.id, intent.side);
+    } else if (intent?.kind === "swap") {
+      workspace.swapVisible(intent.a, intent.b);
     }
   };
 
@@ -146,33 +224,40 @@ export function WorkspacePane({
     <main className="workspace" data-testid="workspace">
       <DndContext
         sensors={sensors}
-        collisionDetection={closestCenter}
+        collisionDetection={snapAwareCollision}
         onDragStart={onDragStart}
         onDragEnd={onDragEnd}
         onDragCancel={() => setActiveId(null)}
       >
         <div
-          className={`workspace-body workspace-body--${mode}${maximized ? " workspace-body--maximized" : ""}`}
-          style={
-            mode === "grid"
-              ? {
-                  gridTemplateColumns: `repeat(${cols}, minmax(0, 1fr))`,
-                  gridTemplateRows: `repeat(${rows}, minmax(0, 1fr))`,
-                }
-              : undefined
-          }
+          className={`workspace-body workspace-body--${paneMode}${maximized ? " workspace-body--maximized" : ""}`}
+          style={pane?.container}
         >
+          {/* Edge drop targets. Mounted whenever a reorder is possible, NOT on
+           * activeId: dnd-kit measures droppable rects when the drag starts, so
+           * a zone mounted inside onDragStart races that measurement. */}
+          {reorderable &&
+            MASTER_SIDES.map((side) => (
+              <SnapZone key={side} side={side} armed={activeId !== null} />
+            ))}
           {orderedTargets.map((target) => {
             const id = target.id;
             const isVisible = maximized ? id === maximized : visible.includes(id);
             const viewState =
-              maximized === id ? "fullscreen" : mode === "grid" ? "grid" : "normal";
+              maximized === id ? "fullscreen" : paneMode === "grid" ? "grid" : "normal";
             return (
               <TerminalCard
                 key={id}
                 target={target}
                 region={regionByKey.get(`${target.instance_type}::${target.instance_name}`)}
-                mode={mode}
+                mode={paneMode}
+                gridArea={pane?.areaById.get(id)}
+                masterSide={
+                  layout.kind === "master" && layout.id === id ? layout.side : null
+                }
+                onCycleTile={
+                  reorderable && isVisible ? () => cycleTile(id) : undefined
+                }
                 isVisible={isVisible}
                 isFocused={focusedId === id}
                 viewState={viewState}
@@ -183,7 +268,7 @@ export function WorkspacePane({
                 onToggleFullscreen={() => toggleFullscreen(id)}
                 onFocusRequest={() => workspace.setFocused(id)}
                 onHoverFocus={
-                  mode === "grid" && !maximized
+                  paneMode === "grid" && !maximized && !settling
                     ? () => {
                         // Focus-follows-mouse: hovering a grid tile focuses it,
                         // but never while dragging (would fight the reorder).

--- a/frontend/src/components/masterLayout.test.ts
+++ b/frontend/src/components/masterLayout.test.ts
@@ -1,0 +1,201 @@
+import { describe, expect, it } from "vitest";
+import type { WorkspaceLayout } from "../state/workspace";
+import { dropIntent, gridColumns, nextMasterSide, paneLayout } from "./masterLayout";
+
+const grid: WorkspaceLayout = { kind: "grid" };
+const master = (id: string, side: "left" | "right" | "top" | "bottom", fraction = 0.6): WorkspaceLayout => ({
+  kind: "master",
+  id,
+  side,
+  fraction,
+});
+
+/** Every grid line an area occupies, so overlaps and holes are detectable. */
+function cellsOf(areaSpec: string): string[] {
+  const [r1, c1, r2, c2] = areaSpec.split(" / ").map(Number);
+  const cells: string[] = [];
+  for (let r = r1; r < r2; r += 1) {
+    for (let c = c1; c < c2; c += 1) {
+      cells.push(`${r},${c}`);
+    }
+  }
+  return cells;
+}
+
+function trackCount(template: string): number {
+  const repeat = /repeat\((\d+),/.exec(template);
+  const repeats = repeat ? Number(repeat[1]) : 0;
+  const singles = (template.match(/minmax\(0, \d+fr\)/g) ?? []).length - (repeat ? 1 : 0);
+  return repeats + Math.max(0, singles);
+}
+
+describe("uniform grid", () => {
+  // The degradation guarantee: with no master set, this module must reproduce
+  // exactly what WorkspacePane rendered before it existed.
+  it.each([
+    [1, false, 1, 1],
+    [2, false, 2, 1],
+    [3, false, 2, 2],
+    [4, false, 2, 2],
+    [5, false, 3, 2],
+    [9, false, 3, 3],
+    [4, true, 1, 4],
+  ])("%i tiles (narrow=%s) -> %i cols x %i rows", (count, narrow, cols, rows) => {
+    const visible = Array.from({ length: count }, (_, i) => `t${i}`);
+    const { container, areaById } = paneLayout(grid, visible, narrow);
+    expect(container.gridTemplateColumns).toBe(`repeat(${cols}, minmax(0, 1fr))`);
+    expect(container.gridTemplateRows).toBe(`repeat(${rows}, minmax(0, 1fr))`);
+    // No explicit areas: tiles auto-place exactly as they always have.
+    expect(areaById.size).toBe(0);
+  });
+
+  it("matches gridColumns, which moved here from WorkspacePane", () => {
+    expect(gridColumns(1, false)).toBe(1);
+    expect(gridColumns(4, false)).toBe(2);
+    expect(gridColumns(5, false)).toBe(3);
+    expect(gridColumns(9, true)).toBe(1);
+  });
+});
+
+describe("master/stack", () => {
+  // The motivating case: 3 terminals, one filling the right side full-height.
+  it("puts the master on the right at 60% with the stack down the left", () => {
+    const { container, areaById } = paneLayout(master("c", "right"), ["a", "b", "c"], false);
+    expect(container.gridTemplateColumns).toBe("repeat(1, minmax(0, 40fr)) minmax(0, 60fr)");
+    expect(container.gridTemplateRows).toBe("repeat(2, minmax(0, 1fr))");
+    expect(areaById.get("c")).toBe("1 / 2 / 3 / 3"); // full height, right column
+    expect(areaById.get("a")).toBe("1 / 1 / 2 / 2");
+    expect(areaById.get("b")).toBe("2 / 1 / 3 / 2");
+  });
+
+  it("mirrors for a left master", () => {
+    const { container, areaById } = paneLayout(master("c", "left"), ["a", "b", "c"], false);
+    expect(container.gridTemplateColumns).toBe("minmax(0, 60fr) repeat(1, minmax(0, 40fr))");
+    expect(areaById.get("c")).toBe("1 / 1 / 3 / 2");
+    expect(areaById.get("a")).toBe("1 / 2 / 2 / 3");
+    expect(areaById.get("b")).toBe("2 / 2 / 3 / 3");
+  });
+
+  it("transposes for a top master — stack tiles horizontally below", () => {
+    const { container, areaById } = paneLayout(master("c", "top"), ["a", "b", "c"], false);
+    expect(container.gridTemplateRows).toBe("minmax(0, 60fr) repeat(1, minmax(0, 40fr))");
+    expect(container.gridTemplateColumns).toBe("repeat(2, minmax(0, 1fr))");
+    expect(areaById.get("c")).toBe("1 / 1 / 2 / 3"); // full width, top row
+    expect(areaById.get("a")).toBe("2 / 1 / 3 / 2");
+    expect(areaById.get("b")).toBe("2 / 2 / 3 / 3");
+  });
+
+  it("transposes for a bottom master", () => {
+    const { container, areaById } = paneLayout(master("c", "bottom"), ["a", "b", "c"], false);
+    expect(container.gridTemplateRows).toBe("repeat(1, minmax(0, 40fr)) minmax(0, 60fr)");
+    expect(areaById.get("c")).toBe("2 / 1 / 3 / 3");
+    expect(areaById.get("a")).toBe("1 / 1 / 2 / 2");
+  });
+
+  it("handles a single stack tile (two visible)", () => {
+    const { container, areaById } = paneLayout(master("a", "right"), ["a", "b"], false);
+    expect(container.gridTemplateRows).toBe("repeat(1, minmax(0, 1fr))");
+    expect(areaById.get("a")).toBe("1 / 2 / 2 / 3");
+    expect(areaById.get("b")).toBe("1 / 1 / 2 / 2");
+  });
+
+  it("follows visible order, skipping the master", () => {
+    const { areaById } = paneLayout(master("b", "right"), ["a", "b", "c", "d"], false);
+    // a, c, d keep their relative order down the stack.
+    expect(areaById.get("a")).toBe("1 / 1 / 2 / 2");
+    expect(areaById.get("c")).toBe("2 / 1 / 3 / 2");
+    expect(areaById.get("d")).toBe("3 / 1 / 4 / 2");
+  });
+
+  // Past four, a 1-wide stack would give ~25px tiles on an iPad — above the
+  // TerminalCard 0x0 guard, so it would fit() to one row and corrupt a TUI.
+  it("widens the stack to two tracks past four stack tiles", () => {
+    const visible = ["m", "a", "b", "c", "d", "e"];
+    const { container, areaById } = paneLayout(master("m", "right"), visible, false);
+    expect(container.gridTemplateColumns).toBe("repeat(2, minmax(0, 40fr)) minmax(0, 120fr)");
+    expect(container.gridTemplateRows).toBe("repeat(3, minmax(0, 1fr))");
+    expect(areaById.get("m")).toBe("1 / 3 / 4 / 4");
+    expect(areaById.get("a")).toBe("1 / 1 / 2 / 2");
+    expect(areaById.get("b")).toBe("1 / 2 / 2 / 3");
+    expect(areaById.get("c")).toBe("2 / 1 / 3 / 2");
+  });
+
+  // The master track is scaled by the stack width so the ratio survives without
+  // ever emitting a fractional fr.
+  it.each([0.3, 0.5, 0.55, 0.6, 0.7, 0.75])(
+    "emits whole fr units at fraction %s",
+    (fraction) => {
+      for (const side of ["left", "right", "top", "bottom"] as const) {
+        for (const count of [2, 3, 6, 9]) {
+          const visible = Array.from({ length: count }, (_, i) => `t${i}`);
+          const { container } = paneLayout(master("t0", side, fraction), visible, false);
+          const template = `${container.gridTemplateColumns} ${container.gridTemplateRows}`;
+          expect(template, `${side} @ ${fraction} x${count}`).not.toMatch(/\d\.\d/);
+        }
+      }
+    },
+  );
+
+  it("tiles the pane exactly — every cell filled once, no overlap", () => {
+    for (const side of ["left", "right", "top", "bottom"] as const) {
+      for (const count of [2, 3, 4, 6, 9]) {
+        const visible = Array.from({ length: count }, (_, i) => `t${i}`);
+        const { container, areaById } = paneLayout(master("t0", side), visible, false);
+        const cols = trackCount(String(container.gridTemplateColumns));
+        const rows = trackCount(String(container.gridTemplateRows));
+        const seen = new Set<string>();
+        let total = 0;
+        for (const spec of areaById.values()) {
+          for (const cell of cellsOf(spec)) {
+            expect(seen.has(cell), `${side} x${count}: ${cell} covered twice`).toBe(false);
+            seen.add(cell);
+            total += 1;
+          }
+        }
+        expect(total, `${side} x${count}`).toBe(rows * cols);
+        expect(areaById.size).toBe(count);
+      }
+    }
+  });
+
+  it("falls back to the uniform grid when the master isn't visible", () => {
+    const { areaById } = paneLayout(master("gone", "right"), ["a", "b"], false);
+    expect(areaById.size).toBe(0);
+  });
+});
+
+describe("dropIntent", () => {
+  it("treats an edge zone as a tiling request, beating the swap", () => {
+    expect(dropIntent("a", { id: "remo-snap:right", snapSide: "right" })).toEqual({
+      kind: "master",
+      id: "a",
+      side: "right",
+    });
+  });
+
+  it("falls back to a swap over another tile", () => {
+    expect(dropIntent("a", { id: "b" })).toEqual({ kind: "swap", a: "a", b: "b" });
+  });
+
+  it("does nothing for a self-drop or no drop target", () => {
+    expect(dropIntent("a", { id: "a" })).toBeNull();
+    expect(dropIntent("a", null)).toBeNull();
+  });
+});
+
+describe("nextMasterSide", () => {
+  it("cycles left -> top -> right -> bottom -> grid", () => {
+    let layout: WorkspaceLayout = grid;
+    const seen: (string | null)[] = [];
+    for (let i = 0; i < 5; i += 1) {
+      const side = nextMasterSide(layout, "a");
+      seen.push(side);
+      layout = side ? master("a", side) : grid;
+    }
+    expect(seen).toEqual(["left", "top", "right", "bottom", null]);
+  });
+
+  it("restarts the cycle when taking mastership from another tile", () => {
+    expect(nextMasterSide(master("b", "bottom"), "a")).toBe("left");
+  });
+});

--- a/frontend/src/components/masterLayout.ts
+++ b/frontend/src/components/masterLayout.ts
@@ -1,0 +1,190 @@
+// Pane geometry for the workspace grid — pure, DOM-free, and unit-tested.
+//
+// Lives outside WorkspacePane for the same reason `themeMenuPosition` lives
+// outside its popup: every rendered tile boots a terminal adapter, so the
+// component is expensive to exercise, while the geometry is the part most worth
+// pinning. jsdom has no layout engine either, so anything measured through the
+// DOM would be untestable — everything here takes its inputs explicitly.
+//
+// Two arrangements are expressed:
+//   - the uniform grid, unchanged from what the console has always rendered;
+//   - master/stack (dwm/xmonad), where one tile takes `fraction` of one side and
+//     the rest tile the remainder.
+//
+// Both are emitted as a `grid-template` for the container plus an explicit
+// `grid-area` per visible tile. The areas matter: CSS auto-placement flowing
+// around an explicitly-placed spanning item is order- and direction-sensitive,
+// so it works until someone reorders the JSX. Placing every tile is one extra
+// map entry and is fully assertable.
+
+import type { CSSProperties } from "react";
+import type { MasterSide, WorkspaceLayout } from "../state/workspace";
+
+export interface PaneLayout {
+  /** Inline grid template for `.workspace-body`. */
+  container: CSSProperties;
+  /** id -> `grid-area`. EMPTY for the uniform grid, so tiles fall back to
+   * auto-placement and the rendered output is byte-identical to before this
+   * module existed. */
+  areaById: Map<string, string>;
+}
+
+/** Columns for the uniform grid. Moved verbatim from WorkspacePane so the
+ * existing layout path gets test coverage too. */
+export function gridColumns(visibleCount: number, narrow: boolean): number {
+  if (narrow) {
+    return 1;
+  }
+  if (visibleCount >= 5) {
+    return 3;
+  }
+  if (visibleCount >= 2) {
+    return 2;
+  }
+  return 1;
+}
+
+/** Past four, the stack goes two-wide.
+ *
+ * A vertical stack of eight in a ~200px-tall pane gives ~25px tiles. That is
+ * ABOVE TerminalCard's 0x0 guard, so it would happily fit() to a single row and
+ * send that to the remote PTY, corrupting a TUI. Widening the stack keeps every
+ * tile at least as big as it would be in the plain grid. */
+function stackColumns(stackCount: number): number {
+  return stackCount >= 5 ? 2 : 1;
+}
+
+const track = (n: number): string => `minmax(0, ${n}fr)`;
+const evenTracks = (n: number): string => `repeat(${n}, minmax(0, 1fr))`;
+
+/** Split a fraction into two whole `fr` units.
+ *
+ * Whole numbers on a 100 basis, because `1 - 0.7` is 0.30000000000000004 in
+ * float64 and that would leak into the style string (and into every assertion
+ * about it). `fr` distributes free space AFTER gaps, so the existing 10px gap is
+ * unaffected. */
+function split(fraction: number): [number, number] {
+  const master = Math.round(fraction * 100);
+  return [master, 100 - master];
+}
+
+/** `grid-area` shorthand: row-start / col-start / row-end / col-end. */
+const area = (r1: number, c1: number, r2: number, c2: number): string =>
+  `${r1} / ${c1} / ${r2} / ${c2}`;
+
+export function paneLayout(
+  layout: WorkspaceLayout,
+  visible: string[],
+  narrow: boolean,
+): PaneLayout {
+  if (layout.kind === "master" && visible.includes(layout.id) && visible.length > 1) {
+    return masterLayout(layout.id, layout.side, layout.fraction, visible);
+  }
+  const cols = gridColumns(visible.length, narrow);
+  const rows = Math.max(1, Math.ceil(visible.length / cols));
+  return {
+    container: { gridTemplateColumns: evenTracks(cols), gridTemplateRows: evenTracks(rows) },
+    areaById: new Map(),
+  };
+}
+
+function masterLayout(
+  masterId: string,
+  side: MasterSide,
+  fraction: number,
+  visible: string[],
+): PaneLayout {
+  const stack = visible.filter((id) => id !== masterId);
+  const [masterFr, stackFr] = split(fraction);
+  const horizontal = side === "left" || side === "right";
+  const masterFirst = side === "left" || side === "top";
+
+  // How the stack subdivides ACROSS the master's axis (1 or 2), and how deep it
+  // runs ALONG it. For a left/right master the stack subdivides into columns and
+  // runs down rows; for top/bottom it is transposed.
+  const across = stackColumns(stack.length);
+  const depth = Math.max(1, Math.ceil(stack.length / across));
+
+  // Scale the master track by `across` so every track stays a whole number: with
+  // a 2-wide stack, 60/40 becomes 120fr against 2x40fr, which is the same ratio
+  // without ever emitting something like 22.5fr.
+  const masterTrack = track(masterFr * across);
+  const stackTracks = `repeat(${across}, ${track(stackFr)})`;
+  const alongTracks = evenTracks(depth);
+  const masterAxis = masterFirst ? `${masterTrack} ${stackTracks}` : `${stackTracks} ${masterTrack}`;
+
+  // Where each region starts on the master's axis (1-based grid lines).
+  const masterLine = masterFirst ? 1 : across + 1;
+  const stackLine = masterFirst ? 2 : 1;
+
+  // A stack that doesn't divide evenly would otherwise leave an empty cell in
+  // its last row — the exact hole this feature exists to remove from the uniform
+  // grid. The final tile spans the remainder instead.
+  const partial = stack.length % across !== 0;
+  const spanEnd = (k: number, line: number): number =>
+    partial && k === stack.length - 1 ? line + across : line + (k % across) + 1;
+
+  const areaById = new Map<string, string>();
+  if (horizontal) {
+    areaById.set(masterId, area(1, masterLine, depth + 1, masterLine + 1));
+    stack.forEach((id, k) => {
+      const row = Math.floor(k / across) + 1;
+      const col = stackLine + (k % across);
+      areaById.set(id, area(row, col, row + 1, spanEnd(k, stackLine)));
+    });
+    return {
+      container: { gridTemplateColumns: masterAxis, gridTemplateRows: alongTracks },
+      areaById,
+    };
+  }
+
+  areaById.set(masterId, area(masterLine, 1, masterLine + 1, depth + 1));
+  stack.forEach((id, k) => {
+    const col = Math.floor(k / across) + 1;
+    const row = stackLine + (k % across);
+    areaById.set(id, area(row, col, spanEnd(k, stackLine), col + 1));
+  });
+  return {
+    container: { gridTemplateColumns: alongTracks, gridTemplateRows: masterAxis },
+    areaById,
+  };
+}
+
+// --- drag/drop and the cycle button ----------------------------------------
+
+export type DropIntent =
+  | { kind: "master"; id: string; side: MasterSide }
+  | { kind: "swap"; a: string; b: string }
+  | null;
+
+/** What a drop means. Pure so it can be tested: jsdom reports every element as
+ * 0x0, so a real dnd-kit drop cannot be simulated and this branch would
+ * otherwise have no coverage at all. */
+export function dropIntent(
+  activeId: string,
+  over: { id: string; snapSide?: MasterSide } | null,
+): DropIntent {
+  if (!over) {
+    return null;
+  }
+  if (over.snapSide) {
+    return { kind: "master", id: activeId, side: over.snapSide };
+  }
+  if (over.id === activeId) {
+    return null;
+  }
+  return { kind: "swap", a: activeId, b: over.id };
+}
+
+/** Order the tile button cycles through. Drawn by the button's glyphs. */
+const MASTER_CYCLE: MasterSide[] = ["left", "top", "right", "bottom"];
+
+/** The next side for `id`, or null to return to the uniform grid. Taking
+ * mastership from another tile restarts the cycle, so the button always
+ * advances visibly rather than appearing to do nothing. */
+export function nextMasterSide(layout: WorkspaceLayout, id: string): MasterSide | null {
+  if (layout.kind !== "master" || layout.id !== id) {
+    return MASTER_CYCLE[0];
+  }
+  return MASTER_CYCLE[MASTER_CYCLE.indexOf(layout.side) + 1] ?? null;
+}

--- a/frontend/src/state/workspace.test.ts
+++ b/frontend/src/state/workspace.test.ts
@@ -96,3 +96,201 @@ describe("workspace grid reorder (swapVisible)", () => {
     expect(result.current.visible).toEqual(["a", "b"]);
   });
 });
+
+// --- master/stack tiling ----------------------------------------------------
+//
+// The invariant lives in one place (normalizeLayout, called from setState), so
+// most of these prove that actions which never mention `layout` still leave it
+// coherent.
+
+const STORAGE_KEY = "remo-web:workspace";
+
+describe("workspace master layout", () => {
+  it("promotes a visible tile to the master area at the default split", async () => {
+    const { result } = await mount();
+    act(() => result.current.openMany([target("a"), target("b"), target("c")]));
+    act(() => result.current.setMaster("c", "right"));
+
+    expect(result.current.layout).toEqual({
+      kind: "master",
+      id: "c",
+      side: "right",
+      fraction: 0.6,
+    });
+  });
+
+  it("keeps the current split when re-tiling to another edge", async () => {
+    const { result } = await mount();
+    act(() => result.current.openMany([target("a"), target("b")]));
+    act(() => result.current.setMaster("a", "right"));
+    act(() => result.current.setMaster("a", "top"));
+
+    expect(result.current.layout).toMatchObject({ side: "top", fraction: 0.6 });
+  });
+
+  it("clearMaster returns to the grid without disturbing the tile order", async () => {
+    const { result } = await mount();
+    act(() => result.current.openMany([target("a"), target("b"), target("c")]));
+    act(() => result.current.setMaster("b", "left"));
+    act(() => result.current.clearMaster());
+
+    expect(result.current.layout).toEqual({ kind: "grid" });
+    expect(result.current.visible).toEqual(["a", "b", "c"]);
+  });
+
+  it("ignores a master that isn't visible, and one with too few tiles", async () => {
+    const { result } = await mount();
+    act(() => result.current.openMany([target("a"), target("b")]));
+
+    act(() => result.current.setMaster("nope", "left"));
+    expect(result.current.layout).toEqual({ kind: "grid" });
+
+    act(() => result.current.selectOnly(target("a")));
+    act(() => result.current.setMaster("a", "left"));
+    expect(result.current.layout).toEqual({ kind: "grid" });
+  });
+
+  it("clamps the split into the usable range", async () => {
+    // Only reachable through a hand-edited store today (the splitter is stage
+    // 2), but the clamp is what stops a 0.99 master squeezing the stack to
+    // nothing. NB: mount() clears localStorage, so seed it and import directly.
+    window.localStorage.clear();
+    window.localStorage.setItem(
+      STORAGE_KEY,
+      JSON.stringify({
+        attached: ["a", "b"],
+        visible: ["a", "b"],
+        focusedId: "a",
+        layout: { kind: "master", id: "a", side: "left", fraction: 0.99 },
+      }),
+    );
+    vi.resetModules();
+    const mod = await import("./workspace");
+    const { result } = renderHook(() => mod.useWorkspace());
+    expect((result.current.layout as { fraction: number }).fraction).toBe(0.75);
+  });
+
+  // Closing the master moves ONE tile instead of reflowing every survivor.
+  it("promotes the head of the stack when the master is closed", async () => {
+    const { result } = await mount();
+    act(() => result.current.openMany([target("a"), target("b"), target("c")]));
+    act(() => result.current.setMaster("c", "right"));
+    act(() => result.current.closeTerm("c"));
+
+    expect(result.current.layout).toMatchObject({ kind: "master", id: "a", side: "right" });
+    expect(result.current.visible).toEqual(["a", "b"]);
+  });
+
+  it("falls back to the grid once too few tiles remain", async () => {
+    const { result } = await mount();
+    act(() => result.current.openMany([target("a"), target("b")]));
+    act(() => result.current.setMaster("a", "right"));
+    act(() => result.current.closeTerm("b"));
+
+    expect(result.current.layout).toEqual({ kind: "grid" });
+  });
+
+  it("survives solo and comes back with the grid", async () => {
+    const { result } = await mount();
+    act(() => result.current.openMany([target("a"), target("b"), target("c")]));
+    act(() => result.current.setMaster("c", "top"));
+    // Escape routes here — the tiling must not be destroyed by it.
+    act(() => result.current.soloTile("a"));
+    expect(result.current.layout).toEqual({ kind: "grid" });
+
+    act(() => result.current.backToGrid());
+    expect(result.current.layout).toMatchObject({ kind: "master", id: "c", side: "top" });
+  });
+
+  it("is discarded by an open-many rebuild", async () => {
+    const { result } = await mount();
+    act(() => result.current.openMany([target("a"), target("b")]));
+    act(() => result.current.setMaster("a", "left"));
+    act(() => result.current.openMany([target("a"), target("b"), target("c")]));
+
+    expect(result.current.layout).toEqual({ kind: "grid" });
+  });
+
+  // Mastership is attached to the SLOT: dragging the master onto a stack tile
+  // must actually move the dragged tile.
+  it("transfers mastership when the master is swapped", async () => {
+    const { result } = await mount();
+    act(() => result.current.openMany([target("a"), target("b"), target("c")]));
+    act(() => result.current.setMaster("a", "right"));
+
+    act(() => result.current.swapVisible("a", "c"));
+    expect(result.current.layout).toMatchObject({ id: "c" });
+
+    act(() => result.current.swapVisible("b", "c"));
+    expect(result.current.layout).toMatchObject({ id: "b" });
+  });
+
+  it("leaves the master alone when neither swapped tile holds it", async () => {
+    const { result } = await mount();
+    act(() => result.current.openMany([target("a"), target("b"), target("c")]));
+    act(() => result.current.setMaster("a", "right"));
+    act(() => result.current.swapVisible("b", "c"));
+
+    expect(result.current.layout).toMatchObject({ id: "a" });
+  });
+
+  it("is orthogonal to fullscreen", async () => {
+    const { result } = await mount();
+    act(() => result.current.openMany([target("a"), target("b")]));
+    act(() => result.current.setMaster("b", "bottom"));
+
+    act(() => result.current.maximize("a"));
+    expect(result.current.layout).toMatchObject({ kind: "master", id: "b" });
+    act(() => result.current.restore());
+    expect(result.current.layout).toMatchObject({ kind: "master", id: "b" });
+  });
+});
+
+describe("workspace master layout persistence", () => {
+  it("round-trips through localStorage", async () => {
+    const first = await mount();
+    act(() => first.result.current.openMany([target("a"), target("b"), target("c")]));
+    act(() => first.result.current.setMaster("b", "left"));
+
+    vi.resetModules();
+    const mod = await import("./workspace");
+    const { result } = renderHook(() => mod.useWorkspace());
+    expect(result.current.layout).toMatchObject({ kind: "master", id: "b", side: "left" });
+  });
+
+  it("does not persist the remembered tiling", async () => {
+    const { result } = await mount();
+    act(() => result.current.openMany([target("a"), target("b")]));
+    act(() => result.current.setMaster("a", "left"));
+    act(() => result.current.soloTile("a"));
+
+    const stored = JSON.parse(window.localStorage.getItem(STORAGE_KEY) ?? "{}") as Record<string, unknown>;
+    expect(Object.keys(stored).sort()).toEqual(["attached", "focusedId", "layout", "visible"]);
+  });
+
+  it.each([
+    ["a stale master id", { kind: "master", id: "gone", side: "left", fraction: 0.6 }],
+    ["a bad side", { kind: "master", id: "a", side: "sideways", fraction: 0.6 }],
+    ["a non-numeric fraction", { kind: "master", id: "a", side: "left", fraction: "wide" }],
+    ["an unknown kind from a newer build", { kind: "columns", id: "a" }],
+    ["a non-object", "master"],
+    ["an array", []],
+  ])("loads sanely with %s", async (_label, layout) => {
+    window.localStorage.setItem(
+      STORAGE_KEY,
+      JSON.stringify({ attached: ["a", "b"], visible: ["a", "b"], focusedId: "a", layout }),
+    );
+    vi.resetModules();
+    const mod = await import("./workspace");
+    const { result } = renderHook(() => mod.useWorkspace());
+
+    // Either a coherent master on a real tile, or the grid. Never a dangling id.
+    const restored = result.current.layout;
+    if (restored.kind === "master") {
+      expect(result.current.visible).toContain(restored.id);
+      expect(restored.fraction).toBeGreaterThanOrEqual(0.3);
+    } else {
+      expect(restored).toEqual({ kind: "grid" });
+    }
+  });
+});

--- a/frontend/src/state/workspace.ts
+++ b/frontend/src/state/workspace.ts
@@ -14,6 +14,13 @@
 //                 can restore it.
 //   - `unread`    attached-but-hidden ids that produced output since last seen
 //                 (drives the rail's activity marker). Not persisted.
+//   - `layout`    how the visible tiles are arranged: the uniform grid (the
+//                 default), or a master/stack tiling where one tile holds a
+//                 chosen side of the pane and the rest tile the leftover strip
+//                 (the dwm/xmonad model). Persisted alongside `visible`, since a
+//                 tiling is exactly as durable as the tile ORDER it decorates.
+//   - `prevLayout`  the tiling remembered when soloing, so "back to grid" can
+//                 restore it. Transient, mirroring `prevGrid`.
 //   - `maximizedId`  the terminal currently shown fullscreen, or null. This is
 //                 an ORTHOGONAL presentation overlay, NOT a third value on the
 //                 single↔grid axis: it never mutates `visible`/`prevGrid`, so
@@ -33,16 +40,83 @@ import type { SessionTarget } from "../api/client";
 
 const STORAGE_KEY = "remo-web:workspace";
 
+export const MASTER_SIDES = ["left", "right", "top", "bottom"] as const;
+export type MasterSide = (typeof MASTER_SIDES)[number];
+
+/** How the visible tiles are arranged. `grid` is the uniform CSS grid the
+ * console has always used, and is both the default and the fallback for every
+ * invalid state. `master` is one tile holding `fraction` of the pane on `side`,
+ * with the rest tiling the remainder. */
+export type WorkspaceLayout =
+  | { kind: "grid" }
+  | { kind: "master"; id: string; side: MasterSide; fraction: number };
+
+/** Shared instance so the uniform-grid case never allocates per write. */
+const GRID_LAYOUT: WorkspaceLayout = { kind: "grid" };
+
+export const DEFAULT_MASTER_FRACTION = 0.6;
+export const MIN_MASTER_FRACTION = 0.3;
+export const MAX_MASTER_FRACTION = 0.75;
+
 interface PersistedWorkspaceState {
   attached: string[];
   visible: string[];
   focusedId: string | null;
+  layout: WorkspaceLayout;
 }
 
 interface WorkspaceState extends PersistedWorkspaceState {
   prevGrid: string[] | null;
+  prevLayout: WorkspaceLayout | null;
   unread: string[];
   maximizedId: string | null;
+}
+
+/**
+ * The layout's cross-field invariant, in ONE place.
+ *
+ * A master area only means anything while its tile is one of two-plus visible
+ * tiles, so everything that shrinks or rebuilds `visible` has to be accounted
+ * for. Rather than teach eight actions that rule — and forget it in the ninth —
+ * `setState` runs this on every write and `loadPersisted` runs it on the
+ * restored blob.
+ *
+ * A master that is no longer visible PROMOTES the head of the stack rather than
+ * un-tiling: closing the master should move one tile, not reflow every survivor
+ * (which resizes each remaining PTY and repaints any TUI). That is also what dwm
+ * does. Returns its input unchanged when already valid, so unrelated actions
+ * like `markUnread` never churn the layout reference.
+ */
+function normalizeLayout(layout: WorkspaceLayout, ids: string[]): WorkspaceLayout {
+  if (layout.kind !== "master") {
+    return GRID_LAYOUT;
+  }
+  if (ids.length < 2) {
+    return GRID_LAYOUT;
+  }
+  const id = ids.includes(layout.id) ? layout.id : ids[0];
+  const raw = Number.isFinite(layout.fraction) ? layout.fraction : DEFAULT_MASTER_FRACTION;
+  const fraction = Math.min(MAX_MASTER_FRACTION, Math.max(MIN_MASTER_FRACTION, raw));
+  return id === layout.id && fraction === layout.fraction ? layout : { ...layout, id, fraction };
+}
+
+/** Shape-only validation of an untrusted persisted layout. Cross-field rules
+ * belong to `normalizeLayout`, which runs after this. An unrecognized `kind`
+ * (written by a newer build) degrades to the grid rather than throwing. */
+function asLayout(v: unknown): WorkspaceLayout {
+  if (typeof v !== "object" || v === null || Array.isArray(v)) {
+    return GRID_LAYOUT;
+  }
+  const l = v as Partial<{ kind: unknown; id: unknown; side: unknown; fraction: unknown }>;
+  if (l.kind !== "master") {
+    return GRID_LAYOUT;
+  }
+  if (typeof l.id !== "string" || !MASTER_SIDES.includes(l.side as MasterSide)) {
+    return GRID_LAYOUT;
+  }
+  // A bad fraction has an obviously-correct default; a bad side does not.
+  const fraction = typeof l.fraction === "number" ? l.fraction : DEFAULT_MASTER_FRACTION;
+  return { kind: "master", id: l.id, side: l.side as MasterSide, fraction };
 }
 
 function loadPersisted(): WorkspaceState {
@@ -50,7 +124,9 @@ function loadPersisted(): WorkspaceState {
     attached: [],
     visible: [],
     focusedId: null,
+    layout: GRID_LAYOUT,
     prevGrid: null,
+    prevLayout: null,
     unread: [],
     maximizedId: null,
   };
@@ -75,7 +151,18 @@ function loadPersisted(): WorkspaceState {
     const visible = asStrings(c.visible).filter((id) => attached.includes(id));
     const focusedId =
       typeof c.focusedId === "string" && visible.includes(c.focusedId) ? c.focusedId : (visible[0] ?? null);
-    return { attached, visible, focusedId, prevGrid: null, unread: [], maximizedId: null };
+    // Validated last, against the already-filtered `visible`.
+    const layout = normalizeLayout(asLayout(c.layout), visible);
+    return {
+      attached,
+      visible,
+      focusedId,
+      layout,
+      prevGrid: null,
+      prevLayout: null,
+      unread: [],
+      maximizedId: null,
+    };
   } catch (error) {
     console.error("workspace: failed to restore from localStorage", error);
     return fallback;
@@ -91,6 +178,7 @@ function persist(state: WorkspaceState): void {
       attached: state.attached,
       visible: state.visible,
       focusedId: state.focusedId,
+      layout: state.layout,
     };
     window.localStorage.setItem(STORAGE_KEY, JSON.stringify(toPersist));
   } catch (error) {
@@ -103,7 +191,11 @@ let state: WorkspaceState = loadPersisted();
 const listeners = new Set<() => void>();
 
 function setState(partial: Partial<WorkspaceState>): void {
-  state = { ...state, ...partial };
+  const next = { ...state, ...partial };
+  // The single write path for every action, so the layout invariant lives here
+  // once instead of in each of them. See normalizeLayout.
+  next.layout = normalizeLayout(next.layout, next.visible);
+  state = next;
   persist(state);
   for (const listener of listeners) {
     listener();
@@ -154,10 +246,15 @@ function addSession(target: SessionTarget): void {
   setState({ attached, visible, focusedId, unread: clearUnread(id), maximizedId: null });
 }
 
-/** Solo a grid tile into the single view, remembering the grid to return to. */
+/** Solo a grid tile into the single view, remembering the grid to return to.
+ * Remembers the TILING under the same condition: Escape routes here
+ * (useConsoleKeyboard), so without this one stray keypress would permanently
+ * destroy a layout that took a drag to build. */
 function soloTile(id: string): void {
+  const wasGrid = state.visible.length > 1;
   setState({
-    prevGrid: state.visible.length > 1 ? state.visible : state.prevGrid,
+    prevGrid: wasGrid ? state.visible : state.prevGrid,
+    prevLayout: wasGrid ? state.layout : state.prevLayout,
     visible: [id],
     focusedId: id,
     unread: clearUnread(id),
@@ -173,11 +270,19 @@ function backToGrid(): void {
   const grid =
     current.length > 1 ? current : (state.prevGrid ?? []).filter((id) => state.attached.includes(id));
   if (grid.length <= 1) {
-    setState({ prevGrid: null, maximizedId: null });
+    setState({ prevGrid: null, prevLayout: null, maximizedId: null });
     return;
   }
   const focusedId = grid.includes(state.focusedId ?? "") ? state.focusedId : grid[grid.length - 1];
-  setState({ visible: grid, focusedId, prevGrid: null, maximizedId: null });
+  // normalizeLayout validates the restored tiling against the restored grid.
+  setState({
+    visible: grid,
+    layout: state.prevLayout ?? GRID_LAYOUT,
+    focusedId,
+    prevGrid: null,
+    prevLayout: null,
+    maximizedId: null,
+  });
 }
 
 /** Open several targets at once as a grid (open-all). */
@@ -192,7 +297,16 @@ function openMany(targets: SessionTarget[]): void {
     }
   }
   const visible = targets.map((t) => t.id);
-  setState({ attached, visible, focusedId: visible[0], prevGrid: null, maximizedId: null });
+  // A full rebuild already discards the custom `visible` order; the tiling is
+  // the same class of arrangement state, so it goes with it.
+  setState({
+    attached,
+    visible,
+    focusedId: visible[0],
+    layout: GRID_LAYOUT,
+    prevGrid: null,
+    maximizedId: null,
+  });
 }
 
 /** Swap two tiles' positions in the grid. The order lives in `visible` (which is
@@ -206,7 +320,35 @@ function swapVisible(a: string, b: string): void {
   }
   const visible = [...state.visible];
   [visible[i], visible[j]] = [visible[j], visible[i]];
-  setState({ visible });
+  // Mastership follows the SLOT, not the tile. Dragging the master onto a stack
+  // tile otherwise swaps their array positions while `layout.id` still names the
+  // master — so the tile the user dragged visibly would not move.
+  let layout = state.layout;
+  if (layout.kind === "master" && (layout.id === a || layout.id === b)) {
+    layout = { ...layout, id: layout.id === a ? b : a };
+  }
+  setState({ visible, layout });
+}
+
+/** Give `id` the master area on `side`, tiling the rest into the remainder.
+ * Keeps the current split when one is already set, so re-tiling to another edge
+ * doesn't silently undo a resize. Normalised away by `normalizeLayout` when `id`
+ * isn't part of a two-plus grid, so callers need no guard. */
+function setMaster(id: string, side: MasterSide): void {
+  // An explicit request naming a tile that isn't on screen is a caller bug, not
+  // a tile disappearing — no-op rather than letting normalizeLayout's promotion
+  // rule hand mastership to whatever happens to be first.
+  if (!state.visible.includes(id)) {
+    return;
+  }
+  const fraction =
+    state.layout.kind === "master" ? state.layout.fraction : DEFAULT_MASTER_FRACTION;
+  setState({ layout: { kind: "master", id, side, fraction } });
+}
+
+/** Back to the uniform grid, leaving the tile ORDER untouched. */
+function clearMaster(): void {
+  setState({ layout: GRID_LAYOUT });
 }
 
 /** Close a terminal: reap it and re-pick focus / restore grid if soloed. */
@@ -271,6 +413,7 @@ export interface UseWorkspaceResult {
   prevGrid: string[] | null;
   unread: string[];
   maximizedId: string | null;
+  layout: WorkspaceLayout;
   selectOnly: (target: SessionTarget) => void;
   addSession: (target: SessionTarget) => void;
   soloTile: (id: string) => void;
@@ -278,6 +421,8 @@ export interface UseWorkspaceResult {
   openMany: (targets: SessionTarget[]) => void;
   closeTerm: (id: string) => void;
   swapVisible: (a: string, b: string) => void;
+  setMaster: (id: string, side: MasterSide) => void;
+  clearMaster: () => void;
   maximize: (id: string) => void;
   restore: () => void;
   setFocused: (id: string | null) => void;
@@ -293,6 +438,7 @@ export function useWorkspace(): UseWorkspaceResult {
     prevGrid: snapshot.prevGrid,
     unread: snapshot.unread,
     maximizedId: snapshot.maximizedId,
+    layout: snapshot.layout,
     selectOnly,
     addSession,
     soloTile,
@@ -300,6 +446,8 @@ export function useWorkspace(): UseWorkspaceResult {
     openMany,
     closeTerm,
     swapVisible,
+    setMaster,
+    clearMaster,
     maximize,
     restore,
     setFocused,


### PR DESCRIPTION
## The problem

Three terminals in the grid gave a 2×2 with an empty fourth cell, and no way to say *"let this one fill the right side while the others stack on the left"*. The hole wasn't a bug to patch — the layout was **implicit** (a uniform grid derived from `visible.length`) and had no vocabulary for it.

```
   before (hole)          after (master right)
  ┌─────┬─────┐          ┌─────┬───────────┐
  │  A  │  B  │          │  A  │           │
  ├─────┼─────┤    →     ├─────┤     C     │
  │  C  │     │          │  B  │           │
  └─────┴─────┘          └─────┴───────────┘
```

## The model

**master + stack** (dwm/xmonad): one tile holds a chosen side, the rest tile the remainder. Deliberately **not** a binary tree (i3 / react-mosaic) — arbitrary nesting buys nothing for a set of equal-weight terminals and costs per-node ratios, splitter widgets and a persistence migration. Master/stack is a strict subset of that model, so it can grow into one later.

Drag a tile to a pane edge, or cycle the new **▦** control in its header (▌ left → ▀ top → ▐ right → ▄ bottom → even grid). The control isn't a nicety: on a touch device, dragging to a 64px band with a thumb is the awkward path. Master takes 60%, and the layout persists beside the tile order.

**The invariant lives in one place.** `normalizeLayout`, called from `setState` — the single write path — so close/solo/select/add-session stay coherent with *no edits to their bodies*. A master that stops being visible **promotes the head of the stack** rather than un-tiling: closing it should move one tile, not reflow every survivor and SIGWINCH each remaining PTY.

## Three things this could have got structurally wrong

**Remounting a terminal.** The obvious implementation wraps the master and stack in slot `<div>`s — which moves a card between parents on *every mastership change*, remounting it, closing its SSH connection and dropping its scrollback. Instead: one flat keyed child list, slots expressed purely as `grid-area` on each card's own root. A test flips through four layouts asserting DOM node identity; **adding a wrapper div makes it fail** (verified).

**Fighting the rail divider.** The rail's resize handle overhangs 3px into this pane's left edge. The snap zones are `pointer-events: none` — dnd-kit resolves drops from measured rects, never hit-testing — so they blanket the edges without intercepting anything.

**A SIGWINCH storm.** No transition on the grid template: it would fire the ResizeObserver every frame with monotonically changing dimensions, which the card's last-dims guard cannot suppress.

## Geometry is a pure module

jsdom has no layout engine and every rendered tile boots a terminal adapter, so `masterLayout.ts` takes its inputs explicitly (the `themeMenuPosition` precedent). Details that mattered:

- `fr` tracks on a 100 basis — `1 - 0.7` is `0.30000000000000004` in float64 and would leak into the style string.
- The master track is scaled by the stack width, so a 2-wide stack stays whole (`120fr` vs `2×40fr`) instead of emitting `22.5fr`.
- A stack that doesn't divide evenly spans its last tile across the remainder — otherwise this feature would **reintroduce the very hole it exists to remove**. The exact-tiling invariant test caught that.

## Verification

Driven in a browser against the built app, with discovery stubbed so real `TerminalCard`s render:

| | |
|---|---|
| before | three tiles, 463×357 each, empty 4th cell |
| after (drag to right edge) | `api` **556×724** — full height, exactly 60% — with 370-wide tiles stacked left |
| after (▦ control) | identical result |
| after reload | identical — persisted |

The zone highlights on hover and the ghost follows the cursor (screenshotted). Also: 201 frontend tests, `lint`, `build`, `check:types-fresh`, `uv run pytest` (2007).

**Four mutations checked to fail first:** the wrapper div; dropping the swap's mastership transfer; dropping the solo→back-to-grid round-trip; un-tiling instead of promoting.

## Keyboard is deliberately absent

`isTypingTarget` returns true for `TEXTAREA`, and xterm focuses a `.xterm-helper-textarea` — so **every console shortcut is already swallowed whenever a terminal has focus**, `f` and `1`–`9` included. A tiling chord has to go through the seam the copy shortcut uses (`keymap.ts` → `attachCustomKeyEventHandler`), which touches the terminal input path and deserves its own change. Also deferred: a draggable splitter to resize the master (fires at pointer rate → needs throttling), and arrow-key focus movement.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011A2RNakq6mYPLA8as3pE1t