### PR TITLE
docs: fix the installer's advertised URL and the --branch flag it never had

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -206,6 +206,6 @@ remo incus destroy test-container --yes --host <incus-host>
 ### Test Installer
 
 ```bash
-# Test from branch
-curl -fsSL https://get2knowio.github.io/remo/install.sh | bash -s -- --branch my-feature
+# Test the latest pre-release
+curl -fsSL https://get2knowio.github.io/remo/install.sh | bash -s -- --pre-release
 ```

--- a/docs/install.sh
+++ b/docs/install.sh
@@ -2,7 +2,7 @@
 # remo installer — installs remo-cli from PyPI via uv
 #
 # Usage:
-#   curl -fsSL https://get2know.io/remo/install.sh | bash
+#   curl -fsSL https://get2knowio.github.io/remo/install.sh | bash
 #   curl -fsSL .../install.sh | bash -s -- --version 0.4.0
 #   curl -fsSL .../install.sh | bash -s -- --pre-release
 
@@ -45,7 +45,7 @@ while [[ $# -gt 0 ]]; do
 remo installer — installs remo-cli from PyPI via uv
 
 USAGE:
-    curl -fsSL https://get2know.io/remo/install.sh | bash
+    curl -fsSL https://get2knowio.github.io/remo/install.sh | bash
     curl -fsSL .../install.sh | bash -s -- [OPTIONS]
 
 OPTIONS:
@@ -55,7 +55,7 @@ OPTIONS:
 
 EXAMPLES:
     # Install latest stable
-    curl -fsSL https://get2know.io/remo/install.sh | bash
+    curl -fsSL https://get2knowio.github.io/remo/install.sh | bash
 
     # Install specific version
     curl -fsSL .../install.sh | bash -s -- --version 0.4.0

--- a/install.sh
+++ b/install.sh
@@ -2,7 +2,7 @@
 # remo installer — installs remo-cli from PyPI via uv
 #
 # Usage:
-#   curl -fsSL https://get2know.io/remo/install.sh | bash
+#   curl -fsSL https://get2knowio.github.io/remo/install.sh | bash
 #   curl -fsSL .../install.sh | bash -s -- --version 0.4.0
 #   curl -fsSL .../install.sh | bash -s -- --pre-release
 
@@ -45,7 +45,7 @@ while [[ $# -gt 0 ]]; do
 remo installer — installs remo-cli from PyPI via uv
 
 USAGE:
-    curl -fsSL https://get2know.io/remo/install.sh | bash
+    curl -fsSL https://get2knowio.github.io/remo/install.sh | bash
     curl -fsSL .../install.sh | bash -s -- [OPTIONS]
 
 OPTIONS:
@@ -55,7 +55,7 @@ OPTIONS:
 
 EXAMPLES:
     # Install latest stable
-    curl -fsSL https://get2know.io/remo/install.sh | bash
+    curl -fsSL https://get2knowio.github.io/remo/install.sh | bash
 
     # Install specific version
     curl -fsSL .../install.sh | bash -s -- --version 0.4.0


### PR DESCRIPTION
Two documented-but-broken bits of the installer's public interface, both found while auditing whether GitHub Pages still earns its keep (it does — Pages serves `docs/install.sh`, which is the opening command of all four provider guides).

## 1. The advertised URL 404s

The script's header comment and `--help` output both advertise:

```bash
curl -fsSL https://get2know.io/remo/install.sh | bash
```

That URL returns **404**. Pages serves this repo at `get2knowio.github.io` and the Pages config has `"cname": null`, so `get2know.io` was never wired to it. Anyone reading the script — or running `--help` — copied a dead link.

Fixed in **both** copies (root `install.sh` and `docs/install.sh`), three occurrences each.

## 2. `--branch` was never implemented

`CONTRIBUTING.md` documented the only way to test the installer as:

```bash
curl -fsSL .../install.sh | bash -s -- --branch my-feature
```

The argument parser handles only `--version`, `--pre-release`, and `--help`. `--branch` falls through to the `*)` case, which prints `Unknown option: --branch` and exits 1 — so that workflow failed immediately for any contributor who tried it.

Swapped for `--pre-release`, which the script actually supports and which serves the same "test a non-stable build" purpose. (Per maintainer direction: drop the `--branch` bit rather than implement it.)

## Verification

- `bash -n` clean on both scripts; `--help` renders the corrected URL
- `https://get2knowio.github.io/remo/install.sh` confirmed live: HTTP 200, `application/x-sh`
- `tests/unit/test_docs_structure.py` + `test_docs_examples.py`: 33 passed

## Not fixed here — flagging separately

`docs/install.sh` and the root `install.sh` have **diverged**, and the published one is the stale side. See the PR discussion; deliberately left out of this change since the fix has a design decision behind it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RcgFXhhdqGGzhk5Ardf9rk