### PR TITLE
docs: add an OrbStack cloud-init example that joins Tailscale

### DIFF
--- a/README.md
+++ b/README.md
@@ -317,6 +317,22 @@ after your macOS account holding UID 1000, and registering *that* user is what
 puts `remo-host` in the home directory the web service logs into, while skipping
 `user_setup`'s UID-1000 reassignment entirely.
 
+To reach the VM from anywhere — your workstation, a homelab box, or the
+`remo web` service — rather than only from its Mac, use
+[`docs/examples/orbstack-cloud-init-tailscale.yaml`](docs/examples/orbstack-cloud-init-tailscale.yaml)
+instead. Same file plus Tailscale; it prints the address to register on first
+boot. Register the MagicDNS name, **not** the OrbStack IP:
+
+```bash
+orb create ubuntu remo-mbp -c docs/examples/orbstack-cloud-init-tailscale.yaml
+remo add mbp <user>@remo-mbp.<your-tailnet>.ts.net --verify
+```
+
+An OrbStack VM's own IP is reachable from its Mac and nowhere else, so a
+registry entry pointing at it is useless to a `remo web` service running
+anywhere else. Use an **ephemeral** auth key: cloud-init keeps your user-data
+on the VM's disk, so the key outlives the boot that used it.
+
 `remo remove NAME [--yes]` deregisters an added host by deleting **only** the
 local registry entry — it makes no connection to and no change on the remote
 environment (unlike a provider `destroy`, which tears down infrastructure). It

