### PR TITLE
docs: fix the OrbStack cloud-init examples' UID-1000 assumption

### DIFF
--- a/README.md
+++ b/README.md
@@ -308,30 +308,67 @@ prepares an [OrbStack](https://orbstack.dev) VM on a Mac so `remo add` and
 `remo configure` work first time:
 
 ```bash
-orb create ubuntu remo-mbp -c docs/examples/orbstack-cloud-init.yaml
+orb create ubuntu remo-mbp -u orbadmin -c docs/examples/orbstack-cloud-init.yaml
+remo add mbp remo@<name-that-resolves> --verify
 ```
 
 It installs only what Ansible needs to connect and hand over — `remo configure`
-does the rest. It deliberately creates no user: OrbStack already makes one named
-after your macOS account holding UID 1000, and registering *that* user is what
-puts `remo-host` in the home directory the web service logs into, while skipping
-`user_setup`'s UID-1000 reassignment entirely.
+does the rest. It creates a `remo` account at **UID 1000** and installs your key
+there, which is the account to register.
 
-To reach the VM from anywhere — your workstation, a homelab box, or the
-`remo web` service — rather than only from its Mac, use
+`-u orbadmin` is not optional. OrbStack creates a Linux account named after your
+macOS user, pins it to your **macOS UID** (501, not 1000), and does so *after*
+cloud-init finishes — it will even renumber a cloud-init-created account that
+shares its name. Giving OrbStack a throwaway name to own leaves UID 1000 free.
+That matters because `user_setup` pins `remo_user` to UID 1000: register an
+account at any other UID and `remo configure` runs `usermod -u 1000` against the
+account Ansible is logged in as, which shadow-utils refuses to do for a user with
+running processes. Add `--isolated` too if you want a plain VM with no Mac file
+sharing; it is independent of the UID fix.
+
+**Which name to register.** An OrbStack VM is not on your LAN — it gets a static
+address on OrbStack's internal bridge, and OrbStack has no bridged/DHCP-from-your
+-router mode — so its own IP means nothing to any other machine. Three paths, in
+increasing reach:
+
+| From | Register | Notes |
+|------|----------|-------|
+| The Mac itself | `remo-mbp.orb.local` | OrbStack's DNS. Nothing to set up. |
+| Your LAN, or a VPN | `<your-mac>` | OrbStack forwards the VM's `:22` to the Mac and exposes it on every interface, so the Mac's name reaches the VM's sshd with nothing installed in the VM. |
+| Anywhere | `remo-mbp.<tailnet>.ts.net` | The Tailscale example below — needed only if you want the VM itself on the tailnet. |
+
+Prefer a **bare name** over an FQDN or an IP: it resolves through whichever
+search domain is up — your VPN's or your router's — so one entry keeps working
+as you move. That is why a registered host reads `"host": "dev1"`.
+
+Two gotchas on the middle row. It routes through the *Mac's* `:22`, so only one
+VM can own it (and it collides with macOS Remote Login) — for a second VM,
+change `Port` in the sshd drop-in and register `remo@<mac>:<port>`. And a Mac
+does not register itself in your router's DNS the way a Linux DHCP client does:
+macOS sends the DHCP hostname only when `HostName` is set, which it is not by
+default (`LocalHostName`, the mDNS `.local` name, is never sent, and Linux hosts
+generally cannot resolve `.local` at all). Fix it once with
+`sudo scutil --set HostName <name> && sudo ipconfig set en0 DHCP` — after which
+the address may change freely, since DNS follows it.
+If a VPN or a Tailscale exit node with LAN access claims OrbStack's subnet
+(`orb config get network.subnet4`), even the Mac-local path black-holes; check
+with `route -n get <vm-ip>`.
+
+To reach the VM from anywhere — including a `remo web` service that cannot reach
+your Mac — use
 [`docs/examples/orbstack-cloud-init-tailscale.yaml`](docs/examples/orbstack-cloud-init-tailscale.yaml)
 instead. Same file plus Tailscale; it prints the address to register on first
-boot. Register the MagicDNS name, **not** the OrbStack IP:
+boot:
 
 ```bash
-orb create ubuntu remo-mbp -c docs/examples/orbstack-cloud-init-tailscale.yaml
-remo add mbp <user>@remo-mbp.<your-tailnet>.ts.net --verify
+orb create ubuntu remo-mbp -u orbadmin -c docs/examples/orbstack-cloud-init-tailscale.yaml
+remo add mbp remo@remo-mbp.<your-tailnet>.ts.net --verify
 ```
 
-An OrbStack VM's own IP is reachable from its Mac and nowhere else, so a
-registry entry pointing at it is useless to a `remo web` service running
-anywhere else. Use an **ephemeral** auth key: cloud-init keeps your user-data
-on the VM's disk, so the key outlives the boot that used it.
+Use an **ephemeral** auth key: cloud-init keeps your user-data on the VM's disk,
+so the key outlives the boot that used it. Leaving the placeholder is fine —
+tailscaled still installs, and `sudo tailscale up` joins interactively with no
+credential on disk.
 
 `remo remove NAME [--yes]` deregisters an added host by deleting **only** the
 local registry entry — it makes no connection to and no change on the remote

--- a/docs/examples/orbstack-cloud-init-tailscale.yaml
+++ b/docs/examples/orbstack-cloud-init-tailscale.yaml
@@ -3,46 +3,82 @@
 # OrbStack VM prepared for `remo add` + `remo configure`, joined to your
 # Tailscale tailnet (remo >= 4.3.0).
 #
-#   orb create ubuntu remo-mbp -c orbstack-cloud-init-tailscale.yaml
+#   orb create ubuntu remo-mbp -u orbadmin -c docs/examples/orbstack-cloud-init-tailscale.yaml
 #
 # This is `orbstack-cloud-init.yaml` plus Tailscale. Everything that file says
-# still applies: it installs only what Ansible needs to connect and take over,
-# and it creates no user — OrbStack already makes one named after your macOS
-# account holding UID 1000, and registering *that* user is what puts remo-host
-# in the home directory `remo web` discovery logs into while skipping
-# user_setup's UID-1000 reassignment.
+# still applies — in particular the `-u orbadmin` flag, which is NOT optional
+# and is explained in full there. In short: OrbStack pins its own default user
+# to your macOS UID (501), after cloud-init has finished, and will renumber a
+# cloud-init-created account that shares its name. Handing OrbStack a throwaway
+# account name leaves UID 1000 free for the `remo` account created below, which
+# is the UID remo's user_setup role pins remo_user to.
 #
-# WHY YOU WANT THIS ONE
+# WHEN YOU WANT THIS ONE (AND WHEN YOU DO NOT)
 #
-# An OrbStack VM's own IP is reachable from its Mac and nowhere else. That is
-# fine when remo runs on the same Mac, and useless the moment you want the
-# workstation, your homelab box, or the `remo web` service to reach it. Joining
-# the tailnet gives the VM a stable address that works from anywhere you are
-# already logged in — the same way you reach dev1.
+# An OrbStack VM is not on your LAN. It gets a static address on OrbStack's own
+# internal bridge — OrbStack has no bridged/DHCP-from-your-router mode — so the
+# VM's own IP means nothing to any other machine. There are three ways to reach
+# it, and Tailscale is only the third:
 #
-# The practical consequence for remo: register the MagicDNS name, not the
-# OrbStack IP.
+#   1. From this Mac:        remo-mbp.orb.local
+#      OrbStack's built-in DNS. Nothing to set up, Mac-only.
+#      Caveat: if a VPN or a Tailscale exit node with LAN access claims
+#      OrbStack's subnet (`orb config get network.subnet4`), traffic to it is
+#      routed off-box and black-holes. `route -n get <vm-ip>` should name
+#      OrbStack's bridge interface, not en0. Changing network.subnet4 to an
+#      unused range fixes it.
 #
-#     remo add mbp <user>@remo-mbp.<your-tailnet>.ts.net --verify
+#   2. From elsewhere on your LAN:   <your-mac>:22
+#      OrbStack forwards a port the VM listens on to the Mac and, with
+#      `machines.expose_ports_to_lan` on (the default), exposes it to the LAN.
+#      So the VM's sshd is reachable at your Mac's address — verified. Give the
+#      Mac a DHCP reservation and a DNS name on your router and register that;
+#      an mDNS `.local` name works from Macs but typically NOT from Linux hosts,
+#      which lack avahi/nss-mdns. Note the VM's :22 occupies the MAC's :22, so
+#      only one VM can own it (and it collides with macOS Remote Login) — for a
+#      second VM, change `Port` in the sshd drop-in below and register
+#      `remo add name remo@<mac>:<port>`.
 #
-# That address is what gets stored in the registry and pushed to the web
-# service, so it must be one the service can resolve too — i.e. the service
-# host must also be on the tailnet.
+#   3. From anywhere:        remo-mbp.<your-tailnet>.ts.net
+#      What this file adds. Needed when the reader is off your LAN, or when the
+#      `remo web` service runs somewhere that cannot reach your Mac directly.
+#
+# remo stores whatever name you register and threads it through `remo shell`,
+# `remo configure` and `remo web push`, so pick the name that resolves for
+# everything that must reach this VM — the service host included.
+#
+#     remo add mbp remo@remo-mbp.<your-tailnet>.ts.net --verify
 
 # ---------------------------------------------------------------------------
 # EDIT THIS (1/2): the public key of the workstation that will run `remo`.
 # ---------------------------------------------------------------------------
 # Leave the placeholder and cloud-init keeps password auth enabled rather than
 # locking you out of a keyless VM (see the guard in runcmd).
-ssh_authorized_keys:
-  - ssh-ed25519 AAAA_REPLACE_WITH_YOUR_PUBLIC_KEY workstation
+#
+# The key is installed here, at account-creation time — NOT from runcmd against
+# "whichever account holds UID 1000", which on OrbStack resolves to the image's
+# transient default user and lands in a home directory OrbStack later deletes.
+# cloud-init reports success either way; the symptom is `remo add --verify`
+# failing to authenticate.
+users:
+  - name: remo
+    uid: 1000
+    shell: /bin/bash
+    # `remo configure` probes `sudo -n true` up front rather than failing
+    # halfway through installing packages and system services.
+    sudo: ALL=(ALL) NOPASSWD:ALL
+    ssh_authorized_keys:
+      - ssh-ed25519 AAAA_REPLACE_WITH_YOUR_PUBLIC_KEY workstation
+
+# Declaring `users:` also suppresses the image's own default account, which is
+# what would otherwise be sitting on UID 1000.
 
 package_update: true
 packages:
   # Ansible needs a Python 3 interpreter on the target.
   - python3
   # hwclock, which `community.general.timezone` — the first task in remo's
-  # shared role list — hard-fails without. On Ubuntu 24.04 it lives here, and
+  # shared role list — hard-fails without. On Ubuntu 24.04+ it lives here, and
   # minimal images do not install it.
   - util-linux-extra
   - openssh-server
@@ -73,6 +109,10 @@ write_files:
   # VM image or a snapshot is ever shared. A reusable non-expiring key in this
   # file is a standing credential to your tailnet.
   #
+  # Leaving it as-is is fine: tailscaled still installs, and you can join
+  # interactively with `orb -m remo-mbp sudo tailscale up --hostname=remo-mbp`,
+  # which keeps every credential off the VM's disk.
+  #
   # Keep this file out of version control once you put a real key in it.
   - path: /etc/remo-tailscale.env
     permissions: '0600'
@@ -84,41 +124,19 @@ write_files:
       TS_HOSTNAME=remo-mbp
 
 runcmd:
-  # Install the key on whichever account holds UID 1000 — OrbStack names it
-  # after your macOS user, so it cannot be hardcoded here.
+  # Harden SSH only once a real key is in place. The key itself was installed
+  # by the `users:` block above; all this does is decide whether turning
+  # passwords off is safe.
   - |
     set -eu
     KEY='ssh-ed25519 AAAA_REPLACE_WITH_YOUR_PUBLIC_KEY workstation'
-    USER_1000="$(getent passwd 1000 | cut -d: -f1)"
-    if [ -z "$USER_1000" ]; then
-      echo "remo-cloud-init: no UID 1000 account; skipping key install" >&2
-      exit 0
-    fi
-    HOME_1000="$(getent passwd 1000 | cut -d: -f6)"
-    install -d -m 700 -o "$USER_1000" -g "$USER_1000" "$HOME_1000/.ssh"
-    touch "$HOME_1000/.ssh/authorized_keys"
     case "$KEY" in
       *REPLACE_WITH_YOUR_PUBLIC_KEY*)
         echo "remo-cloud-init: placeholder key not replaced; leaving password auth as-is" >&2
