### PR TITLE
fix(web): stop three light themes printing invisible text

### DIFF
--- a/docs/web-session-interface.md
+++ b/docs/web-session-interface.md
@@ -182,7 +182,12 @@ background is `--bg-term`, foreground `--text`, ANSI 1–6 the `--danger`/`--ok`
 (a terminal palette must be literal `#rrggbb`; xterm.js's `ITheme` accepts neither `oklch()` nor
 `var()`), so editing a token does not update them. Six curated third-party schemes are also available —
 Catppuccin Mocha/Latte, Dracula, Gruvbox Dark/Light, Solarized Light — and any theme can be used under
-either site mode; picking one explicitly stops the terminal following the site. The Settings choice is
+either site mode. Those ports are faithful with one deliberate exception: three of the light variants
+assign a *background* tone to a neutral slot that applications print as **text** (Solarized Light's
+white/brightWhite, Gruvbox Light's black, Catppuccin Latte's white/brightWhite), which made that text
+invisible on the theme's own background. Those five values are replaced — each with another colour from
+the same palette — and a contrast floor in `terminalThemes.test.ts` keeps every slot above 2.0:1. Every
+chromatic slot is untouched; picking one explicitly stops the terminal following the site. The Settings choice is
 the default for every terminal; an individual terminal can override it from the color swatch in its
 header, and clearing that override back to "Default" makes it follow the global choice again. Theme
 changes apply live — the terminal is recolored in place, keeping the connection and scrollback. Because a browser can't read fonts installed on the

--- a/frontend/src/theme/terminalThemes.test.ts
+++ b/frontend/src/theme/terminalThemes.test.ts
@@ -76,6 +76,44 @@ describe("terminal themes", () => {
     expect(autoTerminalTheme(false).variant).toBe("light");
   });
 
+  // No theme may print text that is invisible on its own background.
+  //
+  // Reported from real use twice: Solarized Light's white and Gruvbox Light's
+  // black were literally the background colour (1.00:1), and Catppuccin Latte's
+  // whites were near enough. Upstream really does assign background tones to
+  // those slots — which is fine for a swatch and useless for text — so the
+  // fixed values are a deliberate deviation this test defends.
+  //
+  // `black` is exempt in DARK themes only: sitting near the background is what
+  // colour 0 is FOR there, and applications use it as a fill rather than as
+  // text. In a LIGHT theme the same slot IS printed as text, so it must be
+  // legible — which is exactly the Gruvbox Light bug.
+  //
+  // The floor is 2.0:1, well below the 3:1 the Remo pair holds to, because this
+  // catches INVISIBLE rather than merely quiet. The data splits cleanly: the
+  // worst canonical slot across all eight themes is Gruvbox Light's yellow at
+  // 2.19, while the five broken ones were all <= 1.91. A floor of 2.0 sits in
+  // that gap, so every upstream chromatic value stays untouched.
+  //
+  // `cursor` is exempt: it is a filled block, not text, and reads at ratios
+  // that would be unusable for glyphs.
+  it.each(TERMINAL_THEMES)("$label prints nothing invisible", (theme) => {
+    const bg = theme.colors.background;
+    for (const [slot, hex] of Object.entries(theme.colors)) {
+      if (
+        ["background", "cursor", "cursorAccent", "selectionBackground", "selectionForeground"].includes(
+          slot,
+        )
+      ) {
+        continue;
+      }
+      if (slot === "black" && theme.variant === "dark") {
+        continue;
+      }
+      expect(contrast(hex, bg), `${theme.id}.${slot} ${hex} on ${bg}`).toBeGreaterThan(2.0);
+    }
+  });
+
   // Every colour the Remo pair can PRINT must be legible on its own
   // background. This is the regression guard for a real report: Remo Light
   // shipped `white` at #d5d8db and `brightWhite` at #fbfcfd — 1.27:1 and

--- a/frontend/src/theme/terminalThemes.ts
+++ b/frontend/src/theme/terminalThemes.ts
@@ -14,6 +14,14 @@
 // tokens so the terminal matches the chrome — see the block comment on them.
 // The rest are the official upstream ports: catppuccin.com/palette,
 // draculatheme.com, github.com/morhetz/gruvbox, github.com/altercation/solarized.