--- a/docs/examples/orbstack-cloud-init-tailscale.yaml
+++ b/docs/examples/orbstack-cloud-init-tailscale.yaml
@@ -1,0 +1,182 @@
+#cloud-config
+#
+# OrbStack VM prepared for `remo add` + `remo configure`, joined to your
+# Tailscale tailnet (remo >= 4.3.0).
+#
+#   orb create ubuntu remo-mbp -c orbstack-cloud-init-tailscale.yaml
+#
+# This is `orbstack-cloud-init.yaml` plus Tailscale. Everything that file says
+# still applies: it installs only what Ansible needs to connect and take over,
+# and it creates no user — OrbStack already makes one named after your macOS
+# account holding UID 1000, and registering *that* user is what puts remo-host
+# in the home directory `remo web` discovery logs into while skipping
+# user_setup's UID-1000 reassignment.
+#
+# WHY YOU WANT THIS ONE
+#
+# An OrbStack VM's own IP is reachable from its Mac and nowhere else. That is
+# fine when remo runs on the same Mac, and useless the moment you want the
+# workstation, your homelab box, or the `remo web` service to reach it. Joining
+# the tailnet gives the VM a stable address that works from anywhere you are
+# already logged in — the same way you reach dev1.
+#
+# The practical consequence for remo: register the MagicDNS name, not the
+# OrbStack IP.
+#
+#     remo add mbp <user>@remo-mbp.<your-tailnet>.ts.net --verify
+#
+# That address is what gets stored in the registry and pushed to the web
+# service, so it must be one the service can resolve too — i.e. the service
+# host must also be on the tailnet.
+
+# ---------------------------------------------------------------------------
+# EDIT THIS (1/2): the public key of the workstation that will run `remo`.
+# ---------------------------------------------------------------------------
+# Leave the placeholder and cloud-init keeps password auth enabled rather than
+# locking you out of a keyless VM (see the guard in runcmd).
+ssh_authorized_keys:
+  - ssh-ed25519 AAAA_REPLACE_WITH_YOUR_PUBLIC_KEY workstation
+
+package_update: true
+packages:
+  # Ansible needs a Python 3 interpreter on the target.
+  - python3
+  # hwclock, which `community.general.timezone` — the first task in remo's
+  # shared role list — hard-fails without. On Ubuntu 24.04 it lives here, and
+  # minimal images do not install it.
+  - util-linux-extra
+  - openssh-server
+  # `remo configure` installs rsync itself; having it up front means `remo cp`
+  # works the moment the host is registered.
+  - rsync
+  # For the Tailscale install script.
+  - curl
+
+write_files:
+  - path: /etc/ssh/sshd_config.d/10-remo.conf
+    permissions: '0644'
+    content: |
+      # Managed by cloud-init for remo. Ubuntu's sshd_config Includes this dir.
+      Port 22
+      PubkeyAuthentication yes
+
+  # ---------------------------------------------------------------------------
+  # EDIT THIS (2/2): a Tailscale auth key.
+  # ---------------------------------------------------------------------------
+  # Generate one at https://login.tailscale.com/admin/settings/keys
+  #
+  # Make it **ephemeral** and **pre-approved**, and tag it (e.g. `tag:remo`).
+  # Ephemeral matters here for a real reason: cloud-init writes this user-data
+  # to disk on the VM (/var/lib/cloud/instance/user-data.txt) and keeps it, so
+  # the key outlives the boot that used it. An ephemeral key expires on its own
+  # and its node is reaped when it goes offline, which bounds the damage if the
+  # VM image or a snapshot is ever shared. A reusable non-expiring key in this
+  # file is a standing credential to your tailnet.
+  #
+  # Keep this file out of version control once you put a real key in it.
+  - path: /etc/remo-tailscale.env
+    permissions: '0600'
+    owner: root:root
+    content: |
+      TS_AUTHKEY=tskey-auth-REPLACE_WITH_YOUR_AUTH_KEY
+      # The machine name on your tailnet; MagicDNS makes this
+      # <hostname>.<your-tailnet>.ts.net
+      TS_HOSTNAME=remo-mbp
+
+runcmd:
+  # Install the key on whichever account holds UID 1000 — OrbStack names it
+  # after your macOS user, so it cannot be hardcoded here.
+  - |
+    set -eu
+    KEY='ssh-ed25519 AAAA_REPLACE_WITH_YOUR_PUBLIC_KEY workstation'
+    USER_1000="$(getent passwd 1000 | cut -d: -f1)"
+    if [ -z "$USER_1000" ]; then
+      echo "remo-cloud-init: no UID 1000 account; skipping key install" >&2
+      exit 0
+    fi
+    HOME_1000="$(getent passwd 1000 | cut -d: -f6)"
+    install -d -m 700 -o "$USER_1000" -g "$USER_1000" "$HOME_1000/.ssh"
+    touch "$HOME_1000/.ssh/authorized_keys"
+    case "$KEY" in
+      *REPLACE_WITH_YOUR_PUBLIC_KEY*)
+        echo "remo-cloud-init: placeholder key not replaced; leaving password auth as-is" >&2
+        ;;
+      *)
+        grep -qxF "$KEY" "$HOME_1000/.ssh/authorized_keys" \
+          || echo "$KEY" >> "$HOME_1000/.ssh/authorized_keys"
+        echo 'PasswordAuthentication no' > /etc/ssh/sshd_config.d/20-remo-hardening.conf
+        ;;
+    esac
+    chown -R "$USER_1000:$USER_1000" "$HOME_1000/.ssh"
+    chmod 600 "$HOME_1000/.ssh/authorized_keys"
+
+  # Passwordless sudo. OrbStack already grants it; the explicit drop-in makes
+  # this file work on a plain cloud image too. `remo configure` probes for it
+  # up front rather than failing halfway through.
+  - |
+    set -eu
+    USER_1000="$(getent passwd 1000 | cut -d: -f1)"
+    [ -n "$USER_1000" ] || exit 0
+    echo "$USER_1000 ALL=(ALL) NOPASSWD:ALL" > "/etc/sudoers.d/90-remo-$USER_1000"
+    chmod 440 "/etc/sudoers.d/90-remo-$USER_1000"
+
+  - systemctl enable --now ssh
+  - systemctl restart ssh
+
+  # Tailscale, via the vendor install script (what Tailscale's own cloud-init
+  # documentation uses). It adds the apt repo and installs tailscaled.
+  - curl -fsSL https://tailscale.com/install.sh | sh
+
+  # Join the tailnet. Split from the install so a bad key fails visibly here
+  # rather than looking like an install failure.
+  - |
+    set -eu
+    . /etc/remo-tailscale.env
+    case "${TS_AUTHKEY:-}" in
+      ''|*REPLACE_WITH_YOUR_AUTH_KEY*)
+        # Not fatal: the VM is still perfectly usable over its OrbStack IP from
+        # this Mac. Only the reach-it-from-anywhere part is missing.
+        echo "remo-cloud-init: no Tailscale auth key set — installed tailscaled but did not join." >&2
+        echo "  Join later with: sudo tailscale up --hostname=${TS_HOSTNAME:-remo-mbp}" >&2
+        exit 0
+        ;;
+    esac
+    tailscale up --auth-key="$TS_AUTHKEY" --hostname="${TS_HOSTNAME:-remo-mbp}"
+    # The key has been redeemed; it does not need to stay readable on disk.
+    # (The copy cloud-init keeps in /var/lib/cloud is why an ephemeral key is
+    # recommended above — this only removes the copy we created.)
+    rm -f /etc/remo-tailscale.env
+
+  # Report the address to register, so it is in the console output rather than
+  # something you have to go and look up.
+  - |
+    set -eu
+    command -v tailscale >/dev/null 2>&1 || exit 0
+    tailscale status --json >/dev/null 2>&1 || exit 0
+    # Parse the JSON properly rather than grepping for the first "DNSName":
+    # peers have that field too, so a text match can hand back a DIFFERENT
+    # machine on your tailnet and tell you to register it. python3 is present
+    # (it is in `packages` above, because Ansible needs it anyway).
+    NAME="$(tailscale status --json | python3 -c \
+      'import json,sys; print(json.load(sys.stdin)["Self"]["DNSName"].rstrip("."))' 2>/dev/null || true)"
+    ADDR="$(tailscale ip -4 2>/dev/null | head -1)"
+    [ -n "$NAME" ] || exit 0
+    USER_1000="$(getent passwd 1000 | cut -d: -f1)"
+    echo "remo-cloud-init: tailnet name=${NAME} addr=${ADDR:-none}"
+    echo "remo-cloud-init: register with -> remo add mbp ${USER_1000}@${NAME} --verify"
+
+final_message: |
+  remo-ready after $UPTIME seconds.
+
+  This VM is on your tailnet. Register the MagicDNS name, NOT the OrbStack IP —
+  the OrbStack address only works from this Mac, which defeats the point:
+
+    remo add mbp <user>@remo-mbp.<your-tailnet>.ts.net --verify
+    remo configure mbp
+    remo web push          # the web service must be on the tailnet too
+
+  The exact name and address were printed above by cloud-init; `tailscale
+  status` on the VM will show them again.
+
+  Do not pass `--skip docker` to configure: the shared role list adds the user
+  to the docker group, which only exists if the docker role ran.