-        ;;
-      *)
-        grep -qxF "$KEY" "$HOME_1000/.ssh/authorized_keys" \
-          || echo "$KEY" >> "$HOME_1000/.ssh/authorized_keys"
-        echo 'PasswordAuthentication no' > /etc/ssh/sshd_config.d/20-remo-hardening.conf
+        exit 0
         ;;
     esac
-    chown -R "$USER_1000:$USER_1000" "$HOME_1000/.ssh"
-    chmod 600 "$HOME_1000/.ssh/authorized_keys"
-
-  # Passwordless sudo. OrbStack already grants it; the explicit drop-in makes
-  # this file work on a plain cloud image too. `remo configure` probes for it
-  # up front rather than failing halfway through.
-  - |
-    set -eu
-    USER_1000="$(getent passwd 1000 | cut -d: -f1)"
-    [ -n "$USER_1000" ] || exit 0
-    echo "$USER_1000 ALL=(ALL) NOPASSWD:ALL" > "/etc/sudoers.d/90-remo-$USER_1000"
-    chmod 440 "/etc/sudoers.d/90-remo-$USER_1000"
+    echo 'PasswordAuthentication no' > /etc/ssh/sshd_config.d/20-remo-hardening.conf
 
   - systemctl enable --now ssh
   - systemctl restart ssh
