### PR TITLE
chore(deps): move the web image's Node base to 24 (Active LTS)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -43,7 +43,7 @@ updates:
 
   # Docker base images. Two Dockerfiles ship images:
   #   /Dockerfile        — the CLI image (python:3.13-slim)
-  #   /docker/Dockerfile — the remo-web service (node:20-slim, python:3.11-slim)
+  #   /docker/Dockerfile — the remo-web service (node:24-slim, python:3.11-slim)
   # Nothing watched these before, so a base image could sit on an unpatched
   # tag indefinitely — the CVEs that matter for a container usually arrive via
   # the base image, not via the app's own dependencies.
@@ -62,3 +62,14 @@ updates:
         update-types:
           - "minor"
           - "patch"
+    ignore:
+      # Dependabot picks the highest published tag and has no concept of
+      # Node's release lines. Left alone it proposed node:20-slim ->
+      # node:25-slim (#156): 25 is an odd-numbered "Current" release that
+      # never becomes LTS and went EOL on 2026-06-01, so that bump would have
+      # swapped one unpatched base image for another — the exact failure this
+      # ecosystem entry exists to prevent. Node majors are picked by hand
+      # instead, on the LTS cadence (even-numbered, each October). Minor and
+      # patch bumps, which carry the base-image CVE fixes, keep flowing.
+      - dependency-name: "node"
+        update-types: ["version-update:semver-major"]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -154,7 +154,7 @@ jobs:
 
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
         with:
-          node-version: "20"
+          node-version: "24"
           cache: npm
           cache-dependency-path: frontend/package-lock.json
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -14,7 +14,7 @@
 # ---------------------------------------------------------------------------
 # Stage 1: frontend-builder
 # ---------------------------------------------------------------------------
-FROM node:20-slim AS frontend-builder
+FROM node:24-slim AS frontend-builder
 
 WORKDIR /app/frontend
 

--- a/tests/image/test_docker_image.py
+++ b/tests/image/test_docker_image.py
@@ -25,7 +25,7 @@ tests (skip honestly rather than fail when infra isn't available):
    reports ready (200) once the required mounts are present.
 
    This tier is opt-in because a multi-arch image build (pulling
-   `python:3.11-slim` / `node:20-slim`, installing AWS CLI v2 / SSM plugin,
+   `python:3.11-slim` / `node:24-slim`, installing AWS CLI v2 / SSM plugin,
    `npm ci`, `pip install`, and -- for arm64 -- running most of that under
    QEMU emulation) is a multi-minute, network-heavy operation: not
    appropriate to run unconditionally on every `pytest` invocation / in
@@ -333,7 +333,7 @@ requires_image_build = pytest.mark.skipif(
     reason=(
         "opt-in image-build test: set REMO_RUN_IMAGE_TESTS=1 with a working "
         "`docker buildx` (network access to pull python:3.11-slim / "
-        "node:20-slim and install packages) to run this"
+        "node:24-slim and install packages) to run this"
     ),
 )
 


### PR DESCRIPTION
Supersedes #156.

## Why not #156

Dependabot proposed `node:20-slim` → `node:25-slim`. Both tags are end-of-life. From Node's own [`schedule.json`](https://github.com/nodejs/Release/blob/main/schedule.json):

| Version | LTS start | EOL | Status today |
|---|---|---|---|
| **20** (current pin) | 2023-10-24 | **2026-04-30** | EOL |
| 22 (Jod) | 2024-10-29 | 2027-04-30 | LTS, in maintenance |
| **24** (Krypton) | 2025-10-28 | 2028-04-30 | **Active LTS** ← this PR |
| **25** (#156) | never — odd-numbered | **2026-06-01** | EOL |

Node 25 is a "Current" release that never becomes LTS. Merging #156 would have swapped one unpatched base image for another — the exact failure the docker ecosystem entry added in #154 exists to prevent. Node 24 is supported until 2028-04-30 and doesn't enter maintenance until 2026-10-20.

The move off 20 is overdue regardless; only the target was wrong.

## What's here

1. `docker/Dockerfile` — frontend-builder stage → `node:24-slim`
2. `.github/workflows/ci.yml` — `setup-node` pin `20` → `24`. Left behind, CI would typecheck and build the frontend on a different major than the shipped image builds it with.
3. `tests/image/test_docker_image.py` — the two hardcoded `node:20-slim` strings (module docstring, skip reason)
4. `.github/dependabot.yml` — the ecosystem comment's stale `node:20-slim`
5. `.github/dependabot.yml` — **ignore `semver-major` for `node`**. Dependabot picks the highest published tag and has no concept of release lines, so it will keep proposing odd majors (26 lands 2026-10-28, 27 a year later). Node majors get picked by hand on the LTS cadence; minor/patch bumps — the ones carrying base-image CVE fixes — keep flowing untouched.

## Verification

- Full multi-stage `docker build -f docker/Dockerfile` succeeds; the built image runs (`remo 4.3.3`) and carries the SPA at `/app/frontend-dist`
- `npm ci && npm run build` is warning-clean (no `EBADENGINE`) on **both** 24-slim and 25-slim, producing identical `dist/` structure — this is a support-lifecycle change, not a compatibility fix
- `tests/image/` 21 passed, 14 skipped; frontend typecheck + build clean; both YAML files parse and the `ignore` entry resolves to exactly `node` / `version-update:semver-major`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RcgFXhhdqGGzhk5Ardf9rk