--- a/tests/unit/test_docs_examples.py
+++ b/tests/unit/test_docs_examples.py
@@ -1,15 +1,20 @@
-"""The shipped cloud-init example must stay valid.
+"""The shipped cloud-init examples must stay valid.
 
-`docs/examples/orbstack-cloud-init.yaml` is an artifact users run verbatim
+`docs/examples/orbstack-cloud-init*.yaml` are artifacts users run verbatim
 against a fresh VM, where a mistake surfaces as a half-provisioned machine and
 a cloud-init log they have to go digging for. These checks are cheap and pin
-the properties that a careless edit would break: it must parse, its shell
-blocks must be syntactically valid, and it must keep installing the two
-packages that remo's configure play hard-fails without.
+the properties a careless edit would break: they must parse, their shell blocks
+must be syntactically valid, and they must keep installing the packages remo's
+configure play hard-fails without.
+
+The Tailscale variant gets two extra guards, both for mistakes that would ship
+silently: a real auth key committed to the repo, and the peer-vs-self parsing
+bug described on `test_reports_self_not_a_peer`.
 """
 
 from __future__ import annotations
 
+import re
 import shutil
 import subprocess
 import tempfile
@@ -19,23 +24,32 @@ import pytest
 import yaml
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
-EXAMPLE = REPO_ROOT / "docs" / "examples" / "orbstack-cloud-init.yaml"
+EXAMPLES_DIR = REPO_ROOT / "docs" / "examples"
+BASE = EXAMPLES_DIR / "orbstack-cloud-init.yaml"
+TAILSCALE = EXAMPLES_DIR / "orbstack-cloud-init-tailscale.yaml"
+ALL_EXAMPLES = [BASE, TAILSCALE]
 
 
-@pytest.fixture(scope="module")
-def config() -> dict:
-    assert EXAMPLE.is_file(), f"{EXAMPLE} is referenced from README.md"
-    data = yaml.safe_load(EXAMPLE.read_text())
+def _load(path: Path) -> dict:
+    assert path.is_file(), f"{path} is referenced from README.md"
+    data = yaml.safe_load(path.read_text())
     assert isinstance(data, dict)
     return data
 
 
-def test_declares_the_cloud_config_header() -> None:
+# ---------------------------------------------------------------------------
+# Shared: every example
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("path", ALL_EXAMPLES, ids=lambda p: p.name)
+def test_declares_the_cloud_config_header(path: Path) -> None:
     # cloud-init dispatches on this exact first line; without it the file is
     # silently treated as an unknown format and nothing runs.
-    assert EXAMPLE.read_text().startswith("#cloud-config\n")
+    assert path.read_text().startswith("#cloud-config\n")
 
 
+@pytest.mark.parametrize("path", ALL_EXAMPLES, ids=lambda p: p.name)
 @pytest.mark.parametrize(
     ("package", "why"),
     [
@@ -47,13 +61,14 @@ def test_declares_the_cloud_config_header() -> None:
         ),
     ],
 )
-def test_installs_packages_configure_depends_on(config, package: str, why: str) -> None:
-    assert package in config["packages"], why
+def test_installs_packages_configure_depends_on(path: Path, package: str, why: str) -> None:
+    assert package in _load(path)["packages"], why
 
 
 @pytest.mark.skipif(shutil.which("bash") is None, reason="bash not available")
-def test_runcmd_shell_blocks_are_valid_bash(config) -> None:
-    for i, cmd in enumerate(config["runcmd"], start=1):
+@pytest.mark.parametrize("path", ALL_EXAMPLES, ids=lambda p: p.name)
+def test_runcmd_shell_blocks_are_valid_bash(path: Path) -> None:
+    for i, cmd in enumerate(_load(path)["runcmd"], start=1):
         if not isinstance(cmd, str) or "\n" not in cmd:
             continue  # a single command, no shell syntax to check
         with tempfile.NamedTemporaryFile("w", suffix=".sh") as fh:
@@ -63,10 +78,11 @@ def test_runcmd_shell_blocks_are_valid_bash(config) -> None:
         assert result.returncode == 0, f"runcmd[{i}] is not valid bash:\n{result.stderr}"
 
 
-def test_placeholder_key_is_obviously_a_placeholder(config) -> None:
+@pytest.mark.parametrize("path", ALL_EXAMPLES, ids=lambda p: p.name)
+def test_placeholder_key_is_obviously_a_placeholder(path: Path) -> None:
     # The guard in runcmd keys off this marker to avoid disabling password
     # auth (and locking the operator out) when no real key was supplied.
-    raw = EXAMPLE.read_text()
+    raw = path.read_text()
     assert "REPLACE_WITH_YOUR_PUBLIC_KEY" in raw
     assert raw.count("REPLACE_WITH_YOUR_PUBLIC_KEY") >= 2, (
         "the marker appears in both ssh_authorized_keys and the runcmd guard; "
@@ -74,7 +90,72 @@ def test_placeholder_key_is_obviously_a_placeholder(config) -> None:
     )
 
 
-def test_does_not_duplicate_what_remo_configure_installs(config) -> None:
+@pytest.mark.parametrize("path", ALL_EXAMPLES, ids=lambda p: p.name)
+def test_does_not_duplicate_what_remo_configure_installs(path: Path) -> None:
     # Duplicating the toolchain here would drift from the Ansible role list.
     for owned_by_configure in ("docker-ce", "docker.io", "nodejs", "zellij"):
-        assert owned_by_configure not in config["packages"]
+        assert owned_by_configure not in _load(path)["packages"]
+
+
+# ---------------------------------------------------------------------------
+# Tailscale variant only
+# ---------------------------------------------------------------------------
+
+
+class TestTailscaleExample:
+    def test_no_real_auth_key_is_committed(self) -> None:
+        """A live `tskey-…` in the repo is a standing credential to a tailnet.
+
+        Tailscale keys are long-lived unless made ephemeral, and this file is
+        meant to be edited locally — so the only acceptable value in git is the
+        placeholder.
+        """
+        raw = TAILSCALE.read_text()
+        for match in re.findall(r"tskey-[A-Za-z0-9_-]+", raw):
+            assert "REPLACE_WITH_YOUR_AUTH_KEY" in match, (
+                f"{match!r} looks like a real Tailscale auth key committed to the repo"
+            )
+
+    def test_joining_is_guarded_on_the_placeholder(self) -> None:
+        # Without the guard, an unedited file runs `tailscale up` with a literal
+        # placeholder and fails the boot instead of just skipping the join.
+        joins = [
+            c for c in _load(TAILSCALE)["runcmd"]
+            if isinstance(c, str) and "tailscale up" in c
+        ]
+        assert joins, "no `tailscale up` invocation found"
+        for block in joins:
+            assert "REPLACE_WITH_YOUR_AUTH_KEY" in block, (
+                "the join must skip when the key was never filled in"
+            )
+
+    def test_reports_self_not_a_peer(self) -> None:
+        """The printed `remo add` line must name THIS machine.
+
+        Peers carry a `DNSName` too, so grepping the status JSON for the first
+        one can hand back a different machine on the tailnet — verified: with a
+        peer listed before `Self`, a `sed`-based match printed
+        `remo add mbp user@dev1.…`, an instruction that looks entirely
+        plausible and points at the wrong host.
+        """
+        blocks = [
+            c for c in _load(TAILSCALE)["runcmd"]
+            if isinstance(c, str) and "DNSName" in c
+        ]
+        assert blocks, "no block reads DNSName"
+        for block in blocks:
+            assert '["Self"]' in block, "must select Self explicitly, not the first match"
+            assert not re.search(r"sed[^|]*DNSName", block), (
+                "a text match over the status JSON can return a peer's name"
+            )
+
+    def test_installs_tailscale_via_the_documented_script(self) -> None:
+        runcmd = _load(TAILSCALE)["runcmd"]
+        assert any(
+            isinstance(c, str) and "tailscale.com/install.sh" in c for c in runcmd
+        ), "Tailscale's own cloud-init docs use the install script"
+
+    def test_curl_is_available_for_the_install_script(self) -> None:
+        # The install script is fetched with curl; a minimal image may not have
+        # it, and the failure would read as a Tailscale problem.
+        assert "curl" in _load(TAILSCALE)["packages"]


### PR DESCRIPTION
An OrbStack VM's own IP is reachable from its Mac **and nowhere else**. Fine when remo runs on that Mac; useless the moment the workstation, a homelab box, or the `remo web` service needs to reach it — a registry entry pointing at that address cannot be resolved by a service running elsewhere.

This is the existing example plus Tailscale, installed with the vendor script [Tailscale's own cloud-init docs](https://tailscale.com/docs/install/with-cloud-init) use. The header states the consequence that actually matters:

```bash
orb create ubuntu remo-mbp -c docs/examples/orbstack-cloud-init-tailscale.yaml
remo add mbp <user>@remo-mbp.<your-tailnet>.ts.net --verify   # MagicDNS name, NOT the OrbStack IP
```

## Auth-key handling

The key sits in a `0600` file the join step sources and then deletes after redeeming it. The docs push toward an **ephemeral, pre-approved, tagged** key for a concrete reason: cloud-init keeps user-data on the VM's disk, so the key outlives the boot that used it — and deleting *our* copy does not delete that one. A reusable non-expiring key in that file is a standing credential to your tailnet.

An unedited placeholder **skips the join** with an explanatory message rather than failing the boot. The VM is still perfectly usable over its OrbStack IP; only the reach-it-from-anywhere part is missing.

## A real bug, caught by testing with a stubbed `tailscale`

The block that prints the address to register originally grepped the status JSON for the first `DNSName`. Peers carry that field too. With a peer listed before `Self`:

```
remo-cloud-init: register with -> remo add mbp ubuntu@dev1.tail1a2b3.ts.net --verify
```

An instruction that looks entirely plausible and names **the wrong machine** — and it only passed my first test because `Self` happened to come first in that sample. It now parses `["Self"]` with `python3` (guaranteed present, Ansible needs it). Both orderings verified to return `remo-mbp`.

Also verified with the stub: the placeholder guard skips the join and leaves the env file for later; a real key produces exactly `tailscale up --auth-key=… --hostname=remo-mbp` and removes the env file afterwards.

## Tests

`tests/unit/test_docs_examples.py` now covers **both** examples, plus two guards for mistakes that would ship silently:

- a real `tskey-…` committed to the repo
- a regression to peer-matching instead of selecting `Self`

Mutation-verified — all four deliberate breakages (real key, peer-parsing bug, dropped join guard, dropped `curl`) fail the suite, and the restored file passes. 2127 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NiM3TyqKUySZr9en9quq5c