@@ -134,8 +152,9 @@ runcmd:
     . /etc/remo-tailscale.env
     case "${TS_AUTHKEY:-}" in
       ''|*REPLACE_WITH_YOUR_AUTH_KEY*)
-        # Not fatal: the VM is still perfectly usable over its OrbStack IP from
-        # this Mac. Only the reach-it-from-anywhere part is missing.
+        # Not fatal: the VM is still reachable by the two LAN-local routes
+        # described at the top of this file. Only the from-anywhere part is
+        # missing, and you can add it later with `tailscale up`.
         echo "remo-cloud-init: no Tailscale auth key set — installed tailscaled but did not join." >&2
         echo "  Join later with: sudo tailscale up --hostname=${TS_HOSTNAME:-remo-mbp}" >&2
         exit 0
@@ -161,22 +180,26 @@ runcmd:
       'import json,sys; print(json.load(sys.stdin)["Self"]["DNSName"].rstrip("."))' 2>/dev/null || true)"
     ADDR="$(tailscale ip -4 2>/dev/null | head -1)"
     [ -n "$NAME" ] || exit 0
-    USER_1000="$(getent passwd 1000 | cut -d: -f1)"
     echo "remo-cloud-init: tailnet name=${NAME} addr=${ADDR:-none}"
-    echo "remo-cloud-init: register with -> remo add mbp ${USER_1000}@${NAME} --verify"
+    echo "remo-cloud-init: register with -> remo add mbp remo@${NAME} --verify"
 
 final_message: |
   remo-ready after $UPTIME seconds.
 
