### PR TITLE
chore(deps): track Docker base images in dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -40,3 +40,25 @@ updates:
         update-types:
           - "minor"
           - "patch"
+
+  # Docker base images. Two Dockerfiles ship images:
+  #   /Dockerfile        — the CLI image (python:3.13-slim)
+  #   /docker/Dockerfile — the remo-web service (node:20-slim, python:3.11-slim)
+  # Nothing watched these before, so a base image could sit on an unpatched
+  # tag indefinitely — the CVEs that matter for a container usually arrive via
+  # the base image, not via the app's own dependencies.
+  - package-ecosystem: "docker"
+    directories:
+      - "/"
+      - "/docker"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    open-pull-requests-limit: 5
+    cooldown:
+      default-days: 7
+    groups:
+      docker-images:
+        update-types:
+          - "minor"
+          - "patch"

--- a/tests/unit/test_dependabot_config.py
+++ b/tests/unit/test_dependabot_config.py
@@ -1,0 +1,112 @@
+"""`.github/dependabot.yml` must point at directories that exist.
+
+Dependabot silently does nothing useful for an entry whose directory is absent
+— there is no build failure and no PR, just an ecosystem that quietly goes
+unwatched. PR #39 proposed a `docker` entry covering `/` and `/notifier`, but
+`/notifier` belongs to an unmerged feature branch and does not exist on main;
+that entry would have looked like Docker coverage while providing none for the
+path that was wrong.
+
+The same trap applies to a Dockerfile that moves. These checks are cheap and
+catch it at review time rather than months later when a base image turns out
+never to have been tracked.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+import yaml
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+CONFIG = REPO_ROOT / ".github" / "dependabot.yml"
+
+
+def _updates() -> list[dict]:
+    data = yaml.safe_load(CONFIG.read_text())
+    assert data["version"] == 2, "dependabot config must declare version 2"
+    updates = data["updates"]
+    assert isinstance(updates, list) and updates
+    return updates
+
+
+def _entry_dirs(entry: dict) -> list[str]:
+    """Both spellings: singular `directory` and plural `directories`."""
+    if "directories" in entry:
+        return list(entry["directories"])
+    return [entry["directory"]]
+
+
+def _ids() -> list[str]:
+    return [
+        f"{e['package-ecosystem']}:{d}" for e in _updates() for d in _entry_dirs(e)
+    ]
+
+
+def _pairs() -> list[tuple[str, str]]:
+    return [(e["package-ecosystem"], d) for e in _updates() for d in _entry_dirs(e)]
+
+
+@pytest.mark.parametrize(("ecosystem", "directory"), _pairs(), ids=_ids())
+def test_configured_directory_exists(ecosystem: str, directory: str) -> None:
+    target = REPO_ROOT / directory.lstrip("/")
+    assert target.is_dir(), (
+        f"dependabot watches {ecosystem} in {directory!r}, which does not exist — "
+        "the entry is silently inert"
+    )
+
+
+@pytest.mark.parametrize(("ecosystem", "directory"), _pairs(), ids=_ids())
+def test_docker_directories_actually_contain_a_dockerfile(
+    ecosystem: str, directory: str
+) -> None:
+    if ecosystem != "docker":
+        pytest.skip("only meaningful for the docker ecosystem")
+    target = REPO_ROOT / directory.lstrip("/")
+    assert (target / "Dockerfile").is_file(), (
+        f"no Dockerfile in {directory!r}; dependabot would find nothing to update"
+    )
+
+
+def test_every_dockerfile_is_covered() -> None:
+    """The inverse: a Dockerfile nobody watches.
+
+    Base images are where container CVEs usually arrive, so an untracked one is
+    the failure that matters — and it is invisible, because an unwatched image
+    simply never produces a PR.
+    """
+    watched = {
+        (REPO_ROOT / d.lstrip("/")).resolve()
+        for eco, d in _pairs()
+        if eco == "docker"
+    }
+    on_disk = {
+        p.parent.resolve()
+        for p in REPO_ROOT.rglob("Dockerfile")
+        # Skip vendored trees: .venv, node_modules, and anything git ignores.
+        if not any(
+            part in {".venv", "node_modules", ".git", "site-packages"}
+            for part in p.parts
+        )
+    }
+    missing = on_disk - watched
+    assert not missing, (
+        "these Dockerfiles are not covered by any dependabot docker entry: "
+        + ", ".join(sorted(str(p.relative_to(REPO_ROOT)) for p in missing))
+    )
+
+
+def test_cooldown_applies_to_every_ecosystem() -> None:
+    """The supply-chain cooldown (#39) should not be half-applied.
+
+    Note it delays *proposals* only — Dependabot exempts security updates from
+    cooldown, which is precisely why it is the right layer for this and a
+    resolver-level `exclude-newer` is not (see the PR that added this file).
+    """
+    for entry in _updates():
+        cooldown = entry.get("cooldown")
+        assert cooldown and cooldown.get("default-days"), (
+            f"{entry['package-ecosystem']} has no cooldown; a new release could "
+            "be proposed the moment it is published"
+        )


### PR DESCRIPTION
Salvages the one useful part of #39 and deliberately drops the rest. Closes #39.

## What this adds

Both Dockerfiles were **unwatched**:

| path | base images |
|---|---|
| `/Dockerfile` | `python:3.13-slim` |
| `/docker/Dockerfile` | `node:20-slim`, `python:3.11-slim` |

A base image could sit on an unpatched tag indefinitely. Base images are where container CVEs usually arrive, and an untracked one fails *invisibly* — it simply never produces a PR.

## What this does NOT take from #39, and why

**1. Its cooldown additions are already on main.** #70 added `default-days: 7` to both the `pip` and `github-actions` entries on 2026-07-22. That half of #39 is redundant.

**2. Its `[tool.uv] exclude-newer = "7 days"` would reopen a security advisory.**

Not theoretical — I applied it and resolved:

```
cryptography: 50.0.0  ->  49.0.0
```

`cryptography 50.0.0` was published 5 days ago, inside the 7-day window. 49.0.0 sits inside the vulnerable range of the `>=44.0.0, <50.0.0` advisory — **the one cleared yesterday in #145**. It also invalidates the lockfile outright (`uv lock --check` fails).

The PR body says *"Security updates are never delayed"*. That is true of **Dependabot**, which exempts security updates from cooldown. It is **not** true of uv's `exclude-newer`, which is a blunt resolution-time filter with no security carve-out. For a repo with a committed lockfile, resolution only happens when someone deliberately runs `uv lock` — which Dependabot already gates. The cooldown belongs at the proposal layer, where it already is; adding it at the resolver buys nothing and costs security latency.

**3. Its docker directories were wrong.** `/` and `/notifier` — but `/notifier` exists only on an unmerged feature branch. That entry would have *looked* like Docker coverage while providing none, and nothing would have said so.

Also worth noting for whoever revisits #39: its diff is **73 files**, because the branch is stale (June 15) and carries the entire unmerged notifier feature — that work is #45/#47. Merging #39 would pull all of it in.

## Guard

`tests/unit/test_dependabot_config.py` checks both directions:

- every configured directory exists — what #39 got wrong
- every Dockerfile on disk is covered by some entry — so a new or moved image cannot silently go unwatched
- the cooldown is not half-applied across ecosystems

Mutation-verified: #39's exact `/notifier` path fails 3 checks; dropping `/docker` fails the coverage check; removing a cooldown fails the third. 2135 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NiM3TyqKUySZr9en9quq5c