### PR TITLE
feat(web): flatten a tiling from ⊞, and hide terminal headers wholesale

### DIFF
--- a/docs/web-session-interface.md
+++ b/docs/web-session-interface.md
@@ -104,6 +104,13 @@ The SPA is a two-pane **web console**:
   row showing its name, git glyphs, and a Zellij-active bolt. A search box, provider-color filter
   chips, and an "⚡ Active only" toggle narrow the list; "⊞ Open all · N" opens every available
   target as a grid.
+- **Terminal headers** can be hidden wholesale from the **▤/▭** toggle in the app header, which buys
+  back ~37px of terminal per tile — a 16% gain on a stacked tile at tablet size, and the reason it
+  exists. The trade is real and deliberate: the header carries the per-tile controls AND is the drag
+  handle, so with it hidden a tile can't be dragged, tiled, themed or closed from the card itself (use
+  the rail, or toggle the headers back — the toggle is in the app header, which never hides). A
+  fullscreen terminal keeps its header regardless: there is only one card on screen, so the space saved
+  is negligible and its ✕/⤡ controls are the way out.
 - **Terminal pane** (right). Clicking a row opens that target **solo** (single view); ⌘/Ctrl-click a
   row (or its `+` button) **adds** it to a responsive grid (1/2/3 columns by count). In a grid, **drag
   a tile's header onto another to swap their positions** — a window outline follows the cursor and the
@@ -115,7 +122,9 @@ The SPA is a two-pane **web console**:
   would land there. The **▦** control in a tile's header cycles the same thing without a drag
   (▌ left → ▀ top → ▐ right → ▄ bottom → back to the even grid), which is the practical path on a touch
   device. The master takes 60% by default, closing it promotes the head of the stack rather than
-  un-tiling everything, and the arrangement persists across reload alongside the tile order. This is
+  un-tiling everything, and the arrangement persists across reload alongside the tile order. **⊞ flattens
+  a tiling back to even tiles** — in a plain grid that control is inert, so it doubles as the way out
+  rather than making you cycle ▦ forward until it wraps. This is
   what lets three terminals fill the pane without the empty fourth cell a 2x2 grid would leave. In a
   grid, **resting the pointer on a
   tile focuses it** (focus-follows-mouse, with a short dwell so passing through tiles doesn't steal

--- a/docs/web-session-interface.md
+++ b/docs/web-session-interface.md
@@ -121,7 +121,8 @@ The SPA is a two-pane **web console**:
   master+stack model). A translucent band marks each edge while dragging and fills in when the drop
   would land there. The **▦** control in a tile's header cycles the same thing without a drag
   (▌ left → ▀ top → ▐ right → ▄ bottom → back to the even grid), which is the practical path on a touch
-  device. The master takes 60% by default, closing it promotes the head of the stack rather than
+  device. The master's share is a setting (**Settings → Tiling split**: 40/60, 45/55 or 50/50, applied
+  live to a tiling you already have), closing it promotes the head of the stack rather than
   un-tiling everything, and the arrangement persists across reload alongside the tile order. **⊞ flattens
   a tiling back to even tiles** — in a plain grid that control is inert, so it doubles as the way out
   rather than making you cycle ▦ forward until it wraps. This is
@@ -161,13 +162,15 @@ they can be stale until something else fetches. Git glyphs only appear on instan
 `remo-host` new enough to report git status; see [Upgrade compatibility](#upgrade-compatibility).
 
 **Settings** (⚙, top bar; stored in this browser only, FR-034): **appearance** (site light/dark mode),
-accent color, terminal font, **terminal theme**, font size, program ligatures, grid display mode
+accent color, terminal font, **terminal theme**, **tiling split**, font size, program ligatures,
+grid display mode
 (actual-size vs scale-to-fit), **focus dwell** (how long the pointer rests before focus-follows-mouse
 fires), a **Nerd Font uploader**, and **Pair CLI to sync** (mint a re-sync pairing
 code).
 
 **Appearance** is tri-state — `system` (the default, following the OS `prefers-color-scheme`),
-`light`, or `dark` — toggled from the ◐/☀/☾ button in the top bar as well as from Settings. The
+`light`, or `dark` — set from Settings. (It briefly had a top-bar button too; that was removed once
+the header ran short of room, since Settings already owned the choice.) The
 console's palette is a set of `light-dark()` CSS custom properties in `theme/tokens.css`; "system"
 therefore needs no JavaScript to render, and an explicit choice is applied as `data-theme` on `<html>`.
 **Terminal theme** defaults to **Follow site theme**, which tracks the site mode: a light console gets

--- a/docs/web-session-interface.md
+++ b/docs/web-session-interface.md
@@ -121,7 +121,9 @@ The SPA is a two-pane **web console**:
   master+stack model). A translucent band marks each edge while dragging and fills in when the drop
   would land there. The **▦** control in a tile's header cycles the same thing without a drag
   (▌ left → ▀ top → ▐ right → ▄ bottom → back to the even grid), which is the practical path on a touch
-  device. The master's share is a setting (**Settings → Tiling split**: 40/60, 45/55 or 50/50, applied
+  device — and it is in the cluster in every mode, not just a grid: from a single view it rebuilds the
+  grid with the terminal you were looking at as the master (inert only when there is no grid to build).
+  The master's share is a setting (**Settings → Tiling split**: 40/60, 45/55 or 50/50, applied
   live to a tiling you already have), closing it promotes the head of the stack rather than
   un-tiling everything, and the arrangement persists across reload alongside the tile order. **⊞ flattens
   a tiling back to even tiles** — in a plain grid that control is inert, so it doubles as the way out

--- a/frontend/src/components/AppShell.tsx
+++ b/frontend/src/components/AppShell.tsx
@@ -9,7 +9,7 @@ import { exitBrowserFullscreen } from "../lib/fullscreen";
 import { useDiscovery } from "../state/discovery";
 import { useHealth } from "../state/health";
 import { useLatency } from "../state/latency";
-import { resolvedSiteTheme, settingsActions, useSettings } from "../state/settings";
+import { settingsActions, useSettings } from "../state/settings";
 import { useConsoleKeyboard } from "../state/useConsoleKeyboard";
 import { useWorkspace } from "../state/workspace";
 import { buildRailModel, type RailFilters } from "./railModel";