-  This VM is on your tailnet. Register the MagicDNS name, NOT the OrbStack IP —
-  the OrbStack address only works from this Mac, which defeats the point:
+  The `remo` account exists at UID 1000 with your workstation key. The account
+  named on `orb create -u …` (UID 501) is OrbStack's own integration account —
+  ignore it; it is not the one to register.
 
-    remo add mbp <user>@remo-mbp.<your-tailnet>.ts.net --verify
+  Register a name that resolves for everything which must reach this VM — the
+  `remo web` service host included. The VM's own OrbStack IP is not one of
+  those names; it means nothing off this Mac.
+
+    remo add mbp remo@remo-mbp.<your-tailnet>.ts.net --verify
     remo configure mbp
     remo web push          # the web service must be on the tailnet too
 
-  The exact name and address were printed above by cloud-init; `tailscale
-  status` on the VM will show them again.
+  If the join was skipped, the exact name and address are printed by
+  `tailscale status` on the VM once you run `tailscale up`.
 
   Do not pass `--skip docker` to configure: the shared role list adds the user
   to the docker group, which only exists if the docker role ran.

--- a/docs/examples/orbstack-cloud-init.yaml
+++ b/docs/examples/orbstack-cloud-init.yaml
@@ -2,22 +2,87 @@
 #
 # OrbStack VM prepared for `remo add` + `remo configure` (remo >= 4.3.0).
 #