+//
+// Three of those ports carry a flaw the originals share: in their LIGHT
+// variants, a neutral slot that applications print as text is assigned a
+// background tone, so that text is invisible on the theme's own background
+// (Solarized Light's white/brightWhite, Gruvbox Light's black, Catppuccin
+// Latte's white/brightWhite). Those five values are deliberately changed — each
+// to another colour from the same palette — and the contrast floor in
+// terminalThemes.test.ts keeps them that way. Every chromatic slot is untouched.
 
 /** The subset of xterm.js's `ITheme` the console sets. */
 export interface TerminalThemeColors {
@@ -250,6 +258,11 @@ export const TERMINAL_THEMES: TerminalTheme[] = [
     },
   },
   {
+    // DELIBERATE DEVIATION from the upstream port, reported from real use.
+    // Upstream assigns background tones to slots that applications print as
+    // TEXT, so they were invisible on this theme's own background. Only those
+    // neutrals move, and only to another colour from this same palette — the
+    // chromatic slots stay canonical.
     id: "solarized-light",
     label: "Solarized Light",
     variant: "light",
@@ -267,7 +280,7 @@ export const TERMINAL_THEMES: TerminalTheme[] = [
       blue: "#268bd2",
       magenta: "#d33682",
       cyan: "#2aa198",
-      white: "#eee8d5",
+      white: "#657b83",
       brightBlack: "#002b36",
       brightRed: "#cb4b16",
       brightGreen: "#586e75",
@@ -275,10 +288,15 @@ export const TERMINAL_THEMES: TerminalTheme[] = [
       brightBlue: "#839496",
       brightMagenta: "#6c71c4",
       brightCyan: "#93a1a1",
-      brightWhite: "#fdf6e3",
+      brightWhite: "#586e75",
     },
   },
   {
+    // DELIBERATE DEVIATION from the upstream port, reported from real use.
+    // Upstream assigns background tones to slots that applications print as
+    // TEXT, so they were invisible on this theme's own background. Only those
+    // neutrals move, and only to another colour from this same palette — the
+    // chromatic slots stay canonical.
     id: "catppuccin-latte",
     label: "Catppuccin Latte",
     variant: "light",
@@ -296,7 +314,7 @@ export const TERMINAL_THEMES: TerminalTheme[] = [
       blue: "#1e66f5",
       magenta: "#ea76cb",
       cyan: "#179299",
-      white: "#acb0be",
+      white: "#7c7f93",
       brightBlack: "#6c6f85",
       brightRed: "#d20f39",
       brightGreen: "#40a02b",
@@ -304,10 +322,15 @@ export const TERMINAL_THEMES: TerminalTheme[] = [
       brightBlue: "#1e66f5",
       brightMagenta: "#ea76cb",
       brightCyan: "#179299",
-      brightWhite: "#bcc0cc",
+      brightWhite: "#4c4f69",
     },
   },
   {
+    // DELIBERATE DEVIATION from the upstream port, reported from real use.
+    // Upstream assigns background tones to slots that applications print as
+    // TEXT, so they were invisible on this theme's own background. Only those
+    // neutrals move, and only to another colour from this same palette — the
+    // chromatic slots stay canonical.
     id: "gruvbox-light",
     label: "Gruvbox Light",
     variant: "light",
@@ -318,7 +341,7 @@ export const TERMINAL_THEMES: TerminalTheme[] = [
       cursorAccent: "#fbf1c7",
       selectionBackground: "#d5c4a1",
       selectionForeground: "#3c3836",
-      black: "#fbf1c7",
+      black: "#282828",
       red: "#cc241d",
       green: "#98971a",
       yellow: "#d79921",


### PR DESCRIPTION
## The report

> white pretty much disappears in solarized light, and (as previously discussed) black does the same on gruvbox light

Both are **literally the background colour** — 1.00:1. That's invisible, not low-contrast.

## Shared, upstream cause

In these light variants a neutral slot that applications print as **text** is assigned a *background* tone. Fine for a swatch, useless for a glyph. Catppuccin Latte has the same flaw a shade less severely, so it's fixed here rather than waiting to be reported.

| theme | slot | was | now |
|---|---|---|---|
| Solarized Light | `white` | base2 `#eee8d5` — **1.14:1** | base00 `#657b83` — 4.13:1 |
| Solarized Light | `brightWhite` | base3 `#fdf6e3` — **1.00:1** | base01 `#586e75` — 4.99:1 |
| Gruvbox Light | `black` | bg0 `#fbf1c7` — **1.00:1** | dark0 `#282828` — 12.99:1 |
| Catppuccin Latte | `white` | surface2 `#acb0be` — 1.91:1 | overlay2 `#7c7f93` — 3.49:1 |
| Catppuccin Latte | `brightWhite` | surface1 `#bcc0cc` — 1.61:1 | text `#4c4f69` — 7.06:1 |

**Every replacement is another colour from that same palette**, so nothing is invented and each theme still looks like itself. Every chromatic slot is untouched.

I'd left these alone twice as "faithful to upstream". Being faithful to a flaw that hides text isn't worth it — the deviation is now recorded beside each palette and in the docs.

## The guard

Nothing a terminal prints may fall below **2.0:1** on its own background, across all eight themes.

The threshold is deliberate rather than round: the worst *canonical* slot anywhere is Gruvbox Light's yellow at **2.19**, and every value fixed here was **≤ 1.91**. 2.0 sits in that gap, so no upstream chromatic colour is disturbed.

- `black` is exempt in **dark** themes only — colour 0 is a background fill there by convention. In a light theme it's printed as text, which is exactly the Gruvbox Light bug.
- `cursor` is exempt: a filled block, not a glyph.

## Verification

Mutation-verified per theme — restoring each upstream value fails its own case. Worth noting the Gruvbox arm needed scoping to the `gruvbox-light` block: `black: "#282828"` matches Gruvbox **Dark** first, so the obvious mutation silently tested nothing and passed. Caught it because Gruvbox was the one theme that *didn't* fail.

`lint`, 214 frontend tests, `build`, docs gate.

## Not fixed, because it isn't ours

The inverted (white-on-black) input line in a light theme is **reverse video** (SGR 7), which swaps foreground and background by definition. Any application using it looks like that on any light theme in any terminal — confirmed earlier against a labelled A/B probe.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011A2RNakq6mYPLA8as3pE1t