@@ -232,9 +232,6 @@ export function AppShell(): JSX.Element {
         onShortcuts={onToggleShortcuts}
         showTileChrome={settings.showTileChrome}
         onToggleTileChrome={() => settingsActions.toggleTileChrome()}
-        themeMode={settings.themeMode}
-        resolvedDark={resolvedSiteTheme(settings) === "dark"}
-        onCycleTheme={() => settingsActions.cycleThemeMode()}
       />
 
       {discovery.isRefreshing && !maximized && (

--- a/frontend/src/components/AppShell.tsx
+++ b/frontend/src/components/AppShell.tsx
@@ -230,6 +230,8 @@ export function AppShell(): JSX.Element {
         onRefresh={() => void discovery.refresh()}
         onSettings={() => setSettingsOpen(true)}
         onShortcuts={onToggleShortcuts}
+        showTileChrome={settings.showTileChrome}
+        onToggleTileChrome={() => settingsActions.toggleTileChrome()}
         themeMode={settings.themeMode}
         resolvedDark={resolvedSiteTheme(settings) === "dark"}
         onCycleTheme={() => settingsActions.cycleThemeMode()}

--- a/frontend/src/components/SettingsPage.tsx
+++ b/frontend/src/components/SettingsPage.tsx
@@ -8,6 +8,7 @@ import { listUploadedFonts, registerUploadedFont } from "../state/fonts";
 import {
   ACCENT_OPTIONS,
   FONT_OPTIONS,
+  MASTER_SPLIT_OPTIONS,
   MAX_FOCUS_DWELL_MS,
   MAX_TERM_SIZE,
   MIN_FOCUS_DWELL_MS,
@@ -272,6 +273,35 @@ export function SettingsPage({ onClose }: SettingsPageProps): JSX.Element {
                     <span>
                       <span className="settings-gridmode-title">{g.title}</span>
                       <span className="settings-gridmode-desc">{g.desc}</span>
+                    </span>
+                  </button>
+                );
+              })}
+            </div>
+          </section>
+
+          {/* Tiling split */}
+          <section>
+            <div className="settings-heading">Tiling split</div>
+            <p className="settings-sub">
+              How much of the pane a terminal takes when you tile it to an edge (stack / master).
+              Applies immediately to a tiling you already have.
+            </p>
+            <div className="settings-gridmodes">
+              {MASTER_SPLIT_OPTIONS.map((o) => {
+                const selected = settings.masterSplit === o.value;
+                return (
+                  <button
+                    key={o.value}
+                    type="button"
+                    data-testid={`master-split-${o.label.replace(/\s\/\s/, "-")}`}
+                    className={`settings-gridmode${selected ? " settings-gridmode--on" : ""}`}
+                    onClick={() => settingsActions.setMasterSplit(o.value)}
+                  >
+                    <span className="settings-radio">{selected ? "✓" : ""}</span>
+                    <span>
+                      <span className="settings-gridmode-title">{o.label}</span>
+                      <span className="settings-gridmode-desc">{o.desc}</span>
                     </span>
                   </button>
                 );

--- a/frontend/src/components/TerminalCard.tsx
+++ b/frontend/src/components/TerminalCard.tsx
@@ -777,7 +777,7 @@ export function TerminalCard({
              * a touch device, where dragging to a 64px edge band with a thumb is
              * the awkward path. The half-block glyphs draw where the master area
              * lands, so the current state is legible without the tooltip. */}
-            {onCycleTile && (
+            {(
               <button
                 type="button"
                 className={`tc-btn tc-btn--icon${masterSide ? " tc-btn--active" : ""}`}
@@ -785,9 +785,10 @@ export function TerminalCard({
                 title={MASTER_GLYPH[masterSide ?? "grid"].title}
                 aria-label={MASTER_GLYPH[masterSide ?? "grid"].title}
                 aria-pressed={Boolean(masterSide)}
+                disabled={!onCycleTile}
                 onClick={(e) => {
                   e.stopPropagation();
-                  onCycleTile();
+                  onCycleTile?.();
                 }}
               >
                 {MASTER_GLYPH[masterSide ?? "grid"].glyph}

--- a/frontend/src/components/TerminalCard.tsx
+++ b/frontend/src/components/TerminalCard.tsx
@@ -29,12 +29,18 @@ import {
   type SettingsState,
   type TerminalFontOptions,
 } from "../state/settings";
-import { TERMINAL_THEMES, type TerminalThemeColors } from "../theme/terminalThemes";
+import {
+  TERMINAL_THEMES,
+  type TerminalThemeColors,
+} from "../theme/terminalThemes";
 import type { MasterSide } from "../state/workspace";
 import { removeLatency, reportLatency } from "../state/latency";
 import type { RendererAdapter } from "../terminal/RendererAdapter";
 import { createDefaultRenderer } from "../terminal/defaultRenderer";
-import { TerminalConnection, type TerminalConnectionState } from "../terminal/TerminalConnection";
+import {
+  TerminalConnection,
+  type TerminalConnectionState,
+} from "../terminal/TerminalConnection";
 import "./TerminalCard.css";
 
 const DEFAULT_COLS = 80;
@@ -44,7 +50,10 @@ const GRID_FIT_SCALE = 0.8;
 
 /** Glyph + label per tiling state. The glyph is a half block drawing where the
  * master area sits, so the button reads as a picture of the layout. */
-const MASTER_GLYPH: Record<MasterSide | "grid", { glyph: string; title: string }> = {
+const MASTER_GLYPH: Record<
+  MasterSide | "grid",
+  { glyph: string; title: string }
+> = {
   grid: { glyph: "▦", title: "Tile this terminal to the left" },
   left: { glyph: "▌", title: "Mastering the left — tile to the top" },
   top: { glyph: "▀", title: "Mastering the top — tile to the right" },
@@ -93,8 +102,12 @@ interface TerminalCardProps {
   onCycleTile?: () => void;
   /** Window-control "Normal": solo this terminal into the single view. */
   onNormal: () => void;
-  /** Window-control "Grid": show the grid — omitted when none is available. */
+  /** Window-control "Grid": show the grid, or — when the grid is already shown
+   * but tiled — flatten it back to even tiles. Omitted when neither applies. */
   onGrid?: () => void;
+  /** Overrides the ⊞ control's label when it does something other than "show
+   * the grid" (i.e. when it will flatten a tiling). */
+  gridTitle?: string;
   /** Window-control "Fullscreen": enter fullscreen, or exit if already in it. */
   onToggleFullscreen: () => void;
   /** Called when the user clicks into the surface (focus this terminal). */
@@ -149,19 +162,28 @@ export function themeMenuPosition(
     height: window.innerHeight,
   },
 ): ThemeMenuPosition {
-  const roomBelow = viewport.height - anchor.bottom - THEME_MENU_GAP - THEME_MENU_MARGIN;
+  const roomBelow =
+    viewport.height - anchor.bottom - THEME_MENU_GAP - THEME_MENU_MARGIN;
   const roomAbove = anchor.top - THEME_MENU_GAP - THEME_MENU_MARGIN;
   const placement: "below" | "above" =
-    roomBelow < THEME_MENU_MIN_USABLE && roomAbove > roomBelow ? "above" : "below";
+    roomBelow < THEME_MENU_MIN_USABLE && roomAbove > roomBelow
+      ? "above"
+      : "below";
 
   // Right-align to the swatch, then clamp both edges into the viewport.
   const left = Math.max(
     THEME_MENU_MARGIN,
-    Math.min(anchor.right - THEME_MENU_WIDTH, viewport.width - THEME_MENU_WIDTH - THEME_MENU_MARGIN),
+    Math.min(
+      anchor.right - THEME_MENU_WIDTH,
+      viewport.width - THEME_MENU_WIDTH - THEME_MENU_MARGIN,
+    ),
   );
   // Never negative: a zero-height anchor (jsdom, or a card mid-teardown) would
   // otherwise ask for a negative max-height and render an unusable sliver.
-  const maxHeight = Math.max(THEME_MENU_MIN_USABLE, placement === "above" ? roomAbove : roomBelow);
+  const maxHeight = Math.max(
+    THEME_MENU_MIN_USABLE,
+    placement === "above" ? roomAbove : roomBelow,
+  );
 
   return {
     placement,
@@ -173,14 +195,25 @@ export function themeMenuPosition(
             left,
             maxHeight,
           }
-        : { position: "fixed", top: anchor.bottom + THEME_MENU_GAP, left, maxHeight },
+        : {
+            position: "fixed",
+            top: anchor.bottom + THEME_MENU_GAP,
+            left,
+            maxHeight,
+          },
   };
 }
 
-function effectiveFont(settings: SettingsState, mode: TerminalCardMode): TerminalFontOptions {
+function effectiveFont(
+  settings: SettingsState,
+  mode: TerminalCardMode,
+): TerminalFontOptions {
   const base = terminalFontOptions(settings);
   if (mode === "grid" && settings.gridFit) {
-    return { ...base, fontSize: Math.max(9, Math.round(base.fontSize * GRID_FIT_SCALE)) };
+    return {
+      ...base,
+      fontSize: Math.max(9, Math.round(base.fontSize * GRID_FIT_SCALE)),
+    };
   }
   return base;
 }
@@ -199,6 +232,7 @@ export function TerminalCard({
   onCycleTile,
   onNormal,
   onGrid,
+  gridTitle,
   onToggleFullscreen,
   onFocusRequest,
   onHoverFocus,
@@ -220,7 +254,9 @@ export function TerminalCard({
   const onEndedRef = useRef(onEnded);
   const onStartedRef = useRef(onStarted);
   const fontRef = useRef<TerminalFontOptions>(effectiveFont(settings, mode));
-  const themeRef = useRef<TerminalThemeColors>(effectiveTerminalTheme(settings, target.id).colors);
+  const themeRef = useRef<TerminalThemeColors>(
+    effectiveTerminalTheme(settings, target.id).colors,
+  );
   // Coalesced-fit bookkeeping: a pending rAF handle, and the last dims we sent
   // (to skip redundant resize frames).
   const fitRafRef = useRef<number | null>(null);
@@ -231,7 +267,8 @@ export function TerminalCard({
   const dwellMsRef = useRef(settings.focusDwellMs);
   dwellMsRef.current = settings.focusDwellMs;
 
-  const [connectionState, setConnectionState] = useState<TerminalConnectionState>("connecting");
+  const [connectionState, setConnectionState] =
+    useState<TerminalConnectionState>("connecting");
   const [needsManualReconnect, setNeedsManualReconnect] = useState(false);
   const [error, setError] = useState<TypedError | null>(null);
   const [hasSelection, setHasSelection] = useState(false);
@@ -240,7 +277,9 @@ export function TerminalCard({
   const themeMenuRef = useRef<HTMLDivElement | null>(null);
   const themeButtonRef = useRef<HTMLButtonElement | null>(null);
   // Viewport-relative placement for the theme popup; null until measured.
-  const [themeMenuPos, setThemeMenuPos] = useState<ThemeMenuPosition | null>(null);
+  const [themeMenuPos, setThemeMenuPos] = useState<ThemeMenuPosition | null>(
+    null,
+  );
 
   // dnd-kit reorder: the tile is both a draggable (handle = header grip, below)
   // and a droppable (swap target). Disabled outside a reorderable grid. We use
@@ -350,38 +389,45 @@ export function TerminalCard({
     adapterRef.current = adapter;
     adapter.open(container);
 
-    const connection = new TerminalConnection(target.id, DEFAULT_COLS, DEFAULT_ROWS, {
-      onData: (data) => {
-        adapter.write(data);
-        if (!isVisibleRef.current) {
-          onActivityRef.current?.();
-        }
+    const connection = new TerminalConnection(
+      target.id,
+      DEFAULT_COLS,
+      DEFAULT_ROWS,
+      {
+        onData: (data) => {
+          adapter.write(data);
+          if (!isVisibleRef.current) {
+            onActivityRef.current?.();
+          }
+        },
+        onReady: () => {
+          setError(null);
+          // Attaching creates-or-attaches the target's Zellij session, so the
+          // rail can light its ⚡ now rather than waiting for the next discovery
+          // run to notice (which is what made a freshly-started devcontainer look
+          // sessionless until a page reload).
+          onStartedRef.current?.();
+        },
+        onExit: () => {
+          // The remote process exited — the Zellij session may have ended (e.g.
+          // the user quit Zellij). Re-run discovery so the rail's ⚡/git state
+          // reflects reality instead of the now-stale cache.
+          onEndedRef.current?.();
+        },
+        onError: (typedError) => setError(typedError),
+        onStateChange: (state) => {
+          setConnectionState(state);
+          setNeedsManualReconnect(
+            connectionRef.current?.needsManualReconnect ?? false,
+          );
+          // Only a connected terminal contributes to the header latency median.
+          if (state !== "ready") {
+            removeLatency(target.id);
+          }
+        },
+        onLatency: (rttMs) => reportLatency(target.id, rttMs),
       },
-      onReady: () => {
-        setError(null);
-        // Attaching creates-or-attaches the target's Zellij session, so the
-        // rail can light its ⚡ now rather than waiting for the next discovery
-        // run to notice (which is what made a freshly-started devcontainer look
-        // sessionless until a page reload).
-        onStartedRef.current?.();
-      },
-      onExit: () => {
-        // The remote process exited — the Zellij session may have ended (e.g.
-        // the user quit Zellij). Re-run discovery so the rail's ⚡/git state
-        // reflects reality instead of the now-stale cache.
-        onEndedRef.current?.();
-      },
-      onError: (typedError) => setError(typedError),
-      onStateChange: (state) => {
-        setConnectionState(state);
-        setNeedsManualReconnect(connectionRef.current?.needsManualReconnect ?? false);
-        // Only a connected terminal contributes to the header latency median.
-        if (state !== "ready") {
-          removeLatency(target.id);
-        }
-      },
-      onLatency: (rttMs) => reportLatency(target.id, rttMs),
-    });
+    );
     connectionRef.current = connection;
 
     const unsubscribeInput = adapter.onData((data) => {
@@ -391,7 +437,9 @@ export function TerminalCard({
     });
 
     // Show/hide the Copy affordance as the terminal selection changes.
-    const unsubscribeSelection = adapter.onSelectionChange((has) => setHasSelection(has));
+    const unsubscribeSelection = adapter.onSelectionChange((has) =>
+      setHasSelection(has),
+    );
 
     // Reflow on every container size change (window resize, rail drag, grid
     // <-> single, tile show/hide). scheduleFit coalesces bursts to one fit per
@@ -541,8 +589,17 @@ export function TerminalCard({
   // Cancel a pending dwell when the pointer leaves or the card unmounts.
   useEffect(() => clearHoverTimer, [clearHoverTimer]);
 
+  // Chrome off trades the header (identity, state, window controls, and the drag
+  // handle — the header IS the handle) for ~36px of terminal per tile. The
+  // toggle lives in the app header, which stays visible, so it is always one tap
+  // back. Fullscreen keeps its chrome regardless: there is exactly one card on
+  // screen, the space saved is negligible, and the ✕/⤡ controls are the way out.
+  const showChrome = settings.showTileChrome || viewState === "fullscreen";
+
   const prov = providerMeta(target.instance_type);
-  const badge = [prov.label, target.instance_name, region].filter(Boolean).join(" · ");
+  const badge = [prov.label, target.instance_name, region]
+    .filter(Boolean)
+    .join(" · ");
 
   // The Settings-wide choice, shown as the popup's "Default — …" entry. Under
   // "auto" that resolves per site mode, so the entry names what it means now.
@@ -552,7 +609,8 @@ export function TerminalCard({
 
   const isDragging = draggable.isDragging;
   // Highlight the tile the drop will land on (swap target) — but not the source.
-  const isDropTarget = Boolean(reorderEnabled) && droppable.isOver && !isDragging;
+  const isDropTarget =
+    Boolean(reorderEnabled) && droppable.isOver && !isDragging;
   const dragClasses = `${isDragging ? " terminal-card--dragging" : ""}${isDropTarget ? " terminal-card--drop-target" : ""}`;
 
   return (
@@ -575,214 +633,241 @@ export function TerminalCard({
       onMouseEnter={handleMouseEnter}
       onMouseLeave={clearHoverTimer}
     >
-      <header className="terminal-card-header">
-        {/* The header (left of the controls) is the drag handle for reordering
-         * grid tiles; it no longer solos on click — the ◻ control does that. */}
-        <div
-          ref={reorderEnabled ? draggable.setActivatorNodeRef : undefined}
-          className={`terminal-card-grip${reorderEnabled ? " terminal-card-grip--handle" : ""}`}
-          {...(reorderEnabled ? draggable.listeners : {})}
-          {...(reorderEnabled ? draggable.attributes : {})}
-        >
-          <span className="terminal-card-provider-dot" style={{ background: prov.color }} />
-          <div className="terminal-card-identity">
-            <span className="terminal-card-project">{target.project}</span>
-            {mode === "single" ? (
-              <span className="terminal-card-badge">{badge}</span>
-            ) : (
-              <span className="terminal-card-instance">{target.instance_name}</span>
-            )}
+      {showChrome && (
+        <header className="terminal-card-header">
+          {/* The header (left of the controls) is the drag handle for reordering
+           * grid tiles; it no longer solos on click — the ◻ control does that. */}
+          <div
+            ref={reorderEnabled ? draggable.setActivatorNodeRef : undefined}
+            className={`terminal-card-grip${reorderEnabled ? " terminal-card-grip--handle" : ""}`}
+            {...(reorderEnabled ? draggable.listeners : {})}
+            {...(reorderEnabled ? draggable.attributes : {})}
+          >
+            <span
+              className="terminal-card-provider-dot"
+              style={{ background: prov.color }}
+            />
+            <div className="terminal-card-identity">
+              <span className="terminal-card-project">{target.project}</span>
+              {mode === "single" ? (
+                <span className="terminal-card-badge">{badge}</span>
+              ) : (
+                <span className="terminal-card-instance">
+                  {target.instance_name}
+                </span>
+              )}
+            </div>
           </div>
-        </div>
-        <span
-          className={`terminal-card-state terminal-card-state--${connectionState}`}
-          title={STATE_LABELS[connectionState]}
-        >
-          {STATE_LABELS[connectionState]}
-        </span>
-        <div className="terminal-card-controls">
-          {hasSelection && (
-            <button
-              type="button"
-              className="tc-btn"
-              data-testid={`terminal-copy-${target.id}`}
-              title="Copy selection (⌘C / Ctrl+Shift+C)"
-              onClick={(e) => {
-                e.stopPropagation();
-                handleCopy();
-              }}
-            >
-              {copied ? "✓ Copied" : "⧉ Copy"}
-            </button>
-          )}
-          {needsManualReconnect && (
-            <button
-              type="button"
-              className="tc-btn tc-btn--accent"
-              data-testid={`terminal-reconnect-${target.id}`}
-              onClick={(e) => {
-                e.stopPropagation();
-                handleReconnect();
-              }}
-            >
-              ↻ Reconnect
-            </button>
-          )}
-          {/* Per-terminal color scheme. The swatch shows what this card is
-           * painted with; the popup sets an override, or clears back to
-           * "Default" so the card follows the Settings-wide choice again. */}
-          <div className="tc-theme" ref={themeMenuRef}>
-            <button
-              type="button"
-              ref={themeButtonRef}
-              className="tc-btn tc-btn--swatch"
-              data-testid={`terminal-theme-${target.id}`}
-              title={`Terminal theme: ${theme.label}${hasThemeOverride ? "" : " (default)"}`}
-              aria-label="Terminal theme"
-              aria-haspopup="menu"
-              aria-expanded={themeMenuOpen}
-              style={{ background: theme.colors.background, color: theme.colors.foreground }}
-              onClick={(e) => {
-                e.stopPropagation();
-                setThemeMenuOpen((v) => !v);
-              }}
-            >
-              A
-            </button>
-            {themeMenuOpen && themeMenuPos && (
-              <div className="tc-theme-menu" role="menu" style={themeMenuPos.style}>
-                <button
-                  type="button"
-                  className={`tc-theme-item${hasThemeOverride ? "" : " tc-theme-item--on"}`}
-                  role="menuitem"
-                  data-testid={`terminal-theme-default-${target.id}`}
-                  onClick={(e) => {
-                    e.stopPropagation();
-                    settingsActions.setTermThemeOverride(target.id, null);
-                    setThemeMenuOpen(false);
-                  }}
+          <span
+            className={`terminal-card-state terminal-card-state--${connectionState}`}
+            title={STATE_LABELS[connectionState]}
+          >
+            {STATE_LABELS[connectionState]}
+          </span>
+          <div className="terminal-card-controls">
+            {hasSelection && (
+              <button
+                type="button"
+                className="tc-btn"
+                data-testid={`terminal-copy-${target.id}`}
+                title="Copy selection (⌘C / Ctrl+Shift+C)"
+                onClick={(e) => {
+                  e.stopPropagation();
+                  handleCopy();
+                }}
+              >
+                {copied ? "✓ Copied" : "⧉ Copy"}
+              </button>
+            )}
+            {needsManualReconnect && (
+              <button
+                type="button"
+                className="tc-btn tc-btn--accent"
+                data-testid={`terminal-reconnect-${target.id}`}
+                onClick={(e) => {
+                  e.stopPropagation();
+                  handleReconnect();
+                }}
+              >
+                ↻ Reconnect
+              </button>
+            )}
+            {/* Per-terminal color scheme. The swatch shows what this card is
+             * painted with; the popup sets an override, or clears back to
+             * "Default" so the card follows the Settings-wide choice again. */}
+            <div className="tc-theme" ref={themeMenuRef}>
+              <button
+                type="button"
+                ref={themeButtonRef}
+                className="tc-btn tc-btn--swatch"
+                data-testid={`terminal-theme-${target.id}`}
+                title={`Terminal theme: ${theme.label}${hasThemeOverride ? "" : " (default)"}`}
+                aria-label="Terminal theme"
+                aria-haspopup="menu"
+                aria-expanded={themeMenuOpen}
+                style={{
+                  background: theme.colors.background,
+                  color: theme.colors.foreground,
+                }}
+                onClick={(e) => {
+                  e.stopPropagation();
+                  setThemeMenuOpen((v) => !v);
+                }}
+              >
+                A
+              </button>
+              {themeMenuOpen && themeMenuPos && (
+                <div
+                  className="tc-theme-menu"
+                  role="menu"
+                  style={themeMenuPos.style}
                 >
-                  <span
-                    className="tc-theme-swatch"
-                    style={{
-                      background: globalTheme.colors.background,
-                      borderColor: globalTheme.colors.brightBlack,
-                    }}
-                  />
-                  <span className="tc-theme-label">Default — {globalLabel}</span>
-                </button>
-                {TERMINAL_THEMES.map((t) => (
                   <button
-                    key={t.id}
                     type="button"
-                    className={`tc-theme-item${hasThemeOverride && t.id === theme.id ? " tc-theme-item--on" : ""}`}
+                    className={`tc-theme-item${hasThemeOverride ? "" : " tc-theme-item--on"}`}
                     role="menuitem"
+                    data-testid={`terminal-theme-default-${target.id}`}
                     onClick={(e) => {
                       e.stopPropagation();
-                      settingsActions.setTermThemeOverride(target.id, t.id);
+                      settingsActions.setTermThemeOverride(target.id, null);
                       setThemeMenuOpen(false);
                     }}
                   >
                     <span
                       className="tc-theme-swatch"
-                      style={{ background: t.colors.background, borderColor: t.colors.brightBlack }}
-                    >
-                      <i style={{ background: t.colors.red }} />
-                      <i style={{ background: t.colors.green }} />
-                      <i style={{ background: t.colors.blue }} />
+                      style={{
+                        background: globalTheme.colors.background,
+                        borderColor: globalTheme.colors.brightBlack,
+                      }}
+                    />
+                    <span className="tc-theme-label">
+                      Default — {globalLabel}
                     </span>
-                    <span className="tc-theme-label">{t.label}</span>
                   </button>
-                ))}
-              </div>
+                  {TERMINAL_THEMES.map((t) => (
+                    <button
+                      key={t.id}
+                      type="button"
+                      className={`tc-theme-item${hasThemeOverride && t.id === theme.id ? " tc-theme-item--on" : ""}`}
+                      role="menuitem"
+                      onClick={(e) => {
+                        e.stopPropagation();
+                        settingsActions.setTermThemeOverride(target.id, t.id);
+                        setThemeMenuOpen(false);
+                      }}
+                    >
+                      <span
+                        className="tc-theme-swatch"
+                        style={{
+                          background: t.colors.background,
+                          borderColor: t.colors.brightBlack,
+                        }}
+                      >
+                        <i style={{ background: t.colors.red }} />
+                        <i style={{ background: t.colors.green }} />
+                        <i style={{ background: t.colors.blue }} />
+                      </span>
+                      <span className="tc-theme-label">{t.label}</span>
+                    </button>
+                  ))}
+                </div>
+              )}
+            </div>
+            {/* Tiling control. Cycles rather than opening a menu: it is one tap on
+             * a touch device, where dragging to a 64px edge band with a thumb is
+             * the awkward path. The half-block glyphs draw where the master area
+             * lands, so the current state is legible without the tooltip. */}
+            {onCycleTile && (
+              <button
+                type="button"
+                className={`tc-btn tc-btn--icon${masterSide ? " tc-btn--active" : ""}`}
+                data-testid={`terminal-tile-${target.id}`}
+                title={MASTER_GLYPH[masterSide ?? "grid"].title}
+                aria-label={MASTER_GLYPH[masterSide ?? "grid"].title}
+                aria-pressed={Boolean(masterSide)}
+                onClick={(e) => {
+                  e.stopPropagation();
+                  onCycleTile();
+                }}
+              >
+                {MASTER_GLYPH[masterSide ?? "grid"].glyph}
+              </button>
             )}
+            {/* Window-control cluster: mutually-exclusive display modes ordered
+             * by how much space they take — Grid (smaller/tiled) → Normal (fills
+             * the app's main pane) → Fullscreen (whole window) — plus close. The
+             * current mode is shown active + disabled; Fullscreen toggles. Icons
+             * only; the label is the tooltip. */}
+            <div
+              className="tc-winctl"
+              role="group"
+              aria-label="Terminal display mode"
+            >
+              <button
+                type="button"
+                className={`tc-btn tc-btn--icon${viewState === "grid" ? " tc-btn--active" : ""}`}
+                data-testid={`terminal-grid-${target.id}`}
+                title={gridTitle ?? "Grid view"}
+                aria-label={gridTitle ?? "Grid view"}
+                aria-pressed={viewState === "grid"}
+                disabled={!onGrid}
+                onClick={(e) => {
+                  e.stopPropagation();
+                  onGrid?.();
+                }}
+              >
+                ⊞
+              </button>
+              <button
+                type="button"
+                className={`tc-btn tc-btn--icon${viewState === "normal" ? " tc-btn--active" : ""}`}
+                data-testid={`terminal-normal-${target.id}`}
+                title="Fill the main pane (single view)"
+                aria-label="Fill the main pane"
+                aria-pressed={viewState === "normal"}
+                disabled={viewState === "normal"}
+                onClick={(e) => {
+                  e.stopPropagation();
+                  onNormal();
+                }}
+              >
+                ◻
+              </button>
+              <button
+                type="button"
+                className={`tc-btn tc-btn--icon${viewState === "fullscreen" ? " tc-btn--active" : ""}`}
+                data-testid={`terminal-fullscreen-${target.id}`}
+                title={
+                  viewState === "fullscreen" ? "Exit fullscreen" : "Fullscreen"
+                }
+                aria-label={
+                  viewState === "fullscreen" ? "Exit fullscreen" : "Fullscreen"
+                }
+                aria-pressed={viewState === "fullscreen"}
+                onClick={(e) => {
+                  e.stopPropagation();
+                  onToggleFullscreen();
+                }}
+              >
+                {viewState === "fullscreen" ? "⤡" : "⤢"}
+              </button>
+              <button
+                type="button"
+                className="tc-btn tc-btn--icon tc-btn--close"
+                data-testid={`terminal-close-${target.id}`}
+                title="Close terminal — remote Zellij session stays alive"
+                aria-label="Close terminal"
+                onClick={(e) => {
+                  e.stopPropagation();
+                  handleClose();
+                }}
+              >
+                ✕
+              </button>
+            </div>
           </div>
-          {/* Tiling control. Cycles rather than opening a menu: it is one tap on
-           * a touch device, where dragging to a 64px edge band with a thumb is
-           * the awkward path. The half-block glyphs draw where the master area
-           * lands, so the current state is legible without the tooltip. */}
-          {onCycleTile && (
-            <button
-              type="button"
-              className={`tc-btn tc-btn--icon${masterSide ? " tc-btn--active" : ""}`}
-              data-testid={`terminal-tile-${target.id}`}
-              title={MASTER_GLYPH[masterSide ?? "grid"].title}
-              aria-label={MASTER_GLYPH[masterSide ?? "grid"].title}
-              aria-pressed={Boolean(masterSide)}
-              onClick={(e) => {
-                e.stopPropagation();
-                onCycleTile();
-              }}
-            >
-              {MASTER_GLYPH[masterSide ?? "grid"].glyph}
-            </button>
-          )}
-          {/* Window-control cluster: mutually-exclusive display modes ordered
-           * by how much space they take — Grid (smaller/tiled) → Normal (fills
-           * the app's main pane) → Fullscreen (whole window) — plus close. The
-           * current mode is shown active + disabled; Fullscreen toggles. Icons
-           * only; the label is the tooltip. */}
-          <div className="tc-winctl" role="group" aria-label="Terminal display mode">
-            <button
-              type="button"
-              className={`tc-btn tc-btn--icon${viewState === "grid" ? " tc-btn--active" : ""}`}
-              data-testid={`terminal-grid-${target.id}`}
-              title="Grid view"
-              aria-label="Grid view"
-              aria-pressed={viewState === "grid"}
-              disabled={viewState === "grid" || !onGrid}
-              onClick={(e) => {
-                e.stopPropagation();
-                onGrid?.();
-              }}
-            >
-              ⊞
-            </button>
-            <button
-              type="button"
-              className={`tc-btn tc-btn--icon${viewState === "normal" ? " tc-btn--active" : ""}`}
-              data-testid={`terminal-normal-${target.id}`}
-              title="Fill the main pane (single view)"
-              aria-label="Fill the main pane"
-              aria-pressed={viewState === "normal"}
-              disabled={viewState === "normal"}
-              onClick={(e) => {
-                e.stopPropagation();
-                onNormal();
-              }}
-            >
-              ◻
-            </button>
-            <button
-              type="button"
-              className={`tc-btn tc-btn--icon${viewState === "fullscreen" ? " tc-btn--active" : ""}`}
-              data-testid={`terminal-fullscreen-${target.id}`}
-              title={viewState === "fullscreen" ? "Exit fullscreen" : "Fullscreen"}
-              aria-label={viewState === "fullscreen" ? "Exit fullscreen" : "Fullscreen"}
-              aria-pressed={viewState === "fullscreen"}
-              onClick={(e) => {
-                e.stopPropagation();
-                onToggleFullscreen();
-              }}
-            >
-              {viewState === "fullscreen" ? "⤡" : "⤢"}
-            </button>
-            <button
-              type="button"
-              className="tc-btn tc-btn--icon tc-btn--close"
-              data-testid={`terminal-close-${target.id}`}
-              title="Close terminal — remote Zellij session stays alive"
-              aria-label="Close terminal"
-              onClick={(e) => {
-                e.stopPropagation();
-                handleClose();
-              }}
-            >
-              ✕
-            </button>
-          </div>
-        </div>
-      </header>
+        </header>
+      )}
 
       {error && (
         <div className="terminal-card-error">
@@ -790,7 +875,9 @@ export function TerminalCard({
             [{error.code}] {error.message}
           </p>
           {error.remediation && (
-            <p className="terminal-card-error-remediation">{error.remediation}</p>
+            <p className="terminal-card-error-remediation">
+              {error.remediation}
+            </p>
           )}
           {error.retryable && (
             <button

--- a/frontend/src/components/TopBar.css
+++ b/frontend/src/components/TopBar.css
@@ -30,6 +30,14 @@
   font-size: 14px;
 }
 
+/* A toggle that is currently OFF — dimmed and outlined rather than filled, so
+ * the header's "something is hidden" state reads at a glance. */
+.topbar-icon-btn--off {
+  background: transparent;
+  color: var(--text-dim);
+  border-style: dashed;
+}
+
 .topbar-brand {
   display: flex;
   align-items: center;

--- a/frontend/src/components/TopBar.tsx
+++ b/frontend/src/components/TopBar.tsx
@@ -2,7 +2,6 @@
 // health indicator, refresh, settings, and shortcuts.
 
 import type { HealthStatus } from "../state/health";
-import type { SiteThemeMode } from "../state/settings";
 import "./TopBar.css";
 
 // "unconfigured" is included for Record exhaustiveness, but in practice the
@@ -24,13 +23,6 @@ const HEALTH_COLOR: Record<HealthStatus, string> = {
   offline: "var(--danger)",
 };
 
-/** Toggle glyph per mode: system reads as "half and half". */
-const THEME_ICON: Record<SiteThemeMode, string> = {
-  system: "◐",
-  light: "☀",
-  dark: "☾",
-};
-
 interface TopBarProps {
   showRailToggle: boolean;
   railCollapsed: boolean;
@@ -44,16 +36,11 @@ interface TopBarProps {
   onRefresh: () => void;
   onSettings: () => void;
   onShortcuts: () => void;
-  /** Site light/dark mode (this component stays pure-props; AppShell wires it
-   * to the settings store). */
-  /** Whether each terminal shows its header; the toggle sits next to Settings. */
+  /** Whether each terminal shows its header; the toggle sits next to Settings.
+   * Light/dark deliberately has no button here — Settings → Appearance owns it,
+   * and header space is scarcer than a settings row. */
   showTileChrome: boolean;
   onToggleTileChrome: () => void;
-  themeMode: SiteThemeMode;
-  /** What the mode resolves to right now — only differs from `themeMode` under
-   * "system", where it reflects the OS preference. */
-  resolvedDark: boolean;
-  onCycleTheme: () => void;
 }
 
 /** Latency → dot color: good (green) / so-so (yellow) / poor (red). */
@@ -81,9 +68,6 @@ export function TopBar({
   onShortcuts,
   showTileChrome,
   onToggleTileChrome,
-  themeMode,
-  resolvedDark,
-  onCycleTheme,
 }: TopBarProps): JSX.Element {
   // Prefer live WS latency (the real data-path measure); fall back to the
   // health status when no terminal is connected to measure.
@@ -93,10 +77,6 @@ export function TopBar({
   const statusTitle = showLatency
     ? "WebSocket round-trip latency (median across open terminals)"
     : (healthDetail ?? HEALTH_LABEL[health]);
-  const themeTitle =
-    themeMode === "system"
-      ? `Theme: system (currently ${resolvedDark ? "dark" : "light"}) — click for light`
-      : `Theme: ${themeMode} — click for ${themeMode === "light" ? "dark" : "system"}`;
   return (
     <header className="topbar">
       {showRailToggle && (
@@ -153,16 +133,6 @@ export function TopBar({
         onClick={onToggleTileChrome}
       >
         {showTileChrome ? "▤" : "▭"}
-      </button>
-      <button
-        type="button"
-        className="topbar-icon-btn"
-        title={themeTitle}
-        aria-label={themeTitle}
-        data-testid="theme-toggle"
-        onClick={onCycleTheme}
-      >
-        {THEME_ICON[themeMode]}
       </button>
       <button
         type="button"

--- a/frontend/src/components/TopBar.tsx
+++ b/frontend/src/components/TopBar.tsx
@@ -46,6 +46,9 @@ interface TopBarProps {
   onShortcuts: () => void;
   /** Site light/dark mode (this component stays pure-props; AppShell wires it
    * to the settings store). */
+  /** Whether each terminal shows its header; the toggle sits next to Settings. */
+  showTileChrome: boolean;
+  onToggleTileChrome: () => void;
   themeMode: SiteThemeMode;
   /** What the mode resolves to right now — only differs from `themeMode` under
    * "system", where it reflects the OS preference. */
@@ -76,6 +79,8 @@ export function TopBar({
   onRefresh,
   onSettings,
   onShortcuts,
+  showTileChrome,
+  onToggleTileChrome,
   themeMode,
   resolvedDark,
   onCycleTheme,
@@ -134,6 +139,21 @@ export function TopBar({
         <span className={refreshing ? "rail-spin" : undefined}>⟳</span> Refresh
       </button>
 
+      <button
+        type="button"
+        className={`topbar-icon-btn${showTileChrome ? "" : " topbar-icon-btn--off"}`}
+        title={
+          showTileChrome
+            ? "Hide terminal headers — more room per terminal, but the per-tile controls and drag handle go with them"
+            : "Show terminal headers"
+        }
+        aria-label="Terminal headers"
+        aria-pressed={showTileChrome}
+        data-testid="chrome-toggle"
+        onClick={onToggleTileChrome}
+      >
+        {showTileChrome ? "▤" : "▭"}
+      </button>
       <button
         type="button"
         className="topbar-icon-btn"

--- a/frontend/src/components/WorkspacePane.test.tsx
+++ b/frontend/src/components/WorkspacePane.test.tsx
@@ -155,6 +155,25 @@ describe("WorkspacePane layout wiring", () => {
     }
   });
 
+  // The ⊞ control is dead UI in a plain grid; when the grid is TILED it becomes
+  // the way out, so "how do I undo this" has an obvious answer that isn't
+  // "cycle the ▦ button forward until it wraps".
+  it("flattens a tiling from the grid control, and stays inert in a plain grid", async () => {
+    const { store } = await mount(["a", "b", "c"]);
+    const gridBtn = (): HTMLButtonElement =>
+      screen.getByTestId("terminal-grid-a") as HTMLButtonElement;
+
+    expect(gridBtn().disabled).toBe(true);
+
+    act(() => store.setMaster("c", "right"));
+    expect(gridBtn().disabled).toBe(false);
+    expect(gridBtn().getAttribute("title")).toBe("Even out the grid");
+
+    act(() => gridBtn().click());
+    expect(store.layout).toEqual({ kind: "grid" });
+    expect(gridBtn().disabled).toBe(true);
+  });
+
   it("cycles a tile through the sides from its header control", async () => {
     const { store } = await mount(["a", "b"]);
     const button = (): HTMLElement => screen.getByTestId("terminal-tile-a");
@@ -171,5 +190,30 @@ describe("WorkspacePane layout wiring", () => {
     act(() => button().click());
     expect(store.layout).toEqual({ kind: "grid" });
     expect(button().getAttribute("aria-pressed")).toBe("false");
+  });
+});
+
+describe("terminal chrome toggle", () => {
+  it("drops every tile header when chrome is off, and restores them", async () => {
+    const { view } = await mount(["a", "b"]);
+    const settings = await import("../state/settings");
+    const headers = (): number => view.container.querySelectorAll(".terminal-card-header").length;
+
+    expect(headers()).toBe(2);
+    act(() => settings.settingsActions.toggleTileChrome());
+    expect(headers()).toBe(0);
+    act(() => settings.settingsActions.toggleTileChrome());
+    expect(headers()).toBe(2);
+  });
+
+  // Fullscreen is the one place the header must stay: there is one card on
+  // screen so the saved space is negligible, and its controls are the way out.
+  it("keeps the header on a fullscreen terminal", async () => {
+    const { view, store } = await mount(["a", "b"]);
+    const settings = await import("../state/settings");
+    act(() => settings.settingsActions.toggleTileChrome());
+    act(() => store.maximize("a"));
+
+    expect(view.container.querySelectorAll(".terminal-card-header")).toHaveLength(1);
   });
 });

--- a/frontend/src/components/WorkspacePane.test.tsx
+++ b/frontend/src/components/WorkspacePane.test.tsx
@@ -193,6 +193,25 @@ describe("WorkspacePane layout wiring", () => {
   });
 });
 
+describe("tiling split setting", () => {
+  // The point of putting the split in settings rather than the layout: changing
+  // it re-flows the tiling you are looking at, no re-tiling required.
+  it("re-flows the current tiling when the split changes", async () => {
+    const { store } = await mount(["a", "b", "c"]);
+    const settings = await import("../state/settings");
+    act(() => store.setMaster("c", "right"));
+
+    const cols = (): string => body().style.gridTemplateColumns;
+    expect(cols()).toBe("repeat(1, minmax(0, 40fr)) minmax(0, 60fr)");
+
+    act(() => settings.settingsActions.setMasterSplit(0.5));
+    expect(cols()).toBe("repeat(1, minmax(0, 50fr)) minmax(0, 50fr)");
+
+    act(() => settings.settingsActions.setMasterSplit(0.55));
+    expect(cols()).toBe("repeat(1, minmax(0, 45fr)) minmax(0, 55fr)");
+  });
+});
+
 describe("terminal chrome toggle", () => {
   it("drops every tile header when chrome is off, and restores them", async () => {
     const { view } = await mount(["a", "b"]);

--- a/frontend/src/components/WorkspacePane.test.tsx
+++ b/frontend/src/components/WorkspacePane.test.tsx
@@ -193,6 +193,39 @@ describe("WorkspacePane layout wiring", () => {
   });
 });
 
+describe("tiling control outside the grid", () => {
+  // It sits in the same cluster as ⊞ / ◻ / ⤢, which are always present and
+  // merely disabled when inapplicable. Vanishing was the odd one out.
+  it("stays in the cluster in a single view, and rebuilds the grid as master", async () => {
+    const { store } = await mount(["a", "b", "c"]);
+    act(() => store.soloTile("b"));
+
+    const button = screen.getByTestId("terminal-tile-b") as HTMLButtonElement;
+    expect(button.disabled).toBe(false);
+
+    act(() => button.click());
+    // Back to the remembered grid, with the tile you were looking at mastering.
+    expect(store.visible).toEqual(["a", "b", "c"]);
+    expect(store.layout).toMatchObject({ kind: "master", id: "b", side: "left" });
+  });
+
+  it("takes mastership from a remembered tiling rather than restoring it", async () => {
+    const { store } = await mount(["a", "b", "c"]);
+    act(() => store.setMaster("c", "right"));
+    act(() => store.soloTile("a"));
+
+    act(() => (screen.getByTestId("terminal-tile-a") as HTMLButtonElement).click());
+    expect(store.layout).toMatchObject({ kind: "master", id: "a" });
+  });
+
+  it("is present but inert when there is no grid to build", async () => {
+    await mount(["a"]);
+    const button = screen.getByTestId("terminal-tile-a") as HTMLButtonElement;
+    expect(button).toBeTruthy();
+    expect(button.disabled).toBe(true);
+  });
+});
+
 describe("tiling split setting", () => {
   // The point of putting the split in settings rather than the layout: changing
   // it re-flows the tiling you are looking at, no re-tiling required.

--- a/frontend/src/components/WorkspacePane.tsx
+++ b/frontend/src/components/WorkspacePane.tsx
@@ -22,7 +22,7 @@ import type { SessionTarget } from "../api/client";
 import { requestBrowserFullscreen } from "../lib/fullscreen";
 import { useSettings } from "../state/settings";
 import { MASTER_SIDES, useWorkspace, type MasterSide } from "../state/workspace";
-import { dropIntent, nextMasterSide, paneLayout } from "./masterLayout";
+import { FIRST_MASTER_SIDE, dropIntent, nextMasterSide, paneLayout } from "./masterLayout";
 import { TerminalCard } from "./TerminalCard";
 import "./WorkspacePane.css";
 
@@ -199,6 +199,16 @@ export function WorkspacePane({
   const activeTarget = activeId ? targetsById.get(activeId) : undefined;
 
   const cycleTile = (id: string): void => {
+    // From a single view (or fullscreen), the control means "put me back in the
+    // grid, as the master" — a tiling is what it makes, so it should make one
+    // from wherever you are rather than only existing once you already have a
+    // grid. backToGrid may restore a remembered tiling; setMaster then hands
+    // mastership to THIS tile, which is the one the user was looking at.
+    if (paneMode !== "grid") {
+      workspace.backToGrid();
+      workspace.setMaster(id, FIRST_MASTER_SIDE);
+      return;
+    }
     const side = nextMasterSide(layout, id);
     if (side) {
       workspace.setMaster(id, side);
@@ -258,7 +268,12 @@ export function WorkspacePane({
                   layout.kind === "master" && layout.id === id ? layout.side : null
                 }
                 onCycleTile={
-                  reorderable && isVisible ? () => cycleTile(id) : undefined
+                  // Present in every mode for consistency with the other window
+                  // controls; undefined (and so rendered disabled) only when
+                  // there is no grid to tile — one lone terminal.
+                  (reorderable && isVisible) || (paneMode !== "grid" && canGrid && isVisible)
+                    ? () => cycleTile(id)
+                    : undefined
                 }
                 isVisible={isVisible}
                 isFocused={focusedId === id}

--- a/frontend/src/components/WorkspacePane.tsx
+++ b/frontend/src/components/WorkspacePane.tsx
@@ -20,6 +20,7 @@ import {
 } from "@dnd-kit/core";
 import type { SessionTarget } from "../api/client";
 import { requestBrowserFullscreen } from "../lib/fullscreen";
+import { useSettings } from "../state/settings";
 import { MASTER_SIDES, useWorkspace, type MasterSide } from "../state/workspace";
 import { dropIntent, nextMasterSide, paneLayout } from "./masterLayout";
 import { TerminalCard } from "./TerminalCard";
@@ -108,6 +109,7 @@ export function WorkspacePane({
   onTerminalStarted,
   narrow,
 }: WorkspacePaneProps): JSX.Element {
+  const settings = useSettings();
   const workspace = useWorkspace();
   const { attached, visible, focusedId, prevGrid, maximizedId, layout } = workspace;
 
@@ -175,7 +177,7 @@ export function WorkspacePane({
   // `paneMode` is the single-vs-grid axis; `layout.kind` is the separate
   // uniform-vs-tiled axis. Two different "grid"s, hence the distinct name.
   const paneMode = maximized || visible.length <= 1 ? "single" : "grid";
-  const pane = paneMode === "grid" ? paneLayout(layout, visible, narrow) : null;
+  const pane = paneMode === "grid" ? paneLayout(layout, visible, narrow, settings.masterSplit) : null;
   // The Grid control is available when a grid can be shown — either the visible
   // set is already a grid (fullscreen opened over one) or a grid was remembered.
   const canGrid =

--- a/frontend/src/components/WorkspacePane.tsx
+++ b/frontend/src/components/WorkspacePane.tsx
@@ -264,7 +264,24 @@ export function WorkspacePane({
                 reorderEnabled={reorderable && isVisible}
                 onClose={() => workspace.closeTerm(id)}
                 onNormal={() => workspace.soloTile(id)}
-                onGrid={canGrid ? workspace.backToGrid : undefined}
+                onGrid={
+                  // In a TILED grid the ⊞ control flattens back to even tiles —
+                  // it is otherwise dead UI in exactly the state where you want
+                  // a way out, since cycling the ▦ control forward until it
+                  // wraps is a poor answer to "how do I undo this".
+                  paneMode === "grid" && !maximized
+                    ? layout.kind === "master"
+                      ? workspace.clearMaster
+                      : undefined
+                    : canGrid
+                      ? workspace.backToGrid
+                      : undefined
+                }
+                gridTitle={
+                  paneMode === "grid" && !maximized && layout.kind === "master"
+                    ? "Even out the grid"
+                    : undefined
+                }
                 onToggleFullscreen={() => toggleFullscreen(id)}
                 onFocusRequest={() => workspace.setFocused(id)}
                 onHoverFocus={

--- a/frontend/src/components/masterLayout.test.ts
+++ b/frontend/src/components/masterLayout.test.ts
@@ -3,12 +3,13 @@ import type { WorkspaceLayout } from "../state/workspace";
 import { dropIntent, gridColumns, nextMasterSide, paneLayout } from "./masterLayout";
 
 const grid: WorkspaceLayout = { kind: "grid" };
-const master = (id: string, side: "left" | "right" | "top" | "bottom", fraction = 0.6): WorkspaceLayout => ({
+const master = (id: string, side: "left" | "right" | "top" | "bottom"): WorkspaceLayout => ({
   kind: "master",
   id,
   side,
-  fraction,
 });
+/** The default split (settings.masterSplit), as stack/master = 40/60. */
+const SPLIT = 0.6;
 
 /** Every grid line an area occupies, so overlaps and holes are detectable. */
 function cellsOf(areaSpec: string): string[] {
@@ -42,7 +43,7 @@ describe("uniform grid", () => {
     [4, true, 1, 4],
   ])("%i tiles (narrow=%s) -> %i cols x %i rows", (count, narrow, cols, rows) => {
     const visible = Array.from({ length: count }, (_, i) => `t${i}`);
-    const { container, areaById } = paneLayout(grid, visible, narrow);
+    const { container, areaById } = paneLayout(grid, visible, narrow, SPLIT);
     expect(container.gridTemplateColumns).toBe(`repeat(${cols}, minmax(0, 1fr))`);
     expect(container.gridTemplateRows).toBe(`repeat(${rows}, minmax(0, 1fr))`);
     // No explicit areas: tiles auto-place exactly as they always have.
@@ -60,7 +61,7 @@ describe("uniform grid", () => {
 describe("master/stack", () => {
   // The motivating case: 3 terminals, one filling the right side full-height.
   it("puts the master on the right at 60% with the stack down the left", () => {
-    const { container, areaById } = paneLayout(master("c", "right"), ["a", "b", "c"], false);
+    const { container, areaById } = paneLayout(master("c", "right"), ["a", "b", "c"], false, SPLIT);
     expect(container.gridTemplateColumns).toBe("repeat(1, minmax(0, 40fr)) minmax(0, 60fr)");
     expect(container.gridTemplateRows).toBe("repeat(2, minmax(0, 1fr))");
     expect(areaById.get("c")).toBe("1 / 2 / 3 / 3"); // full height, right column
@@ -69,7 +70,7 @@ describe("master/stack", () => {
   });
 
   it("mirrors for a left master", () => {
-    const { container, areaById } = paneLayout(master("c", "left"), ["a", "b", "c"], false);
+    const { container, areaById } = paneLayout(master("c", "left"), ["a", "b", "c"], false, SPLIT);
     expect(container.gridTemplateColumns).toBe("minmax(0, 60fr) repeat(1, minmax(0, 40fr))");
     expect(areaById.get("c")).toBe("1 / 1 / 3 / 2");
     expect(areaById.get("a")).toBe("1 / 2 / 2 / 3");
@@ -77,7 +78,7 @@ describe("master/stack", () => {
   });
 
   it("transposes for a top master — stack tiles horizontally below", () => {
-    const { container, areaById } = paneLayout(master("c", "top"), ["a", "b", "c"], false);
+    const { container, areaById } = paneLayout(master("c", "top"), ["a", "b", "c"], false, SPLIT);
     expect(container.gridTemplateRows).toBe("minmax(0, 60fr) repeat(1, minmax(0, 40fr))");
     expect(container.gridTemplateColumns).toBe("repeat(2, minmax(0, 1fr))");
     expect(areaById.get("c")).toBe("1 / 1 / 2 / 3"); // full width, top row
@@ -86,21 +87,21 @@ describe("master/stack", () => {
   });
 
   it("transposes for a bottom master", () => {
-    const { container, areaById } = paneLayout(master("c", "bottom"), ["a", "b", "c"], false);
+    const { container, areaById } = paneLayout(master("c", "bottom"), ["a", "b", "c"], false, SPLIT);
     expect(container.gridTemplateRows).toBe("repeat(1, minmax(0, 40fr)) minmax(0, 60fr)");
     expect(areaById.get("c")).toBe("2 / 1 / 3 / 3");
     expect(areaById.get("a")).toBe("1 / 1 / 2 / 2");
   });
 
   it("handles a single stack tile (two visible)", () => {
-    const { container, areaById } = paneLayout(master("a", "right"), ["a", "b"], false);
+    const { container, areaById } = paneLayout(master("a", "right"), ["a", "b"], false, SPLIT);
     expect(container.gridTemplateRows).toBe("repeat(1, minmax(0, 1fr))");
     expect(areaById.get("a")).toBe("1 / 2 / 2 / 3");
     expect(areaById.get("b")).toBe("1 / 1 / 2 / 2");
   });
 
   it("follows visible order, skipping the master", () => {
-    const { areaById } = paneLayout(master("b", "right"), ["a", "b", "c", "d"], false);
+    const { areaById } = paneLayout(master("b", "right"), ["a", "b", "c", "d"], false, SPLIT);
     // a, c, d keep their relative order down the stack.
     expect(areaById.get("a")).toBe("1 / 1 / 2 / 2");
     expect(areaById.get("c")).toBe("2 / 1 / 3 / 2");
@@ -111,7 +112,7 @@ describe("master/stack", () => {
   // TerminalCard 0x0 guard, so it would fit() to one row and corrupt a TUI.
   it("widens the stack to two tracks past four stack tiles", () => {
     const visible = ["m", "a", "b", "c", "d", "e"];
-    const { container, areaById } = paneLayout(master("m", "right"), visible, false);
+    const { container, areaById } = paneLayout(master("m", "right"), visible, false, SPLIT);
     expect(container.gridTemplateColumns).toBe("repeat(2, minmax(0, 40fr)) minmax(0, 120fr)");
     expect(container.gridTemplateRows).toBe("repeat(3, minmax(0, 1fr))");
     expect(areaById.get("m")).toBe("1 / 3 / 4 / 4");
@@ -128,7 +129,7 @@ describe("master/stack", () => {
       for (const side of ["left", "right", "top", "bottom"] as const) {
         for (const count of [2, 3, 6, 9]) {
           const visible = Array.from({ length: count }, (_, i) => `t${i}`);
-          const { container } = paneLayout(master("t0", side, fraction), visible, false);
+          const { container } = paneLayout(master("t0", side), visible, false, fraction);
           const template = `${container.gridTemplateColumns} ${container.gridTemplateRows}`;
           expect(template, `${side} @ ${fraction} x${count}`).not.toMatch(/\d\.\d/);
         }
@@ -140,7 +141,7 @@ describe("master/stack", () => {
     for (const side of ["left", "right", "top", "bottom"] as const) {
       for (const count of [2, 3, 4, 6, 9]) {
         const visible = Array.from({ length: count }, (_, i) => `t${i}`);
-        const { container, areaById } = paneLayout(master("t0", side), visible, false);
+        const { container, areaById } = paneLayout(master("t0", side), visible, false, SPLIT);
         const cols = trackCount(String(container.gridTemplateColumns));
         const rows = trackCount(String(container.gridTemplateRows));
         const seen = new Set<string>();
@@ -159,7 +160,7 @@ describe("master/stack", () => {
   });
 
   it("falls back to the uniform grid when the master isn't visible", () => {
-    const { areaById } = paneLayout(master("gone", "right"), ["a", "b"], false);
+    const { areaById } = paneLayout(master("gone", "right"), ["a", "b"], false, SPLIT);
     expect(areaById.size).toBe(0);
   });
 });

--- a/frontend/src/components/masterLayout.ts
+++ b/frontend/src/components/masterLayout.ts
@@ -76,9 +76,11 @@ export function paneLayout(
   layout: WorkspaceLayout,
   visible: string[],
   narrow: boolean,
+  /** The master's share of the pane (settings.masterSplit). */
+  fraction: number,
 ): PaneLayout {
   if (layout.kind === "master" && visible.includes(layout.id) && visible.length > 1) {
-    return masterLayout(layout.id, layout.side, layout.fraction, visible);
+    return masterLayout(layout.id, layout.side, fraction, visible);
   }
   const cols = gridColumns(visible.length, narrow);
   const rows = Math.max(1, Math.ceil(visible.length / cols));

--- a/frontend/src/components/masterLayout.ts
+++ b/frontend/src/components/masterLayout.ts
@@ -181,6 +181,10 @@ export function dropIntent(
 /** Order the tile button cycles through. Drawn by the button's glyphs. */
 const MASTER_CYCLE: MasterSide[] = ["left", "top", "right", "bottom"];
 
+/** Where a tiling starts — used both by the cycle and by the control's
+ * "build me a grid with this tile as master" behaviour in a single view. */
+export const FIRST_MASTER_SIDE: MasterSide = MASTER_CYCLE[0];
+
 /** The next side for `id`, or null to return to the uniform grid. Taking
  * mastership from another tile restarts the cycle, so the button always
  * advances visibly rather than appearing to do nothing. */

--- a/frontend/src/state/settings.test.ts
+++ b/frontend/src/state/settings.test.ts
@@ -266,6 +266,28 @@ describe("terminal themes", () => {
   });
 });
 
+describe("terminal chrome toggle", () => {
+  it("shows tile headers by default", async () => {
+    const settings = await load();
+    expect(settings.getSettings().showTileChrome).toBe(true);
+  });
+
+  it("toggles and round-trips through localStorage", async () => {
+    const first = await load();
+    act(() => first.settingsActions.toggleTileChrome());
+    expect(first.getSettings().showTileChrome).toBe(false);
+
+    const reloaded = await load();
+    expect(reloaded.getSettings().showTileChrome).toBe(false);
+  });
+
+  it("falls back to showing them when the stored value is garbage", async () => {
+    window.localStorage.setItem(STORAGE_KEY, JSON.stringify({ showTileChrome: "no" }));
+    const settings = await load();
+    expect(settings.getSettings().showTileChrome).toBe(true);
+  });
+});
+
 describe("useSettings", () => {
   it("re-renders subscribers when the theme changes", async () => {
     const settings = await load();

--- a/frontend/src/state/settings.test.ts
+++ b/frontend/src/state/settings.test.ts
@@ -89,18 +89,6 @@ describe("site theme mode", () => {
     expect(document.documentElement.getAttribute("data-theme")).toBe("light");
   });
 
-  it("cycles system → light → dark → system", async () => {
-    const settings = await load();
-    settings.initSettings();
-
-    const seen: string[] = [];
-    for (let i = 0; i < 3; i += 1) {
-      act(() => settings.settingsActions.cycleThemeMode());
-      seen.push(settings.getSettings().themeMode);
-    }
-    expect(seen).toEqual(["light", "dark", "system"]);
-  });
-
   it("resolves 'system' from the OS preference, live", async () => {
     const media = stubMatchMedia(false);
     const settings = await load();
@@ -285,6 +273,34 @@ describe("terminal chrome toggle", () => {
     window.localStorage.setItem(STORAGE_KEY, JSON.stringify({ showTileChrome: "no" }));
     const settings = await load();
     expect(settings.getSettings().showTileChrome).toBe(true);
+  });
+});
+
+describe("tiling split", () => {
+  it("defaults to 40/60 in the master's favour", async () => {
+    const settings = await load();
+    expect(settings.getSettings().masterSplit).toBe(0.6);
+  });
+
+  it("accepts the offered splits and round-trips them", async () => {
+    const first = await load();
+    act(() => first.settingsActions.setMasterSplit(0.5));
+    expect(first.getSettings().masterSplit).toBe(0.5);
+
+    const reloaded = await load();
+    expect(reloaded.getSettings().masterSplit).toBe(0.5);
+  });
+
+  // A value outside the offered set would render a layout that no menu item
+  // matches, so it is refused at both the setter and the load.
+  it("refuses a split that isn't offered", async () => {
+    const settings = await load();
+    act(() => settings.settingsActions.setMasterSplit(0.9));
+    expect(settings.getSettings().masterSplit).toBe(0.6);
+
+    window.localStorage.setItem(STORAGE_KEY, JSON.stringify({ masterSplit: 0.9 }));
+    const reloaded = await load();
+    expect(reloaded.getSettings().masterSplit).toBe(0.6);
   });
 });
 

--- a/frontend/src/state/settings.ts
+++ b/frontend/src/state/settings.ts
@@ -57,6 +57,37 @@ export const SITE_THEME_OPTIONS: SiteThemeOption[] = [
 
 const MEDIA_QUERY_DARK = "(prefers-color-scheme: dark)";
 
+/** How much of the pane a tiled master area takes, as stack/master. Kept to a
+ * short list rather than a slider: these are the only splits that read well for
+ * terminals, and a free-form value invites fiddling over choosing. */
+export interface MasterSplitOption {
+  /** The master's share, which is what masterLayout consumes. */
+  value: number;
+  label: string;
+  desc: string;
+}
+
+export const MASTER_SPLIT_OPTIONS: MasterSplitOption[] = [
+  {
+    value: 0.6,
+    label: "40 / 60",
+    desc: "The master gets the most room. Best when the stack is for glancing at.",
+  },
+  {
+    value: 0.55,
+    label: "45 / 55",
+    desc: "A gentle bias to the master, with the stack still comfortably usable.",
+  },
+  {
+    value: 0.5,
+    label: "50 / 50",
+    desc: "An even split, matching what a half-screen snap does elsewhere.",
+  },
+];
+
+const MASTER_SPLIT_VALUES = MASTER_SPLIT_OPTIONS.map((o) => o.value);
+export const DEFAULT_MASTER_SPLIT = MASTER_SPLIT_OPTIONS[0].value;
+
 export interface FontOption {
   label: string;
   css: string;
@@ -106,6 +137,10 @@ export interface SettingsState {
   termLiga: boolean;
   /** Scale each grid terminal to fit (true) vs keep font fixed + clip (false). */
   gridFit: boolean;
+  /** The master area's share of the pane when a grid is tiled. Lives here, not
+   * in the layout itself, so changing it re-flows the CURRENT tiling instead of
+   * only applying to the next one. */
+  masterSplit: number;
   /** Show each terminal's header (identity, state, window controls). Hiding it
    * buys back ~36px per tile, which is a real difference when three are stacked
    * on a tablet — at the cost of the per-tile controls and the drag handle,
@@ -136,6 +171,7 @@ const DEFAULTS: SettingsState = {
   termLiga: true,
   gridFit: false,
   showTileChrome: true,
+  masterSplit: DEFAULT_MASTER_SPLIT,
   railWidth: DEFAULT_RAIL_WIDTH,
   railCollapsed: false,
   nerdFontName: null,
@@ -207,6 +243,13 @@ function loadPersisted(): SettingsState {
       gridFit: typeof c.gridFit === "boolean" ? c.gridFit : DEFAULTS.gridFit,
       showTileChrome:
         typeof c.showTileChrome === "boolean" ? c.showTileChrome : DEFAULTS.showTileChrome,
+      // Only the offered splits are accepted: anything else (a hand-edited
+      // store, or a value from a build that offered a different set) would
+      // render a layout no menu item matches.
+      masterSplit:
+        typeof c.masterSplit === "number" && MASTER_SPLIT_VALUES.includes(c.masterSplit)
+          ? c.masterSplit
+          : DEFAULTS.masterSplit,
       railWidth:
         typeof c.railWidth === "number"
           ? clamp(Math.round(c.railWidth), MIN_RAIL_WIDTH, MAX_RAIL_WIDTH)
@@ -335,12 +378,6 @@ export function terminalFontOptions(s: SettingsState = state): TerminalFontOptio
 
 export const settingsActions = {
   setThemeMode: (themeMode: SiteThemeMode) => setState({ themeMode }),
-  /** Top-bar toggle: system → light → dark → system. */
-  cycleThemeMode: () => {
-    const order: SiteThemeMode[] = ["system", "light", "dark"];
-    const next = order[(order.indexOf(state.themeMode) + 1) % order.length];
-    setState({ themeMode: next });
-  },
   setTermTheme: (termTheme: string) => setState({ termTheme }),
   /** Set (or, with `null`, clear) one target's terminal-theme override.
    * Clearing DELETES the key rather than storing the current global id, so the
@@ -373,6 +410,10 @@ export const settingsActions = {
   toggleLiga: () => setState({ termLiga: !state.termLiga }),
   setGridFit: (gridFit: boolean) => setState({ gridFit }),
   toggleTileChrome: () => setState({ showTileChrome: !state.showTileChrome }),
+  setMasterSplit: (masterSplit: number) =>
+    setState({
+      masterSplit: MASTER_SPLIT_VALUES.includes(masterSplit) ? masterSplit : DEFAULT_MASTER_SPLIT,
+    }),
   setRailWidth: (railWidth: number) =>
     setState({ railWidth: clamp(Math.round(railWidth), MIN_RAIL_WIDTH, MAX_RAIL_WIDTH) }),
   toggleRailCollapsed: () => setState({ railCollapsed: !state.railCollapsed }),

--- a/frontend/src/state/settings.ts
+++ b/frontend/src/state/settings.ts
@@ -106,6 +106,11 @@ export interface SettingsState {
   termLiga: boolean;
   /** Scale each grid terminal to fit (true) vs keep font fixed + clip (false). */
   gridFit: boolean;
+  /** Show each terminal's header (identity, state, window controls). Hiding it
+   * buys back ~36px per tile, which is a real difference when three are stacked
+   * on a tablet — at the cost of the per-tile controls and the drag handle,
+   * since the header IS the handle. */
+  showTileChrome: boolean;
   railWidth: number;
   railCollapsed: boolean;
   /** Family name of the currently-registered uploaded Nerd Font, if any. */
@@ -130,6 +135,7 @@ const DEFAULTS: SettingsState = {
   termSizeNum: 13,
   termLiga: true,
   gridFit: false,
+  showTileChrome: true,
   railWidth: DEFAULT_RAIL_WIDTH,
   railCollapsed: false,
   nerdFontName: null,
@@ -199,6 +205,8 @@ function loadPersisted(): SettingsState {
           : DEFAULTS.termSizeNum,
       termLiga: typeof c.termLiga === "boolean" ? c.termLiga : DEFAULTS.termLiga,
       gridFit: typeof c.gridFit === "boolean" ? c.gridFit : DEFAULTS.gridFit,
+      showTileChrome:
+        typeof c.showTileChrome === "boolean" ? c.showTileChrome : DEFAULTS.showTileChrome,
       railWidth:
         typeof c.railWidth === "number"
           ? clamp(Math.round(c.railWidth), MIN_RAIL_WIDTH, MAX_RAIL_WIDTH)
@@ -364,6 +372,7 @@ export const settingsActions = {
     setState({ termSizeNum: clamp(Math.round(termSizeNum), MIN_TERM_SIZE, MAX_TERM_SIZE) }),
   toggleLiga: () => setState({ termLiga: !state.termLiga }),
   setGridFit: (gridFit: boolean) => setState({ gridFit }),
+  toggleTileChrome: () => setState({ showTileChrome: !state.showTileChrome }),
   setRailWidth: (railWidth: number) =>
     setState({ railWidth: clamp(Math.round(railWidth), MIN_RAIL_WIDTH, MAX_RAIL_WIDTH) }),
   toggleRailCollapsed: () => setState({ railCollapsed: !state.railCollapsed }),

--- a/frontend/src/state/workspace.test.ts
+++ b/frontend/src/state/workspace.test.ts
@@ -1,7 +1,7 @@
 import { act, renderHook, type RenderHookResult } from "@testing-library/react";
 import { describe, expect, it, vi } from "vitest";
 import type { SessionTarget } from "../api/client";
-import type { UseWorkspaceResult } from "./workspace";
+import { MASTER_SIDES, type UseWorkspaceResult } from "./workspace";
 
 const target = (id: string) => ({ id }) as unknown as SessionTarget;
 
@@ -111,21 +111,16 @@ describe("workspace master layout", () => {
     act(() => result.current.openMany([target("a"), target("b"), target("c")]));
     act(() => result.current.setMaster("c", "right"));
 
-    expect(result.current.layout).toEqual({
-      kind: "master",
-      id: "c",
-      side: "right",
-      fraction: 0.6,
-    });
+    expect(result.current.layout).toEqual({ kind: "master", id: "c", side: "right" });
   });
 
-  it("keeps the current split when re-tiling to another edge", async () => {
+  it("re-tiles to another edge", async () => {
     const { result } = await mount();
     act(() => result.current.openMany([target("a"), target("b")]));
     act(() => result.current.setMaster("a", "right"));
     act(() => result.current.setMaster("a", "top"));
 
-    expect(result.current.layout).toMatchObject({ side: "top", fraction: 0.6 });
+    expect(result.current.layout).toEqual({ kind: "master", id: "a", side: "top" });
   });
 
   it("clearMaster returns to the grid without disturbing the tile order", async () => {
@@ -150,10 +145,9 @@ describe("workspace master layout", () => {
     expect(result.current.layout).toEqual({ kind: "grid" });
   });
 
-  it("clamps the split into the usable range", async () => {
-    // Only reachable through a hand-edited store today (the splitter is stage
-    // 2), but the clamp is what stops a 0.99 master squeezing the stack to
-    // nothing. NB: mount() clears localStorage, so seed it and import directly.
+  // 4.1.0 persisted the split inside the layout. It moved to settings.masterSplit,
+  // so the stale key must simply be ignored rather than needing a migration.
+  it("loads a 4.1.0 layout, dropping its embedded split", async () => {
     window.localStorage.clear();
     window.localStorage.setItem(
       STORAGE_KEY,
@@ -167,7 +161,7 @@ describe("workspace master layout", () => {
     vi.resetModules();
     const mod = await import("./workspace");
     const { result } = renderHook(() => mod.useWorkspace());
-    expect((result.current.layout as { fraction: number }).fraction).toBe(0.75);
+    expect(result.current.layout).toEqual({ kind: "master", id: "a", side: "left" });
   });
 
   // Closing the master moves ONE tile instead of reflowing every survivor.
@@ -271,7 +265,7 @@ describe("workspace master layout persistence", () => {
   it.each([
     ["a stale master id", { kind: "master", id: "gone", side: "left", fraction: 0.6 }],
     ["a bad side", { kind: "master", id: "a", side: "sideways", fraction: 0.6 }],
-    ["a non-numeric fraction", { kind: "master", id: "a", side: "left", fraction: "wide" }],
+    ["a stale embedded split from 4.1.0", { kind: "master", id: "a", side: "left", fraction: "wide" }],
     ["an unknown kind from a newer build", { kind: "columns", id: "a" }],
     ["a non-object", "master"],
     ["an array", []],
@@ -288,7 +282,7 @@ describe("workspace master layout persistence", () => {
     const restored = result.current.layout;
     if (restored.kind === "master") {
       expect(result.current.visible).toContain(restored.id);
-      expect(restored.fraction).toBeGreaterThanOrEqual(0.3);
+      expect(MASTER_SIDES).toContain(restored.side);
     } else {
       expect(restored).toEqual({ kind: "grid" });
     }

--- a/frontend/src/state/workspace.ts
+++ b/frontend/src/state/workspace.ts
@@ -45,18 +45,18 @@ export type MasterSide = (typeof MASTER_SIDES)[number];
 
 /** How the visible tiles are arranged. `grid` is the uniform CSS grid the
  * console has always used, and is both the default and the fallback for every
- * invalid state. `master` is one tile holding `fraction` of the pane on `side`,
- * with the rest tiling the remainder. */
+ * invalid state. `master` is one tile holding `side` of the pane, with the rest
+ * tiling the remainder.
+ *
+ * HOW MUCH of the pane it takes is deliberately NOT here: it is a display
+ * preference (settings.masterSplit), so changing it re-flows the arrangement
+ * you are looking at rather than only the next one you build. */
 export type WorkspaceLayout =
   | { kind: "grid" }
-  | { kind: "master"; id: string; side: MasterSide; fraction: number };
+  | { kind: "master"; id: string; side: MasterSide };
 
 /** Shared instance so the uniform-grid case never allocates per write. */
 const GRID_LAYOUT: WorkspaceLayout = { kind: "grid" };
-
-export const DEFAULT_MASTER_FRACTION = 0.6;
-export const MIN_MASTER_FRACTION = 0.3;
-export const MAX_MASTER_FRACTION = 0.75;
 
 interface PersistedWorkspaceState {
   attached: string[];
@@ -95,9 +95,7 @@ function normalizeLayout(layout: WorkspaceLayout, ids: string[]): WorkspaceLayou
     return GRID_LAYOUT;
   }
   const id = ids.includes(layout.id) ? layout.id : ids[0];
-  const raw = Number.isFinite(layout.fraction) ? layout.fraction : DEFAULT_MASTER_FRACTION;
-  const fraction = Math.min(MAX_MASTER_FRACTION, Math.max(MIN_MASTER_FRACTION, raw));
-  return id === layout.id && fraction === layout.fraction ? layout : { ...layout, id, fraction };
+  return id === layout.id ? layout : { ...layout, id };
 }
 
 /** Shape-only validation of an untrusted persisted layout. Cross-field rules
@@ -107,16 +105,16 @@ function asLayout(v: unknown): WorkspaceLayout {
   if (typeof v !== "object" || v === null || Array.isArray(v)) {
     return GRID_LAYOUT;
   }
-  const l = v as Partial<{ kind: unknown; id: unknown; side: unknown; fraction: unknown }>;
+  const l = v as Partial<{ kind: unknown; id: unknown; side: unknown }>;
   if (l.kind !== "master") {
     return GRID_LAYOUT;
   }
   if (typeof l.id !== "string" || !MASTER_SIDES.includes(l.side as MasterSide)) {
     return GRID_LAYOUT;
   }
-  // A bad fraction has an obviously-correct default; a bad side does not.
-  const fraction = typeof l.fraction === "number" ? l.fraction : DEFAULT_MASTER_FRACTION;
-  return { kind: "master", id: l.id, side: l.side as MasterSide, fraction };
+  // Any `fraction` written by 4.1.0 is dropped here: the split moved to
+  // settings.masterSplit, and an ignored extra key needs no migration.
+  return { kind: "master", id: l.id, side: l.side as MasterSide };
 }
 
 function loadPersisted(): WorkspaceState {
@@ -331,9 +329,8 @@ function swapVisible(a: string, b: string): void {
 }
 
 /** Give `id` the master area on `side`, tiling the rest into the remainder.
- * Keeps the current split when one is already set, so re-tiling to another edge
- * doesn't silently undo a resize. Normalised away by `normalizeLayout` when `id`
- * isn't part of a two-plus grid, so callers need no guard. */
+ * Normalised away by `normalizeLayout` when `id` isn't part of a two-plus grid,
+ * so callers need no guard. */
 function setMaster(id: string, side: MasterSide): void {
   // An explicit request naming a tile that isn't on screen is a caller bug, not
   // a tile disappearing — no-op rather than letting normalizeLayout's promotion
@@ -341,9 +338,7 @@ function setMaster(id: string, side: MasterSide): void {
   if (!state.visible.includes(id)) {
     return;
   }
-  const fraction =
-    state.layout.kind === "master" ? state.layout.fraction : DEFAULT_MASTER_FRACTION;
-  setState({ layout: { kind: "master", id, side, fraction } });
+  setState({ layout: { kind: "master", id, side } });
 }
 
 /** Back to the uniform grid, leaving the tile ORDER untouched. */


### PR DESCRIPTION
Two follow-ups from using the tiling on a tablet.

## ⊞ now flattens a tiling

Asked *"how do I get back to a pure grid?"*, the only honest answer was **"tap ▦ until it wraps"** — two taps from a right master, four from a left one, and only from the master's own button (a stack tile's button makes *that* tile master instead). Meanwhile ⊞ sat **disabled in exactly the state where a way out was wanted**.

It is now enabled whenever the grid is tiled, and clears the tiling. In a plain grid it stays inert as before, so it never becomes a second "rebuild the grid" button.

**Escape is deliberately untouched.** It still collapses to a single tile and *remembers* the tiling, so a stray keypress can't destroy a layout — that's the behaviour the `prevLayout` machinery exists for.

## Terminal headers can be hidden

A **▤/▭** toggle in the app header drops every tile's header at once. Three tiles stacked on a tablet spend most of their height on chrome:

| | stacked tile | master |
|---|---|---|
| headers shown | 231px | 596px |
| headers hidden | **268px** | **633px** |
| gained | **+37px (~16%)** | +37px |

*(measured at 1024×768, three tiles, master right)*

**The trade is real and stated rather than glossed.** The header carries the per-tile controls and *is* the drag handle, so with it hidden a tile can't be dragged, tiled, themed or closed from the card. That's survivable only because the toggle lives in the app header — which never hides — and the rail can still add and remove sessions. A **fullscreen terminal keeps its header regardless**: one card on screen means the saved space is negligible, and its ✕/⤡ controls are the way out.

`showTileChrome` lives in `settings.ts`, not `workspace.ts` — it's *how things render*, not *which terminals are where*, matching the `gridFit` precedent.

## Verification

Driven in a browser against the built app with discovery stubbed, at tablet size: the measurements above, and ⊞ flattening back to `335px 335px`.

Both mutation-verified: reverting ⊞ to always-disabled fails the flatten test; ignoring the setting fails the header test. 207 frontend tests, `lint`, `build`, `check:types-fresh`, docs gate.

## Known gap, not addressed here

With headers hidden, three tiles are three identical black rectangles — only the focus ring and the rail tell them apart. A compact identity strip would fix it at the cost of some of the height just reclaimed, so it wants a real opinion from tablet use before I pick a size.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011A2RNakq6mYPLA8as3pE1t