-#   orb create ubuntu remo-mbp -c orbstack-remo-cloud-init.yaml
+#   orb create ubuntu remo-mbp -u orbadmin -c docs/examples/orbstack-cloud-init.yaml
 #
 # Deliberately minimal: this installs ONLY what Ansible needs in order to
 # connect and take over. Docker, Node.js, zellij, fzf, the GitHub CLI, the
 # devcontainers CLI and remo-host are all installed by `remo configure`, which
 # is idempotent — duplicating any of that here would only drift.
 #
-# It also does NOT create a user. OrbStack already creates one named after your
-# macOS account, holding UID 1000 with passwordless sudo. `remo configure`
-# binds its workspace account to whichever user you register, so registering
-# that existing user means:
-#   * remo-host lands in the home directory discovery actually logs into, and
-#   * user_setup's UID-1000 reassignment (which rewrites /etc/passwd and drops
-#     the live SSH session) is skipped entirely, because the holder of UID 1000
-#     is already the account being configured.
-# Creating a separate `remo` user here would forfeit both.
+# ---------------------------------------------------------------------------
+# `-u orbadmin` IS NOT OPTIONAL. Leave it off and this file does not work.
+# ---------------------------------------------------------------------------
+# OrbStack creates a Linux account named after your macOS user and pins it to
+# your **macOS UID** — 501 on a normal Mac, not 1000 — and it does so AFTER
+# cloud-init has finished. Two consequences, both verified on OrbStack 2.2.1 +
+# Ubuntu 26.04 (2026-08-06):
+#
+#   * Anything cloud-init does to "whichever account holds UID 1000" runs before
+#     that account exists. During runcmd the only UID-1000 account is the image's
+#     transient default user, so an SSH key installed there lands in a home
+#     directory OrbStack later deletes. cloud-init still reports `status: done`
+#     with `errors: []` — the only symptom is `remo add --verify` failing to
+#     authenticate afterwards.
+#   * OrbStack renumbers its own default user even if cloud-init already created
+#     it at UID 1000. A `remo` account made here was moved 1000 -> 501 when
+#     `remo` was also OrbStack's default user name.
+#
+# Naming OrbStack's default user something else (`orbadmin`) leaves UID 1000
+# free for the account this file creates. `orbadmin` is vestigial — it exists so
+# `orb` has its integration account, and you never log into it.
+#
+# WHY UID 1000 MATTERS TO REMO
+#
+# remo's user_setup role pins remo_user to UID 1000 (it matches the devcontainer
+# `vscode` user). Register an account at any other UID and `remo configure`
+# reaches "Create remo user with UID 1000" and runs `usermod -u 1000` against
+# the very account Ansible is logged in as — which shadow-utils refuses to do
+# for a user with running processes. Creating `remo` at 1000 up front makes that
+# task a no-op and means the UID-displacement branch (which rewrites /etc/passwd
+# and drops the live SSH session) never fires at all.
+#
+# OPTIONAL: add `--isolated` to the `orb create` line to turn off OrbStack's Mac
+# file sharing and integration — no /mnt/mac, no ~/.ssh symlinked back to macOS.
+# It is independent of the UID fix above (both were verified with and without
+# it); use it if you want the VM to be a plain Linux box.
+#
+# ---------------------------------------------------------------------------
+# WHICH NAME TO REGISTER
+# ---------------------------------------------------------------------------
+# Do NOT register the VM's own IP. An OrbStack VM is not on your LAN: it gets a
+# static address on OrbStack's internal bridge, and OrbStack has no bridged /
+# DHCP-from-your-router mode, so that address means nothing to any other
+# machine — including a `remo web` service running elsewhere.
+#
+# Register your MAC's name instead. OrbStack forwards a port the VM listens on
+# to the Mac and, with `machines.expose_ports_to_lan` on (the default), exposes
+# it on every interface — so `<your-mac>:22` reaches the VM's sshd from your
+# LAN, and over a VPN like Tailscale, with nothing installed in the VM.
+# Verified end-to-end: a remote host connecting to the Mac's port 22 gets the
+# VM's SSH banner, not macOS's.
+#
+# Two consequences worth knowing before you pick a name:
+#
+#   * The VM's :22 occupies the MAC's :22. Only one VM can own it, and it
+#     collides with macOS Remote Login. For a second VM, change `Port` in the
+#     sshd drop-in below and register `remo add name remo@<mac>:<port>`.
+#
+#   * A Mac does not register itself in your router's DNS the way a Linux DHCP
+#     client does. macOS sends the DHCP hostname option only when `HostName` is
+#     set, and it is unset by default — `scutil --get HostName` says "not set",
+#     while `LocalHostName` (the mDNS `.local` name) is never sent. So the
+#     router has no name for your Mac, and mDNS `.local` will not help: Linux
+#     hosts typically lack avahi/nss-mdns and cannot resolve it. Fix it once:
+#
+#         sudo scutil --set HostName <name> && sudo ipconfig set en0 DHCP
+#
+#     After that the Mac is registered like any other DHCP client and its
+#     address may change freely — DNS follows it, so no static IP or reservation
+#     is needed.
+#
+# Prefer a bare name over an FQDN or an IP. A bare name resolves through
+# whichever search domain is available — your VPN's when it is up, your
+# router's when it is not — so one registry entry keeps working as you move.
 
 # ---------------------------------------------------------------------------
 # EDIT THIS: the public key of the workstation that will run `remo`.
