### PR TITLE
fix(ci): stop release-please failing on every release

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -71,13 +71,23 @@ jobs:
       - uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
         if: ${{ steps.release.outputs.pr }}
 
+      # `pr` is passed through as raw JSON and parsed in the shell rather than
+      # with `fromJSON(...)` here. A step's `env:` expressions are evaluated even
+      # when its `if:` is false, and on the push that MERGES a release there are
+      # no new commits, so release-please emits no PR and `outputs.pr` is the
+      # empty string — `fromJSON('')` then fails the whole job with "Error
+      # reading JToken from JsonReader", after the tag and publish have already
+      # succeeded. That made this workflow red after every single release and
+      # would have masked a real failure. The neighbouring setup-uv step, which
+      # has the same `if:` but no `env:`, skipped correctly throughout.
       - name: Sync uv.lock onto the release PR
         if: ${{ steps.release.outputs.pr }}
         env:
-          RELEASE_BRANCH: ${{ fromJSON(steps.release.outputs.pr).headBranchName }}
+          RELEASE_PR: ${{ steps.release.outputs.pr }}
           GH_TOKEN: ${{ steps.app-token.outputs.token || secrets.RELEASE_PLEASE_TOKEN || secrets.GITHUB_TOKEN }}
         run: |
           set -euo pipefail
+          RELEASE_BRANCH="$(jq -er '.headBranchName' <<<"$RELEASE_PR")"
           git clone --branch "$RELEASE_BRANCH" --depth 1 \
             "https://x-access-token:${GH_TOKEN}@github.com/${GITHUB_REPOSITORY}.git" release-pr
           cd release-pr


### PR DESCRIPTION
`release-please.yml` has failed on **every push that merges a release** — 17:52, 18:00 and 20:02 today alone, including the pushes that shipped **4.3.0** and **4.3.1**.

The releases themselves were fine: `release-please-action` succeeded and the tag was created each time (which is why PyPI publishing worked). But the workflow went red immediately afterwards, and a workflow that is always red cannot tell you when something real breaks.

## Cause

```yaml
RELEASE_BRANCH: ${{ fromJSON(steps.release.outputs.pr).headBranchName }}   # line 77
```

On the push that *merges* a release there are no new commits, so release-please emits no PR and `outputs.pr` is the **empty string**:

```
✔ Considering: 0 commits
✔ No commits for path: ., skipping
##[error]The template is not valid. .github/workflows/release-please.yml (Line: 77, Col: 27):
         Error reading JToken from JsonReader. Path '', line 0, position 0.
```

A step's `env:` expressions are evaluated **even when its `if:` is false**, so `fromJSON('')` fails the whole job. The step list makes the asymmetry plain — the neighbouring `setup-uv` step has the same `if:` and no `env:`, and skipped correctly:

| step | conclusion |
|---|---|
| 3 · `googleapis/release-please-action` | success |
| 4 · `astral-sh/setup-uv` (same `if:`, no `env:`) | **skipped** |
| 5 · Sync uv.lock onto the release PR | **failure** |

## Fix

Pass the output through as raw JSON and parse it in the shell, so no expression-level `fromJSON` can ever see an empty string. The `if:` already prevents the step running in that case; this removes the failure mode entirely rather than relying on it.

Verified against a real release-please `pr` payload (parses to the right branch) and the empty case.

## Not the action bump

This is unrelated to #101 (release-please-action v4→v5), merged just before. The v5 run failed **identically**, at the same line, with the action step green — so v5 is fine and this bug predates it.

## How to confirm

This workflow only runs on push to `main`, so PR CI cannot exercise it. The check is the next push to main after merge: `release-please.yml` should be green, where it has been red on every release to date.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NiM3TyqKUySZr9en9quq5c