### PR TITLE
fix: three defects found while building `remo configure`

### DIFF
--- a/README.md
+++ b/README.md
@@ -301,6 +301,22 @@ remo configure mybox --skip docker  # everything except Docker
 remo web push                       # authorize the web service on it
 ```
 
+#### Example: an OrbStack VM
+
+[`docs/examples/orbstack-cloud-init.yaml`](docs/examples/orbstack-cloud-init.yaml)
+prepares an [OrbStack](https://orbstack.dev) VM on a Mac so `remo add` and
+`remo configure` work first time:
+
+```bash
+orb create ubuntu remo-mbp -c docs/examples/orbstack-cloud-init.yaml
+```
+
+It installs only what Ansible needs to connect and hand over — `remo configure`
+does the rest. It deliberately creates no user: OrbStack already makes one named
+after your macOS account holding UID 1000, and registering *that* user is what
+puts `remo-host` in the home directory the web service logs into, while skipping
+`user_setup`'s UID-1000 reassignment entirely.
+
 `remo remove NAME [--yes]` deregisters an added host by deleting **only** the
 local registry entry — it makes no connection to and no change on the remote
 environment (unlike a provider `destroy`, which tears down infrastructure). It

--- a/ansible/roles/user_setup/tasks/main.yml
+++ b/ansible/roles/user_setup/tasks/main.yml
@@ -243,11 +243,25 @@
     - user_setup_cloud_keys.content | default('') | length > 0
 # --- end cloud-injected key bootstrap --------------------------------------
 
+# The docker group only exists if the `docker` role ran. Skipping that role
+# (`--skip docker`, or `configure_docker=false`) previously made the next task
+# fail outright with "Group docker does not exist", taking the whole configure
+# down after it had already changed the host — so `--skip docker` was, in
+# effect, not a supported option on any provider. Gate on the group rather than
+# on `configure_docker` so a host where Docker was installed by other means
+# (or by an earlier run) still gets the membership.
+- name: Check whether a docker group exists
+  ansible.builtin.command: getent group docker
+  register: user_setup_docker_group
+  changed_when: false
+  failed_when: false
+
 - name: Add remo user to docker group
   ansible.builtin.user:
     name: "{{ remo_user }}"
     groups: docker
     append: true
+  when: user_setup_docker_group.rc | default(1) == 0
 
 - name: Configure passwordless sudo for remo user
   ansible.builtin.lineinfile:

--- a/docs/examples/orbstack-cloud-init.yaml
+++ b/docs/examples/orbstack-cloud-init.yaml
@@ -1,0 +1,120 @@
+#cloud-config
+#
+# OrbStack VM prepared for `remo add` + `remo configure` (remo >= 4.3.0).
+#
+#   orb create ubuntu remo-mbp -c orbstack-remo-cloud-init.yaml
+#
+# Deliberately minimal: this installs ONLY what Ansible needs in order to
+# connect and take over. Docker, Node.js, zellij, fzf, the GitHub CLI, the
+# devcontainers CLI and remo-host are all installed by `remo configure`, which
+# is idempotent — duplicating any of that here would only drift.
+#
+# It also does NOT create a user. OrbStack already creates one named after your
+# macOS account, holding UID 1000 with passwordless sudo. `remo configure`
+# binds its workspace account to whichever user you register, so registering
+# that existing user means:
+#   * remo-host lands in the home directory discovery actually logs into, and
+#   * user_setup's UID-1000 reassignment (which rewrites /etc/passwd and drops
+#     the live SSH session) is skipped entirely, because the holder of UID 1000
+#     is already the account being configured.
+# Creating a separate `remo` user here would forfeit both.
+
+# ---------------------------------------------------------------------------
+# EDIT THIS: the public key of the workstation that will run `remo`.
+# ---------------------------------------------------------------------------
+# If remo runs on this same Mac, that is ~/.ssh/id_ed25519.pub.
+# Leave the placeholder in place and cloud-init keeps password auth enabled
+# rather than locking you out (see the guard in runcmd).
+ssh_authorized_keys:
+  - ssh-ed25519 AAAA_REPLACE_WITH_YOUR_PUBLIC_KEY workstation
+
+package_update: true
+packages:
+  # Ansible needs a Python 3 interpreter on the target. ssh_configure.yml
+  # probes for it with `raw` and fails with an actionable message if absent,
+  # but there is no reason to make you see that message.
+  - python3
+  # hwclock. `community.general.timezone` — the first task in remo's shared
+  # role list — hard-fails with 'Failed to find required executable "hwclock"'
+  # without it, and on Ubuntu 24.04 it lives in util-linux-extra, which minimal
+  # images do not install. Found the hard way while testing this feature.
+  - util-linux-extra
+  - openssh-server
+  # remo's configure play installs rsync itself, but having it up front means
+  # `remo cp` works the moment the host is registered.
+  - rsync
+
+# ---------------------------------------------------------------------------
+# SSH port
+# ---------------------------------------------------------------------------
+# 22 is right when remo runs on this Mac: the VM gets its own IP that macOS can
+# reach directly, so nothing needs forwarding.
+#
+# Change it if you are reaching this VM from somewhere else (e.g. your homelab
+# box) via a forwarded port — remo stores the port per host and threads it
+# through `remo shell`, `remo configure` and `remo web push`. Register it with
+#     remo add mbp <user>@<host>:<port>
+# Note this is NOT OrbStack's own SSH (127.0.0.1:32222, Mac-local only); this
+# is a normal sshd inside the VM, which is what remo drives.
+write_files:
+  - path: /etc/ssh/sshd_config.d/10-remo.conf
+    permissions: '0644'
+    content: |
+      # Managed by cloud-init for remo. Ubuntu's sshd_config Includes this dir.
+      Port 22
+      PubkeyAuthentication yes
+
+runcmd:
+  # Put the key on the UID-1000 account explicitly. `ssh_authorized_keys` above
+  # targets cloud-init's notion of the default user, which is not guaranteed to
+  # be the user OrbStack created — this makes it deterministic either way.
+  - |
+    set -eu
+    KEY='ssh-ed25519 AAAA_REPLACE_WITH_YOUR_PUBLIC_KEY workstation'
+    USER_1000="$(getent passwd 1000 | cut -d: -f1)"
+    if [ -z "$USER_1000" ]; then
+      echo "remo-cloud-init: no UID 1000 account; skipping key install" >&2
+      exit 0
+    fi
+    HOME_1000="$(getent passwd 1000 | cut -d: -f6)"
+    install -d -m 700 -o "$USER_1000" -g "$USER_1000" "$HOME_1000/.ssh"
+    touch "$HOME_1000/.ssh/authorized_keys"
+    case "$KEY" in
+      *REPLACE_WITH_YOUR_PUBLIC_KEY*)
+        # Refuse to harden SSH when no real key was supplied — disabling
+        # password auth here would leave the VM unreachable over SSH.
+        echo "remo-cloud-init: placeholder key not replaced; leaving password auth as-is" >&2
+        ;;
+      *)
+        grep -qxF "$KEY" "$HOME_1000/.ssh/authorized_keys" \
+          || echo "$KEY" >> "$HOME_1000/.ssh/authorized_keys"
+        echo 'PasswordAuthentication no' > /etc/ssh/sshd_config.d/20-remo-hardening.conf
+        ;;
+    esac
+    chown -R "$USER_1000:$USER_1000" "$HOME_1000/.ssh"
+    chmod 600 "$HOME_1000/.ssh/authorized_keys"
+
+  # Passwordless sudo: OrbStack already grants it, but an explicit drop-in
+  # makes this file work on a plain cloud image too. remo needs it — the
+  # configure play installs packages and system services, and probes for it
+  # up front rather than failing halfway through.
+  - |
+    set -eu
+    USER_1000="$(getent passwd 1000 | cut -d: -f1)"
+    [ -n "$USER_1000" ] || exit 0
+    echo "$USER_1000 ALL=(ALL) NOPASSWD:ALL" > "/etc/sudoers.d/90-remo-$USER_1000"
+    chmod 440 "/etc/sudoers.d/90-remo-$USER_1000"
+
+  - systemctl enable --now ssh
+  - systemctl restart ssh
+
+final_message: |
+  remo-ready after $UPTIME seconds.
+
+  From the workstation running remo:
+    remo add mbp <user>@<this-vm-ip> --verify     # add :PORT if you changed it
+    remo configure mbp
+    remo web push                                 # if you use the web console
+
+  Do not pass `--skip docker` to configure: the shared role list adds the user
+  to the docker group, which only exists if the docker role ran.

--- a/src/remo_cli/core/ssh.py
+++ b/src/remo_cli/core/ssh.py
@@ -76,6 +76,7 @@ def build_ssh_opts(
     control_dir: str | None = None,
     identity_file: str | None = None,
     known_hosts_file: str | None = None,
+    use_registry_identity: bool = True,
 ) -> tuple[list[str], str]:
     """Build SSH option flags and target string for the given host.
 
@@ -98,6 +99,15 @@ def build_ssh_opts(
         to ambient ``~/.ssh`` identities or agent keys (adopted-mode web
         service identity, R6). ``None`` (the default) emits nothing, leaving
         the argv byte-identical to before this parameter existed.
+    use_registry_identity:
+        When ``True`` (the default) and *identity_file* is ``None``, fall back
+        to an added host's stored ``ssh_identity``. Set ``False`` when the
+        caller cannot assume that path resolves in *its* filesystem — the
+        registry records a **workstation** path, so the web service running in
+        a container may not have it. Emitting it anyway is not a harmless
+        no-op: it comes with ``IdentitiesOnly=yes``, which suppresses every
+        key that *would* have worked, turning a missing file into a guaranteed
+        auth failure.
     known_hosts_file:
         When set, emit ``-o UserKnownHostsFile=<path>``. ``None`` (the
         default) emits nothing. For SSM hosts the access-mode block's
@@ -152,7 +162,9 @@ def build_ssh_opts(
     # wins; otherwise an added (ssh-type) host's stored identity is used
     # (``ssh_identity`` is None for every other type, so their argv is unchanged).
     # ------------------------------------------------------------------
-    effective_identity = identity_file if identity_file is not None else host.ssh_identity
+    effective_identity = identity_file
+    if effective_identity is None and use_registry_identity:
+        effective_identity = host.ssh_identity
     if effective_identity is not None:
         ssh_opts += [
             "-o", f"IdentityFile={effective_identity}",
@@ -180,6 +192,7 @@ def build_ssh_base_cmd(
     control_dir: str | None = None,
     identity_file: str | None = None,
     known_hosts_file: str | None = None,
+    use_registry_identity: bool = True,
     extra_opts: list[str] | None = None,
 ) -> list[str]:
     """Build the full ``ssh`` argv for connecting to *host*.
@@ -213,6 +226,9 @@ def build_ssh_base_cmd(
         Forwarded to :func:`build_ssh_opts` — emits ``-o
         UserKnownHostsFile=<path>`` when set; ``None`` (the default) leaves
         the argv unchanged.
+    use_registry_identity:
+        Forwarded to :func:`build_ssh_opts`. Leave ``True`` on the CLI, whose
+        filesystem is the one the registry path was recorded against.
     extra_opts:
         Extra argv elements inserted after *ssh_opts* but before the
         ``-tt``/target elements — e.g. ``["-L", "8080:localhost:8080"]``
@@ -233,6 +249,7 @@ def build_ssh_base_cmd(
         control_dir=control_dir,
         identity_file=identity_file,
         known_hosts_file=known_hosts_file,
+        use_registry_identity=use_registry_identity,
     )
 
     cmd: list[str] = ["ssh"] + ssh_opts

--- a/src/remo_cli/models/host.py
+++ b/src/remo_cli/models/host.py
@@ -126,6 +126,22 @@ class KnownHost:
             return self.region
         return None
 
+    @property
+    def display_region(self) -> str:
+        """``region`` when it really is a region, ``""`` when the slot is reused.
+
+        For an added (``ssh``-type) host the slot holds the operator's *private
+        key path*, so anything that surfaces ``region`` as a label — the web
+        service's discovery snapshot, which the console renders as a badge —
+        was publishing that path to every viewer of the console. Blanking it
+        here fixes it for every consumer at once rather than at one call site.
+
+        Proxmox reuses the same slot for the node login, which is mislabeled as
+        a "region" but is neither secret nor new; it is left alone deliberately
+        so this fix does not silently change what Proxmox users see.
+        """
+        return "" if self.type == "ssh" else (self.region or "")
+
     # ------------------------------------------------------------------
     # Display
     # ------------------------------------------------------------------

--- a/src/remo_cli/web/check.py
+++ b/src/remo_cli/web/check.py
@@ -273,7 +273,10 @@ def _instance_check(host: KnownHost, settings: WebSettings) -> CheckResult:
     ssh_argv_prefix = build_ssh_base_cmd(
         host,
         control_dir=settings.ssh_control_dir,
-        identity_file=settings.ssh_identity_file,
+        identity_file=settings.ssh_identity_for(host),
+        # The service must not inherit a WORKSTATION key path from the
+        # registry; ssh_identity_for() decides, and only when usable here.
+        use_registry_identity=False,
         known_hosts_file=settings.ssh_known_hosts_file,
     )
 

--- a/src/remo_cli/web/config.py
+++ b/src/remo_cli/web/config.py
@@ -7,6 +7,7 @@ from dataclasses import dataclass, field
 from pathlib import Path
 
 from remo_cli.core.config import get_remo_home_readonly
+from remo_cli.models.host import KnownHost
 
 
 class WebConfigError(ValueError):
@@ -223,6 +224,30 @@ class WebSettings:
     def ssh_identity_file(self) -> str | None:
         if self._service_identity_active():
             return str(self.service_private_key_path)
+        return None
+
+    def ssh_identity_for(self, host: KnownHost) -> str | None:
+        """The identity *this service* should use to reach *host*.
+
+        In adopted mode that is always the service's own key — the one
+        ``remo web push`` authorized. Otherwise (mounted/unconfigured/broken)
+        fall back to an added host's registry identity, but **only when the
+        path resolves here**.
+
+        That guard is the fix for a real failure: the registry records a
+        *workstation* path (``/home/you/.ssh/key``), which a containerized
+        service generally does not have. Passing it anyway is not a harmless
+        no-op — :func:`~remo_cli.core.ssh.build_ssh_opts` pairs an identity
+        with ``IdentitiesOnly=yes``, which suppresses every key that *would*
+        have worked, so a missing file turns into a guaranteed auth failure.
+        Falling back to the mounted ``~/.ssh`` is both safer and what the
+        operator expects in mounted mode.
+        """
+        if self._service_identity_active():
+            return str(self.service_private_key_path)
+        identity = host.ssh_identity
+        if identity and Path(identity).expanduser().is_file():
+            return identity
         return None
 
     @property

--- a/src/remo_cli/web/discovery.py
+++ b/src/remo_cli/web/discovery.py
@@ -109,13 +109,16 @@ def _discover_one_sync(
     host: KnownHost, settings: WebSettings
 ) -> tuple[RemoteCapability, list[ProjectEntry]]:
     """Blocking discovery of one instance; run in a worker thread."""
-    # identity_file/known_hosts_file resolve to the service identity only in
-    # adopted mode (R6); in mounted/unconfigured/broken mode both properties
-    # return None and the argv is byte-identical to before (FR-005/FR-023).
+    # Adopted mode uses the service's own key (R6). Other modes fall back to
+    # the mounted ~/.ssh — and to a registry identity only when that path
+    # actually resolves here; see WebSettings.ssh_identity_for.
     ssh_argv_prefix = build_ssh_base_cmd(
         host,
         control_dir=settings.ssh_control_dir,
-        identity_file=settings.ssh_identity_file,
+        identity_file=settings.ssh_identity_for(host),
+        # The service must not inherit a WORKSTATION key path from the
+        # registry; ssh_identity_for() decides, and only when usable here.
+        use_registry_identity=False,
         known_hosts_file=settings.ssh_known_hosts_file,
     )
     capability = get_capabilities(ssh_argv_prefix, timeout=settings.discovery_timeout_s)
@@ -141,7 +144,10 @@ def _snapshot(
         targets=targets or [],
         error=error,
         refreshed_at=_now_iso(),
-        region=host.region or "",
+        # NOT `host.region`: for an added SSH host that slot holds the
+        # operator's private key path, and this value is rendered as a badge in
+        # the console.
+        region=host.display_region,
     )
 
 

--- a/src/remo_cli/web/terminal.py
+++ b/src/remo_cli/web/terminal.py
@@ -201,7 +201,10 @@ def build_attach_argv(
         tty=True,
         multiplex=True,
         control_dir=control_dir,
-        identity_file=resolved_settings.ssh_identity_file,
+        identity_file=resolved_settings.ssh_identity_for(host),
+        # The service must not inherit a WORKSTATION key path from the
+        # registry; ssh_identity_for() decides, and only when usable here.
+        use_registry_identity=False,
         known_hosts_file=resolved_settings.ssh_known_hosts_file,
     )
     remote_cmd = build_remo_host_shell_cmd("sessions attach", project=project)

--- a/tests/ansible/test_user_setup_docker_group.py
+++ b/tests/ansible/test_user_setup_docker_group.py
@@ -1,0 +1,88 @@
+"""`user_setup` must not require a docker group it did not create.
+
+`--skip docker` (equivalently `configure_docker=false`) skips the `docker`
+role, which is what creates the `docker` group. The membership task that
+follows used to run unconditionally and died with "Group docker does not
+exist" — *after* the play had already changed the host — so the documented
+`--skip` flag was in practice unusable on every provider, not just on the new
+`remo configure` path where it was found.
+
+The gate is on the group's existence rather than on `configure_docker` so a
+host where Docker arrived by other means (or on an earlier run) still gets the
+membership.
+"""
+
+from __future__ import annotations
+
+import shutil
+import subprocess
+from pathlib import Path
+from typing import Any
+
+import pytest
+import yaml
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+USER_SETUP_TASKS = REPO_ROOT / "ansible" / "roles" / "user_setup" / "tasks" / "main.yml"
+
+DOCKER_GROUP_TASK = "Add remo user to docker group"
+PROBE_TASK = "Check whether a docker group exists"
+
+
+def _tasks() -> list[dict[str, Any]]:
+    data = yaml.safe_load(USER_SETUP_TASKS.read_text())
+    assert isinstance(data, list)
+    return data
+
+
+def _by_name(name: str) -> dict[str, Any]:
+    for task in _tasks():
+        if task.get("name") == name:
+            return task
+    raise AssertionError(f"no task named {name!r} in {USER_SETUP_TASKS}")
+
+
+class TestDockerGroupIsConditional:
+    def test_membership_task_is_gated(self) -> None:
+        task = _by_name(DOCKER_GROUP_TASK)
+        assert "when" in task, (
+            "an ungated `groups: docker` fails the whole play when the docker "
+            "role was skipped, after the host has already been changed"
+        )
+
+    def test_gate_reads_the_probe_defensively(self) -> None:
+        # Constitution Principle V: a registered variable is never accessed
+        # without `| default()`. Here it matters for real — the probe is a
+        # task like any other and can be skipped.
+        when = _by_name(DOCKER_GROUP_TASK)["when"]
+        clause = when if isinstance(when, str) else " ".join(str(c) for c in when)
+        assert "user_setup_docker_group" in clause
+        assert "| default(" in clause, "unguarded .rc access (Principle V)"
+
+    def test_probe_precedes_the_task_that_uses_it(self) -> None:
+        names = [t.get("name") for t in _tasks()]
+        assert names.index(PROBE_TASK) < names.index(DOCKER_GROUP_TASK)
+
+    def test_probe_never_reports_changed_or_fails(self) -> None:
+        # A pure query: it must not fail the run when the group is absent —
+        # that absence is the condition it exists to detect.
+        probe = _by_name(PROBE_TASK)
+        assert probe.get("changed_when") is False
+        assert probe.get("failed_when") is False
+
+
+@pytest.mark.skipif(shutil.which("getent") is None, reason="getent not available")
+class TestProbeCommandBehavesAsAssumed:
+    """The gate's correctness rests on `getent group` exit codes — verify them
+    against the real binary rather than assuming."""
+
+    def _rc(self, group: str) -> int:
+        return subprocess.run(
+            ["getent", "group", group], capture_output=True
+        ).returncode
+
+    def test_existing_group_exits_zero(self) -> None:
+        assert self._rc("root") == 0
+
+    def test_missing_group_exits_nonzero(self) -> None:
+        assert self._rc("definitely-not-a-real-group-xyzzy") != 0

--- a/tests/unit/core/test_ssh_identity_opts.py
+++ b/tests/unit/core/test_ssh_identity_opts.py
@@ -361,3 +361,69 @@ class TestSsmInteraction:
             "-o", "UserKnownHostsFile=/state/web-identity/known_hosts",
             "remo@i-0abc123def",
         ]
+
+
+class TestUseRegistryIdentity:
+    """The registry stores a WORKSTATION key path — not every caller shares it.
+
+    `build_ssh_opts` pairs an identity with `IdentitiesOnly=yes`, so handing it
+    a path that does not exist in the caller's filesystem is not a harmless
+    no-op: it suppresses every key that WOULD have authenticated. The web
+    service, which may run in a container with no such file, opts out.
+    """
+
+    @staticmethod
+    def _build():
+        from remo_cli.core.ssh import build_ssh_base_cmd, build_ssh_opts
+
+        return build_ssh_opts, build_ssh_base_cmd
+
+    def _added_host(self):
+        return KnownHost(
+            type="ssh",
+            name="box",
+            host="10.0.0.5",
+            user="remo",
+            instance_id="22",
+            access_mode="direct",
+            region="/home/me/.ssh/id_ed25519",
+        )
+
+    def test_defaults_to_using_the_registry_identity(self):
+        # The CLI's behavior, unchanged: its filesystem is the one the path
+        # was recorded against.
+        build_ssh_opts, _bc = self._build()
+        opts, _ = build_ssh_opts(self._added_host())
+        assert "IdentityFile=/home/me/.ssh/id_ed25519" in opts
+        assert "IdentitiesOnly=yes" in opts
+
+    def test_opting_out_emits_no_identity_at_all(self):
+        build_ssh_opts, _bc = self._build()
+        opts, _ = build_ssh_opts(self._added_host(), use_registry_identity=False)
+        assert not any(o.startswith("IdentityFile=") for o in opts)
+        assert "IdentitiesOnly=yes" not in opts
+
+    def test_an_explicit_identity_still_wins_when_opted_out(self):
+        # This is the adopted-mode service path: its own key, never the
+        # operator's.
+        build_ssh_opts, _bc = self._build()
+        opts, _ = build_ssh_opts(
+            self._added_host(),
+            identity_file="/svc/web-identity/id_ed25519",
+            use_registry_identity=False,
+        )
+        assert "IdentityFile=/svc/web-identity/id_ed25519" in opts
+        assert "IdentityFile=/home/me/.ssh/id_ed25519" not in opts
+        assert "IdentitiesOnly=yes" in opts
+
+    def test_opting_out_is_a_no_op_for_provider_hosts(self):
+        # `ssh_identity` is None for every non-ssh type, so their argv must be
+        # byte-identical either way.
+        build_ssh_opts, _bc = self._build()
+        host = KnownHost(type="hetzner", name="web1", host="1.2.3.4", user="remo")
+        assert build_ssh_opts(host)[0] == build_ssh_opts(host, use_registry_identity=False)[0]
+
+    def test_flag_is_threaded_through_build_ssh_base_cmd(self):
+        _bo, build_ssh_base_cmd = self._build()
+        cmd = build_ssh_base_cmd(self._added_host(), use_registry_identity=False)
+        assert not any(a.startswith("IdentityFile=") for a in cmd)

--- a/tests/unit/test_docs_examples.py
+++ b/tests/unit/test_docs_examples.py
@@ -1,0 +1,80 @@
+"""The shipped cloud-init example must stay valid.
+
+`docs/examples/orbstack-cloud-init.yaml` is an artifact users run verbatim
+against a fresh VM, where a mistake surfaces as a half-provisioned machine and
+a cloud-init log they have to go digging for. These checks are cheap and pin
+the properties that a careless edit would break: it must parse, its shell
+blocks must be syntactically valid, and it must keep installing the two
+packages that remo's configure play hard-fails without.
+"""
+
+from __future__ import annotations
+
+import shutil
+import subprocess
+import tempfile
+from pathlib import Path
+
+import pytest
+import yaml
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+EXAMPLE = REPO_ROOT / "docs" / "examples" / "orbstack-cloud-init.yaml"
+
+
+@pytest.fixture(scope="module")
+def config() -> dict:
+    assert EXAMPLE.is_file(), f"{EXAMPLE} is referenced from README.md"
+    data = yaml.safe_load(EXAMPLE.read_text())
+    assert isinstance(data, dict)
+    return data
+
+
+def test_declares_the_cloud_config_header() -> None:
+    # cloud-init dispatches on this exact first line; without it the file is
+    # silently treated as an unknown format and nothing runs.
+    assert EXAMPLE.read_text().startswith("#cloud-config\n")
+
+
+@pytest.mark.parametrize(
+    ("package", "why"),
+    [
+        ("python3", "Ansible needs an interpreter on the target"),
+        (
+            "util-linux-extra",
+            "provides hwclock; community.general.timezone — the first task in "
+            "remo's shared role list — hard-fails without it on Ubuntu 24.04",
+        ),
+    ],
+)
+def test_installs_packages_configure_depends_on(config, package: str, why: str) -> None:
+    assert package in config["packages"], why
+
+
+@pytest.mark.skipif(shutil.which("bash") is None, reason="bash not available")
+def test_runcmd_shell_blocks_are_valid_bash(config) -> None:
+    for i, cmd in enumerate(config["runcmd"], start=1):
+        if not isinstance(cmd, str) or "\n" not in cmd:
+            continue  # a single command, no shell syntax to check
+        with tempfile.NamedTemporaryFile("w", suffix=".sh") as fh:
+            fh.write(cmd)
+            fh.flush()
+            result = subprocess.run(["bash", "-n", fh.name], capture_output=True, text=True)
+        assert result.returncode == 0, f"runcmd[{i}] is not valid bash:\n{result.stderr}"
+
+
+def test_placeholder_key_is_obviously_a_placeholder(config) -> None:
+    # The guard in runcmd keys off this marker to avoid disabling password
+    # auth (and locking the operator out) when no real key was supplied.
+    raw = EXAMPLE.read_text()
+    assert "REPLACE_WITH_YOUR_PUBLIC_KEY" in raw
+    assert raw.count("REPLACE_WITH_YOUR_PUBLIC_KEY") >= 2, (
+        "the marker appears in both ssh_authorized_keys and the runcmd guard; "
+        "dropping it from the guard would harden SSH with no key installed"
+    )
+
+
+def test_does_not_duplicate_what_remo_configure_installs(config) -> None:
+    # Duplicating the toolchain here would drift from the Ansible role list.
+    for owned_by_configure in ("docker-ce", "docker.io", "nodejs", "zellij"):
+        assert owned_by_configure not in config["packages"]

--- a/tests/unit/test_host_ssh_type.py
+++ b/tests/unit/test_host_ssh_type.py
@@ -96,6 +96,25 @@ class TestSshAccessors:
         h = KnownHost(type="ssh", name="box", host="h", user="remo")
         assert h.ssh_identity is None
 
+    # `region` is a reused slot: for an added host it holds the operator's
+    # PRIVATE KEY PATH. The web service copies `region` onto every discovery
+    # snapshot and the console renders it as a badge, so returning it verbatim
+    # published that path to everyone with console access.
+    def test_display_region_hides_an_added_hosts_key_path(self) -> None:
+        h = KnownHost(
+            type="ssh", name="box", host="h", user="remo", region="/home/me/.ssh/id_ed25519"
+        )
+        assert h.ssh_identity == "/home/me/.ssh/id_ed25519"  # still usable internally
+        assert h.display_region == ""  # but never displayed
+
+    def test_display_region_passes_through_a_real_region(self) -> None:
+        h = KnownHost(type="aws", name="dev", host="h", user="remo", region="us-west-2")
+        assert h.display_region == "us-west-2"
+
+    def test_display_region_is_a_string_when_unset(self) -> None:
+        # The API field is a plain `str`; None would break serialization.
+        assert KnownHost(type="aws", name="d", host="h", user="remo").display_region == ""
+
     def test_non_ssh_types_return_neutral_values(self) -> None:
         # A proxmox host stores a numeric vmid in instance_id — it must NOT be
         # read as a port, and it has no ssh identity.

--- a/tests/unit/web/test_discovery.py
+++ b/tests/unit/web/test_discovery.py
@@ -23,7 +23,7 @@ from remo_cli.models.session_target import DevcontainerRunning, ZellijState
 from remo_cli.web import discovery as discovery_module
 from remo_cli.web.config import WebSettings
 from remo_cli.models.host import KnownHost
-from remo_cli.web.discovery import DiscoveryService, _configure_remediation
+from remo_cli.web.discovery import DiscoveryService, _configure_remediation, _snapshot
 
 pytestmark = pytest.mark.usefixtures("tmp_config_dir")
 
@@ -334,3 +334,35 @@ class TestConfigureRemediation:
         # container part alone, so the full name would not be accepted.
         remediation = _configure_remediation(self._host("incus", "node1/dev"))
         assert "remo incus upgrade dev" in remediation
+
+
+class TestSnapshotDoesNotPublishTheKeyPath:
+    """The snapshot's `region` reaches the browser and is rendered as a badge.
+
+    For an added host the registry's `region` slot holds the operator's PRIVATE
+    KEY PATH, so copying it verbatim published that path to everyone with
+    console access. Covering the model property alone is not enough — this
+    pins the call site, which is what a revert would touch.
+    """
+
+    def test_added_host_snapshot_carries_no_key_path(self):
+        host = KnownHost(
+            type="ssh",
+            name="mbp",
+            host="10.0.0.5",
+            user="remo",
+            instance_id="2222",
+            access_mode="direct",
+            region="/home/me/.ssh/id_ed25519",
+        )
+
+        snap = _snapshot("iid", host, InstanceStatus.OK)
+
+        assert snap.region == ""
+        assert "id_ed25519" not in snap.region
+
+    def test_a_real_region_still_reaches_the_console(self):
+        host = KnownHost(
+            type="aws", name="dev", host="h", user="remo", region="us-west-2"
+        )
+        assert _snapshot("iid", host, InstanceStatus.OK).region == "us-west-2"

--- a/tests/unit/web/test_service_identity_selection.py
+++ b/tests/unit/web/test_service_identity_selection.py
@@ -1,0 +1,95 @@
+"""Which SSH identity the *service* uses for a host (`WebSettings.ssh_identity_for`).
+
+An added host's registry entry stores the operator's key path — a **workstation**
+path. The service, which commonly runs in a container, generally does not have
+that file. Handing it to ssh anyway is not a harmless no-op: `build_ssh_opts`
+pairs an identity with `IdentitiesOnly=yes`, so a missing file suppresses every
+key that *would* have worked and turns a working mounted-mode deployment into
+a guaranteed `auth_failed`.
+
+Adopted mode was never affected (it always passes the service's own key). This
+pins both modes so neither regresses into the other.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from remo_cli.models.host import KnownHost
+from remo_cli.web.config import WebSettings
+
+
+def _added_host(identity: str = "") -> KnownHost:
+    return KnownHost(
+        type="ssh",
+        name="mbp",
+        host="10.0.0.5",
+        user="remo",
+        instance_id="2222",
+        access_mode="direct",
+        region=identity,
+    )
+
+
+@pytest.fixture
+def settings(tmp_path: Path) -> WebSettings:
+    s = WebSettings()
+    s.web_identity_dir = tmp_path / "web-identity"
+    return s
+
+
+class TestMountedMode:
+    """No service identity: fall back to ambient keys unless the path is real."""
+
+    def test_a_missing_workstation_key_path_is_not_used(self, settings, mocker):
+        mocker.patch.object(WebSettings, "_service_identity_active", return_value=False)
+
+        # The regression: this used to return the path, and ssh then refused
+        # every other key because of IdentitiesOnly=yes.
+        assert settings.ssh_identity_for(_added_host("/home/you/.ssh/id_ed25519")) is None
+
+    def test_a_key_path_that_does_resolve_here_is_honored(self, settings, mocker, tmp_path):
+        # A home-directory mount can make the recorded path genuinely valid;
+        # blanket-suppressing it would break that deployment.
+        mocker.patch.object(WebSettings, "_service_identity_active", return_value=False)
+        key = tmp_path / "id_ed25519"
+        key.write_text("PRIVATE KEY")
+
+        assert settings.ssh_identity_for(_added_host(str(key))) == str(key)
+
+    def test_a_directory_is_not_mistaken_for_a_key(self, settings, mocker, tmp_path):
+        mocker.patch.object(WebSettings, "_service_identity_active", return_value=False)
+        assert settings.ssh_identity_for(_added_host(str(tmp_path))) is None
+
+    def test_no_stored_identity_yields_none(self, settings, mocker):
+        mocker.patch.object(WebSettings, "_service_identity_active", return_value=False)
+        assert settings.ssh_identity_for(_added_host()) is None
+
+    def test_provider_hosts_never_carry_an_identity(self, settings, mocker):
+        # `ssh_identity` is None for every non-ssh type; a Proxmox entry's
+        # `region` (the node login) must never be read as a key path.
+        mocker.patch.object(WebSettings, "_service_identity_active", return_value=False)
+        host = KnownHost(type="proxmox", name="n/c", host="h", user="remo", region="root")
+        assert settings.ssh_identity_for(host) is None
+
+
+class TestAdoptedMode:
+    """The service's own key, always — it is the one `remo web push` authorized."""
+
+    def test_service_key_wins_over_a_stored_identity(self, settings, mocker, tmp_path):
+        mocker.patch.object(WebSettings, "_service_identity_active", return_value=True)
+        real_key = tmp_path / "operator_key"
+        real_key.write_text("PRIVATE KEY")
+
+        chosen = settings.ssh_identity_for(_added_host(str(real_key)))
+
+        assert chosen == str(settings.service_private_key_path)
+        assert chosen != str(real_key)
+
+    def test_service_key_used_even_with_no_stored_identity(self, settings, mocker):
+        mocker.patch.object(WebSettings, "_service_identity_active", return_value=True)
+        assert settings.ssh_identity_for(_added_host()) == str(
+            settings.service_private_key_path
+        )


### PR DESCRIPTION
Three defects surfaced while testing #143. All predate it, so each is fixed on its own terms rather than folded into that feature.

## 1. `--skip docker` broke every provider's configure

`user_setup` added the workspace account to the `docker` group unconditionally — but that group only exists if the `docker` role ran. With the role skipped the play died with **"Group docker does not exist"**, *after* it had already changed the host. A documented flag (`--skip docker`, `configure_docker=false`) was in practice unusable on `incus`/`proxmox`/`aws`/`hetzner` upgrade too, not just the new path where it was found.

Gated on the group existing rather than on `configure_docker`, so a host where Docker arrived by other means (or on an earlier run) still gets the membership.

**Proven end to end** against a live SSH target with no docker group:

| | result |
|---|---|
| fix stashed | `fatal: Group docker does not exist`, exit 1 |
| fix restored, identical command | exit 0, `remo-host` installed, user correctly *not* in a docker group |
| docker group present from elsewhere | exit 0, user **is** added — which is why the gate is on the group, not the flag |

## 2. The console published the operator's private key path

`KnownHost.region` is a reused slot: for an added SSH host it holds the **identity path**. `web/discovery.py` copied it onto every discovery snapshot, and `TerminalCard.tsx` renders that field as a badge — so anyone with console access saw `/home/you/.ssh/id_ed25519`.

New `KnownHost.display_region` blanks it for added hosts and passes a real region through, fixing every consumer at once rather than one call site.

Proxmox reuses the same slot for the node login. That is mislabeled as a "region" but is neither secret nor new, so it is left alone deliberately — this fix does not silently change what Proxmox users see.

## 3. Mounted mode could never authenticate to an added host

`WebSettings.ssh_identity_file` is `None` outside adopted mode, so the registry's identity won in `build_ssh_opts` — a **workstation** path the container generally does not have.

That is not a harmless no-op. `build_ssh_opts` pairs an identity with `IdentitiesOnly=yes`, which suppresses every key that *would* have worked, turning a missing file into a guaranteed auth failure.

- `build_ssh_opts` / `build_ssh_base_cmd` gain `use_registry_identity` (default `True`, so **CLI argv is byte-identical**).
- The three service call sites now go through `WebSettings.ssh_identity_for(host)`: the service key in adopted mode, and a registry identity only when that path actually resolves here — a home-directory mount can make it valid, and blanket-suppressing would break that deployment.

## Plus: an OrbStack cloud-init example

`docs/examples/orbstack-cloud-init.yaml`, referenced from the README:

```bash
orb create ubuntu remo-mbp -c docs/examples/orbstack-cloud-init.yaml
```

Installs only what Ansible needs to connect and hand over — `remo configure` does the rest and is idempotent. Two packages are there for specific reasons: `python3`, and **`util-linux-extra`** for `hwclock`, without which `community.general.timezone` (the first task in remo's shared role list) hard-fails on Ubuntu 24.04 minimal images. Found the hard way.

It creates **no user**: OrbStack already makes one named after your macOS account at UID 1000, and registering that user is what puts `remo-host` in the directory discovery logs into while skipping `user_setup`'s UID-1000 reassignment entirely.

The runcmd blocks were executed in a real Ubuntu 24.04 container — both branches of the placeholder guard behave correctly (with the placeholder left in it refuses to write `PasswordAuthentication no` rather than locking you out of a keyless VM), permissions land at 700/600/440, and three consecutive runs leave exactly one key line.

## Verification

29 new tests; 2097 pass, 17 skipped. Every fix mutation-verified against a deliberately broken implementation.

One mutation initially **passed** — reverting `discovery.py` to `host.region` — proving the model-level test alone didn't cover the wiring. Added a test that pins the call site, and re-confirmed it now fails.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NiM3TyqKUySZr9en9quq5c