@@ -25,8 +90,22 @@
 # If remo runs on this same Mac, that is ~/.ssh/id_ed25519.pub.
 # Leave the placeholder in place and cloud-init keeps password auth enabled
 # rather than locking you out (see the guard in runcmd).
-ssh_authorized_keys:
-  - ssh-ed25519 AAAA_REPLACE_WITH_YOUR_PUBLIC_KEY workstation
+#
+# The key is installed here, by cloud-init, at account-creation time — NOT from
+# runcmd. That is what makes it deterministic: the account is created by this
+# file, so there is no "find the right user" step to get wrong.
+users:
+  - name: remo
+    uid: 1000
+    shell: /bin/bash
+    # `remo configure` probes `sudo -n true` up front rather than failing
+    # halfway through installing packages and system services.
+    sudo: ALL=(ALL) NOPASSWD:ALL
+    ssh_authorized_keys:
+      - ssh-ed25519 AAAA_REPLACE_WITH_YOUR_PUBLIC_KEY workstation
+
+# Declaring `users:` also suppresses the image's own default account, which is
+# what would otherwise be sitting on UID 1000.
 
 package_update: true
 packages:
@@ -36,7 +115,7 @@ packages:
   - python3
   # hwclock. `community.general.timezone` — the first task in remo's shared
   # role list — hard-fails with 'Failed to find required executable "hwclock"'
-  # without it, and on Ubuntu 24.04 it lives in util-linux-extra, which minimal
+  # without it, and on Ubuntu 24.04+ it lives in util-linux-extra, which minimal
   # images do not install. Found the hard way while testing this feature.
   - util-linux-extra
   - openssh-server
@@ -53,7 +132,7 @@ packages:
 # Change it if you are reaching this VM from somewhere else (e.g. your homelab
 # box) via a forwarded port — remo stores the port per host and threads it
 # through `remo shell`, `remo configure` and `remo web push`. Register it with
-#     remo add mbp <user>@<host>:<port>
+#     remo add mbp remo@<host>:<port>
 # Note this is NOT OrbStack's own SSH (127.0.0.1:32222, Mac-local only); this
 # is a normal sshd inside the VM, which is what remo drives.
 write_files:
@@ -65,45 +144,21 @@ write_files:
       PubkeyAuthentication yes
 
 runcmd:
-  # Put the key on the UID-1000 account explicitly. `ssh_authorized_keys` above
-  # targets cloud-init's notion of the default user, which is not guaranteed to
-  # be the user OrbStack created — this makes it deterministic either way.
+  # Harden SSH only once a real key is in place. The key itself was installed
+  # by the `users:` block above; all this does is decide whether turning
+  # passwords off is safe.
   - |
     set -eu
     KEY='ssh-ed25519 AAAA_REPLACE_WITH_YOUR_PUBLIC_KEY workstation'
-    USER_1000="$(getent passwd 1000 | cut -d: -f1)"
-    if [ -z "$USER_1000" ]; then
-      echo "remo-cloud-init: no UID 1000 account; skipping key install" >&2
-      exit 0
-    fi
-    HOME_1000="$(getent passwd 1000 | cut -d: -f6)"
-    install -d -m 700 -o "$USER_1000" -g "$USER_1000" "$HOME_1000/.ssh"
-    touch "$HOME_1000/.ssh/authorized_keys"
     case "$KEY" in
       *REPLACE_WITH_YOUR_PUBLIC_KEY*)
         # Refuse to harden SSH when no real key was supplied — disabling
         # password auth here would leave the VM unreachable over SSH.
         echo "remo-cloud-init: placeholder key not replaced; leaving password auth as-is" >&2
-        ;;
-      *)
-        grep -qxF "$KEY" "$HOME_1000/.ssh/authorized_keys" \
-          || echo "$KEY" >> "$HOME_1000/.ssh/authorized_keys"
-        echo 'PasswordAuthentication no' > /etc/ssh/sshd_config.d/20-remo-hardening.conf
+        exit 0
         ;;
     esac
-    chown -R "$USER_1000:$USER_1000" "$HOME_1000/.ssh"
-    chmod 600 "$HOME_1000/.ssh/authorized_keys"
-
-  # Passwordless sudo: OrbStack already grants it, but an explicit drop-in
-  # makes this file work on a plain cloud image too. remo needs it — the
-  # configure play installs packages and system services, and probes for it
-  # up front rather than failing halfway through.
-  - |
-    set -eu
-    USER_1000="$(getent passwd 1000 | cut -d: -f1)"
-    [ -n "$USER_1000" ] || exit 0
-    echo "$USER_1000 ALL=(ALL) NOPASSWD:ALL" > "/etc/sudoers.d/90-remo-$USER_1000"
-    chmod 440 "/etc/sudoers.d/90-remo-$USER_1000"
+    echo 'PasswordAuthentication no' > /etc/ssh/sshd_config.d/20-remo-hardening.conf
 
   - systemctl enable --now ssh
   - systemctl restart ssh
@@ -111,8 +166,12 @@ runcmd:
 final_message: |
   remo-ready after $UPTIME seconds.
 
+  The `remo` account exists at UID 1000 with your workstation key. The account
+  named on `orb create -u …` (UID 501) is OrbStack's own integration account —
+  ignore it; it is not the one to register.
+
   From the workstation running remo:
-    remo add mbp <user>@<this-vm-ip> --verify     # add :PORT if you changed it
+    remo add mbp remo@<this-vm-ip> --verify       # add :PORT if you changed it
     remo configure mbp
     remo web push                                 # if you use the web console
 

--- a/tests/unit/test_docs_examples.py
+++ b/tests/unit/test_docs_examples.py
@@ -91,6 +91,60 @@ def test_placeholder_key_is_obviously_a_placeholder(path: Path) -> None:
 
 
 @pytest.mark.parametrize("path", ALL_EXAMPLES, ids=lambda p: p.name)
+def test_creates_the_login_at_uid_1000(path: Path) -> None:
+    """The registered account must be created here, at UID 1000.
+
+    `user_setup` pins remo_user to UID 1000. An account registered at any other
+    UID sends `remo configure` into `usermod -u 1000` against the account
+    Ansible is logged in as — which shadow-utils refuses for a user with running
+    processes, failing the play.
+
+    On OrbStack this cannot be left to the platform: it names its default user
+    after the macOS account and pins it to the macOS UID (501), *after*
+    cloud-init has run. Hence `orb create -u orbadmin` in the header, which
+    leaves 1000 free for this account.
+    """
+    users = _load(path).get("users")
+    assert users, "the example must create the account it tells you to register"
+    remo = [u for u in users if isinstance(u, dict) and u.get("name") == "remo"]
+    assert remo, f"expected a `remo` user, got {[u.get('name') for u in users]}"
+    assert remo[0].get("uid") == 1000, "the registered account must hold UID 1000"
+    assert remo[0].get("ssh_authorized_keys"), (
+        "install the key here, not from runcmd — see "
+        "test_does_not_resolve_the_account_by_uid_lookup"
+    )
+
+
+@pytest.mark.parametrize("path", ALL_EXAMPLES, ids=lambda p: p.name)
+def test_does_not_resolve_the_account_by_uid_lookup(path: Path) -> None:
+    """No runcmd may look the account up with `getent passwd 1000`.
+
+    That is the bug these examples used to ship. On OrbStack, runcmd executes
+    before the platform has created its user, so UID 1000 resolves to the
+    image's transient default account and anything written there lands in a home
+    directory that is subsequently deleted. cloud-init still reports
+    `status: done` with `errors: []`; the only symptom is `remo add --verify`
+    failing to authenticate later.
+    """
+    for i, cmd in enumerate(_load(path)["runcmd"], start=1):
+        if not isinstance(cmd, str):
+            continue
+        assert "getent passwd 1000" not in cmd, (
+            f"runcmd[{i}] resolves the account by UID lookup; declare it under "
+            "`users:` instead, where cloud-init creates it deterministically"
+        )
+
+
+@pytest.mark.parametrize("path", ALL_EXAMPLES, ids=lambda p: p.name)
+def test_header_documents_the_required_default_user_flag(path: Path) -> None:
+    # Without `-u <throwaway>`, OrbStack renumbers the `remo` account created
+    # above from 1000 to the macOS UID, and the file silently stops working.
+    assert "-u orbadmin" in path.read_text(), (
+        "the `orb create` line must pass -u to keep UID 1000 free"
+    )
+
+
+@pytest.mark.parametrize("path", ALL_EXAMPLES, ids=lambda p: p.name)
 def test_does_not_duplicate_what_remo_configure_installs(path: Path) -> None:
     # Duplicating the toolchain here would drift from the Ansible role list.
     for owned_by_configure in ("docker-ce", "docker.io", "nodejs", "zellij"):


### PR DESCRIPTION
## The bug

Both shipped examples installed the workstation SSH key onto *"whichever account holds UID 1000"*, resolved from `runcmd`. On OrbStack that account does not exist yet — OrbStack creates its Linux user **after** cloud-init finishes and pins it to the **macOS UID (501, not 1000)**. During `runcmd` the only UID-1000 account is the image's transient default user, so the key and sudoers drop-in landed in a home directory OrbStack then deleted.

cloud-init still reported `status: done` with `errors: []`. The only symptom was `remo add --verify` failing to authenticate later.

Verified on OrbStack 2.2.1 + Ubuntu 26.04.

## The fix

OrbStack also renumbers a cloud-init-created account that shares its default user's name (a `remo` user created at 1000 was moved to 501), so this has two halves:

- **`orb create -u orbadmin`** hands OrbStack a throwaway account to pin, leaving UID 1000 free. Documented as mandatory in both headers and the README.
- **The `remo` account is declared under `users:` at uid 1000** with its key, so cloud-init creates it deterministically — no "find the right user" step to get wrong.

UID 1000 matters because `user_setup` pins `remo_user` to it. An account registered at any other UID sends `remo configure` into `usermod -u 1000` against the account Ansible is logged in as, which shadow-utils refuses for a user with running processes.

The placeholder guard is preserved, so an unedited file still refuses to disable password auth and strand an unreachable VM.

## Which name to register

The examples never covered this, and it's the other half of getting a usable VM. An OrbStack VM is not on the LAN and OrbStack has no bridged/DHCP-from-router mode — but it forwards the VM's `:22` to the Mac on every interface, so the Mac's own name reaches the VM's sshd with nothing installed in the VM. Confirmed end-to-end: a remote host connecting to the Mac's port 22 gets the VM's SSH banner, not macOS's. Tailscale is therefore only needed to put the VM itself on a tailnet.

Includes the macOS gotcha that a Mac sends no DHCP hostname unless `HostName` is set — so unlike a Linux DHCP client it never lands in the router's DNS — and the rule to prefer a bare name over an FQDN or IP.

## Gates

Three new checks pin the invariants rather than relax the existing ones:

- the account must be created at UID 1000 with its key
- no `runcmd` may resolve it via `getent passwd 1000`
- the header must carry the `-u` flag

The existing marker-count gate passes unchanged.

## Test plan

- `uv run pytest tests/unit/test_docs_examples.py` — 23 passed
- Full suite: 2122 passed. Pre-existing failures in `tests/integration` and `tests/perf` are live-infrastructure only (`sshd on 192.168.215.x never became reachable`); this change touches no Python source.
- Both fixed examples were exercised against real OrbStack VMs while developing them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)