### PR TITLE
fix(web): the push/adopt defect trio (#157, #158, #159)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -104,7 +104,7 @@ src/remo_cli/              # Python CLI package (src layout, hatchling build)
 │   ├── pairing.py              # In-memory, single-live, TTL'd pairing-code session manager replacing the static setup API token
 │   └── api/
 │       ├── hosts.py            # GET /api/v1/hosts, /sessions, POST /discovery/refresh
-│       ├── setup.py            # Token-gated /api/v1/setup/{status,identity,registry,verify} (011-web-adopt)
+│       ├── setup.py            # Pairing-gated /api/v1/setup/{status,identity,registry,verify,end} (011-web-adopt; `end` added by #158)
 │       ├── terminals.py        # POST/GET/DELETE /api/v1/terminals, WS /api/v1/terminals/{id}
 │       └── pairing.py          # POST /api/v1/pairing/{mint,end} — operator-auth-gated pairing-code control plane, outside the dormant setup router
 └── models/

--- a/docs/web-session-interface.md
+++ b/docs/web-session-interface.md
@@ -522,8 +522,11 @@ shows the "awaiting adoption" page. (Bare-metal `remo web serve` on a writable h
 now — see [How the service decides its mode](#how-the-service-decides-its-mode).)
 
 **2. Copy the pairing code and run `remo web push`.** On the awaiting-adoption page (or, after the
-first push, the dashboard's **Pair CLI to sync** affordance), click **Copy pairing code** — the code
-lands on your clipboard and is never displayed. On the workstation, inputs resolve in this order:
+first push, the dashboard's **Pair CLI to sync** affordance), the code is copied to your clipboard
+the moment it is minted. If the browser refuses that (page load is not a user gesture, so this is
+normal on the adopt page), the button says **Copy pairing code (required)** — click it, because the
+code is never displayed anywhere else. Note that every mint rotates the previous code, so always copy
+after the most recent one. On the workstation, inputs resolve in this order:
 
 | Input | Resolution order |
 |---|---|
@@ -852,7 +855,7 @@ interactive session (only `remo-host capabilities` is invoked, never `sessions a
 | Failure | What it means | Fix |
 |---|---|---|
 | `/api/v1/setup/*` returns `404` for everything | No pairing session is live — the surface is dormant (fail closed). | Open the awaiting-adoption page (through your SSO proxy) to mint a code; if the page can't mint, set `REMO_WEB_OPERATOR_AUTH` (`forward` + header, or `none` for loopback). |
-| `remo web push` (or the deprecated `adopt`) fails: "pairing code is no longer valid … dormant" | The code expired (idle TTL), was rotated by reopening the page, or was already used. | Reopen the awaiting-adoption page (or the dashboard's "Pair CLI to sync" affordance) for a fresh code and retry. |
+| `remo web push` (or the deprecated `adopt`) fails: "pairing code is no longer valid … dormant" | Usually the clipboard holds a code that a *later* mint rotated away — every open of the adopt page / "Pair CLI to sync" mints and rotates. Otherwise the code expired (idle TTL) or the session was already ended. | Click **Copy pairing code** after the most recent mint and paste that one. Only if the page is closed, reopen it for a fresh code — and copy it before retrying, since reopening rotates again. |
 | Mint page shows "you are not signed in" / `POST /pairing/mint` returns `403` | Forward auth is required but the request reached the service without the trusted identity header. | Ensure the request goes through the SSO proxy that injects `REMO_WEB_FORWARD_AUTH_HEADER`; verify the proxy sets and strips it. |
 | adopt fails: deployment "configured via read-only mounts" | The target is a bind-mount deployment (`mount_configured`) — its configuration is operator-provided and read-only, so adoption does not apply. | Update the mounted files instead, or deploy the adopted-mode service (writable state volume, no mounts) if you want adoption. |
 | adopt refuses: empty registry | Your local registry has no instances — pushing would wipe a previously adopted service (a classic wrong-workstation accident). | Register/sync instances first, or pass `--allow-empty` if wiping is intentional. |

--- a/docs/web-session-interface.md
+++ b/docs/web-session-interface.md
@@ -540,7 +540,9 @@ longer valid), verifies the payload version, fetches the service's public key an
 — per direct-access instance, with a bounded per-instance time budget so one slow instance delays
 only itself — `ssh-keyscan`s the host, verifies the scanned key against your own trusted
 `~/.ssh/known_hosts` record (`ssh-keygen -F`, so hashed known_hosts files work; the service itself
-**never** makes a trust-on-first-use decision), and installs the service's key into that instance's
+**never** makes a trust-on-first-use decision — if you have no record for the host, *you* are asked to
+confirm its SHA256 fingerprint, and confirming appends it to your `~/.ssh/known_hosts` so the
+authorization step that follows can connect), and installs the service's key into that instance's
 `~/.ssh/authorized_keys` idempotently. Instances that are **unchanged since the last successful push**
 (their registry entry matches the non-secret push cache for this `deployment_id`) skip that
 keyscan/authorize work and reuse their cached host-key lines — reported `unchanged`. New or changed
@@ -568,7 +570,7 @@ remediation where applicable:
 | `repaired` | The instance was skipped as `unchanged`, service-side verification then reported `auth_failed` for it, and the push re-keyscanned and re-authorized it. The service key had gone missing host-side; no action needed. |
 | `skipped_unreachable` | Keyscan failed or timed out — instance down or unreachable from the workstation. Not fatal; re-run push when it's back. |
 | `skipped_by_design` | SSM-routed instance (AWS-managed transport). No action needed — SSM instances are excluded from host-key and service-key push by design; see [Credentials and SSM](#credentials-and-ssm). |
-| `skipped_no_trust` | Your workstation has no trusted host-key record and the run was non-interactive (`--yes`), so nothing was pushed. Interactively, you're prompted to confirm the SHA256 fingerprint instead. |
+| `skipped_no_trust` | Your workstation has no trusted host-key record and the run was non-interactive (`--yes`), so nothing was pushed. Interactively, you're prompted to confirm the SHA256 fingerprint instead — confirming also records the key in your own `~/.ssh/known_hosts`, which the authorization step immediately needs. |
 | `security_flagged` | **The scanned host key does not match your workstation's trusted record.** Rendered prominently as a potential MITM warning; nothing is pushed for that instance and the rest of the run continues. Investigate before trusting; if the instance was legitimately rebuilt, `ssh-keygen -R <host>`, reconnect once to re-trust it, then re-run the push. |
 
 Removed instances (in the last push but no longer in the registry) get their own **Revocation**

--- a/docs/web-session-interface.md
+++ b/docs/web-session-interface.md
@@ -704,10 +704,11 @@ intervening external push, never warn.
 
 ### The setup API and pairing codes
 
-The CLI talks to four endpoints under `/api/v1/setup/*`
+The CLI talks to five endpoints under `/api/v1/setup/*`
 ([`setup-api.md`](../specs/012-web-adopt-pairing/contracts/setup-api.md)): `GET /status`,
-`GET /identity`, `PUT /registry`, `POST /verify`. The surface is **dormant** unless a pairing session
-is live; each route requires `Authorization: Bearer <pairing-code>`, compared in constant time:
+`GET /identity`, `PUT /registry`, `POST /verify`, `POST /end`. The surface is **dormant** unless a
+pairing session is live; each route requires `Authorization: Bearer <pairing-code>`, compared in
+constant time:
 
 - **No live session → the setup surface does not exist.** Every `/api/v1/setup/*` request gets a plain
   `404`, indistinguishable from an absent feature — fail closed. A session is live only while an
@@ -715,9 +716,17 @@ is live; each route requires `Authorization: Bearer <pairing-code>`, compared in
 - **Wrong/missing/expired code → the same dormant `404`** — never a distinguishable `401` that would
   reveal a session exists. The attempt is logged without the presented code; codes and `Authorization`
   headers are covered by the service's log redaction (`src/remo_cli/web/logging_config.py`).
-- **The session ends when the flow completes** (on the terminal `POST /verify`), and a code is
-  single-use per handoff — reopening the page mints a fresh one and invalidates the prior. There is no
-  rotation to manage: codes are ephemeral by construction.
+- **The session ends when the flow completes** — the CLI calls `POST /setup/end` once its push has
+  succeeded. `POST /verify` is repeatable and does *not* end the session: the push flow re-PUTs the
+  mirror and re-verifies after a self-heal, and ending on verify made both of those calls hit the
+  dormant `404`, so the repair never landed and the next push reported a phantom flap (#158). A
+  failed or aborted push deliberately leaves the session live, so you can retry with the same code.
+  A code is single-use per handoff — reopening the page mints a fresh one and invalidates the prior.
+  There is no rotation to manage: codes are ephemeral by construction.
+  *Version skew:* an older CLI against an upgraded service never calls `/setup/end`, so its session
+  lingers until the idle TTL expires (or the page-hide beacon fires); a newer CLI against an older
+  service gets a `404` from `/setup/end`, which it treats as "already ended" — that service had
+  ended the session on verify.
 
 ### Service key rotation
 

--- a/frontend/src/api/generated/openapi.json
+++ b/frontend/src/api/generated/openapi.json
@@ -526,6 +526,17 @@
         "title": "SessionsResponse",
         "type": "object"
       },
+      "SetupEndResponse": {
+        "properties": {
+          "ended": {
+            "default": true,
+            "title": "Ended",
+            "type": "boolean"
+          }
+        },
+        "title": "SetupEndResponse",
+        "type": "object"
+      },
       "SetupStatusResponse": {
         "properties": {
           "deployment_id": {
@@ -925,6 +936,25 @@
         "summary": "Get Sessions"
       }
     },
+    "/api/v1/setup/end": {
+      "post": {
+        "description": "`POST /api/v1/setup/end` -- end the pairing session (FR-007).\n\nThe explicit close the CLI calls once its flow has succeeded, returning the\nsetup surface to dormant. Previously `POST /verify` ended the session as a\nside effect, which broke the push flow's self-heal re-PUT + re-verify\n(#158); ending is now a step of its own, so any number of setup calls may\nprecede it.\n\nIdempotent: ending an already-ended session is a no-op \u2014 though a second\ncall from the *same* client sees the dormant 404 from the router gate, since\nits code is no longer live. The CLI treats that as success.\n\nThis lives on the setup router (not the browser-only `/api/v1/pairing/*`\ncontrol plane) deliberately: it is pairing-code-authenticated like the rest\nof the flow, and only `/api/v1/setup/*` is exempt from the Origin allowlist,\nwhich every Origin-less CLI request needs.",
+        "operationId": "post_end_api_v1_setup_end_post",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SetupEndResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          }
+        },
+        "summary": "Post End"
+      }
+    },
     "/api/v1/setup/identity": {
       "get": {
         "description": "`GET /api/v1/setup/identity` -- deployment id + public key.\n\nA mount-configured service has no service identity to authorize -> 409\n(FR-017). Otherwise the identity is generated on first call when absent\n(idempotent: an existing keypair is loaded, NEVER regenerated, FR-002).",
@@ -1018,7 +1048,7 @@
     },
     "/api/v1/setup/verify": {
       "post": {
-        "description": "`POST /api/v1/setup/verify` -- the existing check pass, as JSON.\n\nThin wrapper over `web.check.run_checks()` (research R4: verify reuses\nthe check module, never duplicates it), instance round-trips included.\nDeliberately a sync route: FastAPI executes it in a threadpool, so the\nup-to-~5s-per-unreachable-instance runtime never blocks the event loop.",
+        "description": "`POST /api/v1/setup/verify` -- the existing check pass, as JSON.\n\nThin wrapper over `web.check.run_checks()` (research R4: verify reuses\nthe check module, never duplicates it), instance round-trips included.\nDeliberately a sync route: FastAPI executes it in a threadpool, so the\nup-to-~5s-per-unreachable-instance runtime never blocks the event loop.\n\nVerify is repeatable and does NOT end the pairing session. It used to\n(it was the flow's last authenticated step), but the push flow's\nself-heal pass re-PUTs the mirror and re-verifies *after* that first\nverify, and both calls hit the now-dormant surface as a 404 \u2014 the repair\nnever landed and the local push cache was never written (#158). Ending is\nnow the client's explicit call: `POST /setup/end`.",
         "operationId": "post_verify_api_v1_setup_verify_post",
         "responses": {
           "200": {

--- a/frontend/src/api/generated/schema.d.ts
+++ b/frontend/src/api/generated/schema.d.ts
@@ -152,6 +152,41 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/v1/setup/end": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Post End
+         * @description `POST /api/v1/setup/end` -- end the pairing session (FR-007).
+         *
+         *     The explicit close the CLI calls once its flow has succeeded, returning the
+         *     setup surface to dormant. Previously `POST /verify` ended the session as a
+         *     side effect, which broke the push flow's self-heal re-PUT + re-verify
+         *     (#158); ending is now a step of its own, so any number of setup calls may
+         *     precede it.
+         *
+         *     Idempotent: ending an already-ended session is a no-op — though a second
+         *     call from the *same* client sees the dormant 404 from the router gate, since
+         *     its code is no longer live. The CLI treats that as success.
+         *
+         *     This lives on the setup router (not the browser-only `/api/v1/pairing/*`
+         *     control plane) deliberately: it is pairing-code-authenticated like the rest
+         *     of the flow, and only `/api/v1/setup/*` is exempt from the Origin allowlist,
+         *     which every Origin-less CLI request needs.
+         */
+        post: operations["post_end_api_v1_setup_end_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/v1/setup/identity": {
         parameters: {
             query?: never;
@@ -246,6 +281,13 @@ export interface paths {
          *     the check module, never duplicates it), instance round-trips included.
          *     Deliberately a sync route: FastAPI executes it in a threadpool, so the
          *     up-to-~5s-per-unreachable-instance runtime never blocks the event loop.
+         *
+         *     Verify is repeatable and does NOT end the pairing session. It used to
+         *     (it was the flow's last authenticated step), but the push flow's
+         *     self-heal pass re-PUTs the mirror and re-verifies *after* that first
+         *     verify, and both calls hit the now-dormant surface as a 404 — the repair
+         *     never landed and the local push cache was never written (#158). Ending is
+         *     now the client's explicit call: `POST /setup/end`.
          */
         post: operations["post_verify_api_v1_setup_verify_post"];
         delete?: never;
@@ -521,6 +563,14 @@ export interface components {
             /** Targets */
             targets: components["schemas"]["SessionTargetOut"][];
         };
+        /** SetupEndResponse */
+        SetupEndResponse: {
+            /**
+             * Ended
+             * @default true
+             */
+            ended: boolean;
+        };
         /** SetupStatusResponse */
         SetupStatusResponse: {
             /** Deployment Id */
@@ -766,6 +816,26 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["SessionsResponse"];
+                };
+            };
+        };
+    };
+    post_end_api_v1_setup_end_post: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["SetupEndResponse"];
                 };
             };
         };

--- a/frontend/src/components/AwaitingAdoption.css
+++ b/frontend/src/components/AwaitingAdoption.css
@@ -113,3 +113,10 @@
   background: var(--warn);
   animation: rpulse 1.5s ease infinite;
 }
+
+/* Mint-time copy was refused (no user gesture on page load): this button is the
+ * only way to obtain the code, which is never displayed. */
+.adopt-copy-btn-attention {
+  border-color: var(--accent);
+  background: var(--bg-btn-hover);
+}

--- a/frontend/src/components/AwaitingAdoption.test.tsx
+++ b/frontend/src/components/AwaitingAdoption.test.tsx
@@ -1,0 +1,107 @@
+// Copy-on-mint for the awaiting-adoption page (#159) plus the unmount session
+// end (#158).
+//
+// The code is never displayed, so a mint the operator doesn't copy is an
+// invisible dead end. There is no user gesture on page load, so the automatic
+// write is usually refused here — that path has to be loud, not quiet.
+
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { AwaitingAdoption } from "./AwaitingAdoption";
+
+const mintPairingCode = vi.fn();
+const endPairing = vi.fn();
+
+vi.mock("../api/client", async () => {
+  const actual = await vi.importActual<typeof import("../api/client")>("../api/client");
+  return {
+    ...actual,
+    mintPairingCode: (...args: unknown[]) => mintPairingCode(...args),
+    endPairing: () => endPairing(),
+  };
+});
+
+vi.mock("../state/health", () => ({
+  useHealth: () => ({ retry: vi.fn() }),
+}));
+
+const CODE = "hunter2-pairing-code";
+const writeText = vi.fn();
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mintPairingCode.mockResolvedValue({ code: CODE, expires_in: 900 });
+  writeText.mockResolvedValue(undefined);
+  Object.defineProperty(navigator, "clipboard", {
+    value: { writeText },
+    configurable: true,
+  });
+  document.execCommand = vi.fn().mockReturnValue(false);
+});
+
+async function ready() {
+  await waitFor(() => expect(screen.getByTestId("adopt-copy")).toBeEnabled());
+}
+
+describe("AwaitingAdoption", () => {
+  it("copies the minted code without waiting for a click", async () => {
+    render(<AwaitingAdoption />);
+
+    await ready();
+
+    expect(writeText).toHaveBeenCalledWith(CODE);
+    expect(screen.getByTestId("adopt-copy")).toHaveTextContent("Copied ✓");
+    expect(screen.getByText(/on your clipboard/i)).toBeInTheDocument();
+  });
+
+  it("makes the copy button required when the automatic write is refused", async () => {
+    // The expected first render in most browsers: page load is not a gesture.
+    writeText.mockRejectedValue(new Error("NotAllowedError"));
+    render(<AwaitingAdoption />);
+
+    await ready();
+
+    const button = screen.getByTestId("adopt-copy");
+    await waitFor(() => expect(button).toHaveTextContent("Copy pairing code (required)"));
+    expect(screen.getByText(/before you run the command/i)).toBeInTheDocument();
+
+    writeText.mockResolvedValue(undefined);
+    fireEvent.click(button);
+    await waitFor(() => expect(button).toHaveTextContent("Copied ✓"));
+  });
+
+  it("never renders the code into the DOM", async () => {
+    const { container } = render(<AwaitingAdoption />);
+
+    await ready();
+
+    expect(container.innerHTML).not.toContain(CODE);
+  });
+
+  it("ends the pairing session on unmount", async () => {
+    // Unmount is exactly when adoption completes, and since #158 the CLI's
+    // verify call no longer ends the session on our behalf.
+    const { unmount } = render(<AwaitingAdoption />);
+    await ready();
+
+    unmount();
+
+    expect(endPairing).toHaveBeenCalledTimes(1);
+  });
+
+  it("prompts to sign in instead of minting when operator auth refuses", async () => {
+    const { ApiError } = await vi.importActual<typeof import("../api/client")>("../api/client");
+    mintPairingCode.mockRejectedValue(
+      new ApiError({
+        code: "forbidden",
+        message: "nope",
+        remediation: "Sign in through your access proxy.",
+        retryable: false,
+      }),
+    );
+    render(<AwaitingAdoption />);
+
+    await waitFor(() => expect(screen.getByText(/not signed in/i)).toBeInTheDocument());
+    expect(writeText).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/src/components/AwaitingAdoption.tsx
+++ b/frontend/src/components/AwaitingAdoption.tsx
@@ -59,6 +59,11 @@ export function AwaitingAdoption(): JSX.Element {
   }, []);
 
   // Best-effort end on hide/unload (FR-004); idle TTL is the real backstop.
+  // Unmount ends the session too: this component unmounts exactly when adoption
+  // completes, and since #158 the CLI's verify call no longer ends it for us
+  // (the CLI's own POST /setup/end does, but an operator who never finished the
+  // flow — or a service that predates that route — would otherwise leave the
+  // session live for the full idle TTL).
   useEffect(() => {
     const onHide = () => {
       if (document.visibilityState === "hidden") endPairing();
@@ -68,6 +73,7 @@ export function AwaitingAdoption(): JSX.Element {
     return () => {
       window.removeEventListener("pagehide", endPairing);
       document.removeEventListener("visibilitychange", onHide);
+      endPairing();
     };
   }, []);
 

--- a/frontend/src/components/AwaitingAdoption.tsx
+++ b/frontend/src/components/AwaitingAdoption.tsx
@@ -4,9 +4,16 @@
 // Rendered by AppRoot instead of the console shell while GET /api/v1/ready
 // reports status "unconfigured". On mount it mints an ephemeral pairing code
 // (rotation-on-open, FR-003) and holds it ONLY in a non-rendered ref — the
-// value never enters the DOM (FR-015/FR-016). The operator clicks "Copy pairing
-// code", pastes it into `remo web adopt <origin>` on their workstation, and the
-// browser flips to the dashboard the moment adoption completes.
+// value never enters the DOM (FR-015/FR-016). The code goes straight to the
+// clipboard, the operator pastes it into `remo web adopt <origin>` on their
+// workstation, and the browser flips to the dashboard the moment adoption
+// completes.
+//
+// The clipboard write is attempted on mint (#159) — the code is never shown, so
+// "minted but not copied" is an invisible dead end. There is no user gesture on
+// page load, so most browsers refuse that write; the Copy button then carries a
+// non-expiring "(required)" state rather than a quiet fallback, because until
+// it is clicked the clipboard holds nothing usable.
 //
 // The code is fetched at runtime (never embedded in the served bundle) and the
 // page best-effort ends the session on hide/unload (FR-004); the server's idle
@@ -36,6 +43,20 @@ export function AwaitingAdoption(): JSX.Element {
   const [copyState, setCopyState] = useState<"idle" | "copied" | "failed">("idle");
   const copyResetHandle = useRef<ReturnType<typeof setTimeout>>();
 
+  const copyCode = useCallback(async () => {
+    clearTimeout(copyResetHandle.current);
+    const code = codeRef.current;
+    if (!code) {
+      setCopyState("failed");
+      return;
+    }
+    const ok = await copyText(code);
+    setCopyState(ok ? "copied" : "failed");
+    // Only the success state auto-clears; "copy required" must persist, since
+    // in that state the clipboard does NOT hold a usable code.
+    if (ok) copyResetHandle.current = setTimeout(() => setCopyState("idle"), 2_000);
+  }, []);
+
   // Mint on open (rotation-on-open, FR-003). The response code is stashed in the
   // ref; only expires_in / auth status drive rendering.
   useEffect(() => {
@@ -45,6 +66,7 @@ export function AwaitingAdoption(): JSX.Element {
         if (cancelled) return;
         codeRef.current = res.code;
         setMintState("ready");
+        void copyCode();
       })
       .catch((err) => {
         if (cancelled) return;
@@ -56,7 +78,7 @@ export function AwaitingAdoption(): JSX.Element {
     return () => {
       cancelled = true;
     };
-  }, []);
+  }, [copyCode]);
 
   // Best-effort end on hide/unload (FR-004); idle TTL is the real backstop.
   // Unmount ends the session too: this component unmounts exactly when adoption
@@ -84,19 +106,6 @@ export function AwaitingAdoption(): JSX.Element {
 
   useEffect(() => () => clearTimeout(copyResetHandle.current), []);
 
-  const onCopy = useCallback(() => {
-    const code = codeRef.current;
-    if (!code) {
-      setCopyState("failed");
-      return;
-    }
-    void copyText(code).then((ok) => {
-      setCopyState(ok ? "copied" : "failed");
-      clearTimeout(copyResetHandle.current);
-      copyResetHandle.current = setTimeout(() => setCopyState("idle"), 2_000);
-    });
-  }, []);
-
   return (
     <div className="adopt-page" data-testid="awaiting-adoption">
       <div className="adopt-card">
@@ -117,6 +126,16 @@ export function AwaitingAdoption(): JSX.Element {
           <code className="adopt-command-text">{command}</code>
         </div>
 
+        {mintState === "ready" && (
+          <p className="adopt-body">
+            {copyState === "copied"
+              ? "The pairing code is on your clipboard — paste it when the CLI prompts."
+              : copyState === "failed"
+                ? "Click “Copy pairing code” below before you run the command — this browser does not allow copying without a click, and the code is never shown."
+                : "The pairing code is never shown; copy it to your clipboard below."}
+          </p>
+        )}
+
         {mintState === "unauthorized" ? (
           <p className="adopt-body adopt-error">
             You are not signed in. This service mints pairing codes only for an authenticated
@@ -131,15 +150,17 @@ export function AwaitingAdoption(): JSX.Element {
             <span className="adopt-command-text">Pairing code ready (hidden)</span>
             <button
               type="button"
-              className="adopt-copy-btn"
-              onClick={onCopy}
+              className={
+                copyState === "failed" ? "adopt-copy-btn adopt-copy-btn-attention" : "adopt-copy-btn"
+              }
+              onClick={() => void copyCode()}
               disabled={mintState !== "ready"}
               data-testid="adopt-copy"
             >
               {mintState !== "ready" && "…"}
               {mintState === "ready" && copyState === "idle" && "Copy pairing code"}
               {mintState === "ready" && copyState === "copied" && "Copied ✓"}
-              {mintState === "ready" && copyState === "failed" && "Copy failed"}
+              {mintState === "ready" && copyState === "failed" && "Copy pairing code (required)"}
             </button>
           </div>
         )}

--- a/frontend/src/components/PairToSync.css
+++ b/frontend/src/components/PairToSync.css
@@ -69,3 +69,13 @@
 .pairsync-close:hover {
   color: var(--text, #e6e8ec);
 }
+
+/* The clipboard write is attempted on mint; when the browser refuses it, this
+ * button is the ONLY way to get a usable code (it is never displayed), so it
+ * has to read as required rather than optional. */
+.pairsync-btn-attention {
+  border-color: var(--accent, #6ea8fe);
+  background: var(--bg-btn-hover, #2c2f36);
+  color: var(--text-1, #e6e8ec);
+  font-weight: 600;
+}

--- a/frontend/src/components/PairToSync.test.tsx
+++ b/frontend/src/components/PairToSync.test.tsx
@@ -1,0 +1,119 @@
+// Copy-on-mint for the Settings re-sync affordance (#159).
+//
+// The pairing code is deliberately never displayed, so the clipboard IS the
+// only channel. Minting used to rotate the previous code while only an explicit
+// Copy click wrote the clipboard, which left a dead code there — invisibly.
+
+import { act, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { PairToSync } from "./PairToSync";
+
+const mintPairingCode = vi.fn();
+const endPairing = vi.fn();
+
+vi.mock("../api/client", async () => {
+  const actual = await vi.importActual<typeof import("../api/client")>("../api/client");
+  return {
+    ...actual,
+    mintPairingCode: (...args: unknown[]) => mintPairingCode(...args),
+    endPairing: () => endPairing(),
+  };
+});
+
+const CODE = "hunter2-pairing-code";
+const writeText = vi.fn();
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mintPairingCode.mockResolvedValue({ code: CODE, expires_in: 900 });
+  writeText.mockResolvedValue(undefined);
+  Object.defineProperty(navigator, "clipboard", {
+    value: { writeText },
+    configurable: true,
+  });
+  // The legacy execCommand fallback must not silently "succeed" in jsdom.
+  document.execCommand = vi.fn().mockReturnValue(false);
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+async function open() {
+  fireEvent.click(screen.getByTestId("pair-to-sync"));
+  await waitFor(() => expect(screen.getByTestId("pairsync-copy")).toBeEnabled());
+}
+
+describe("PairToSync", () => {
+  it("copies the freshly minted code without waiting for a click", async () => {
+    render(<PairToSync />);
+
+    await open();
+
+    expect(writeText).toHaveBeenCalledWith(CODE);
+    expect(screen.getByTestId("pairsync-copy")).toHaveTextContent("Copied ✓");
+    expect(screen.getByText(/on your clipboard now/i)).toBeInTheDocument();
+  });
+
+  it("demands an explicit copy when the browser refuses the automatic one", async () => {
+    writeText.mockRejectedValue(new Error("NotAllowedError"));
+    render(<PairToSync />);
+
+    await open();
+
+    const button = screen.getByTestId("pairsync-copy");
+    expect(button).toHaveTextContent("Copy pairing code (required)");
+    expect(screen.getByText(/refused the automatic copy/i)).toBeInTheDocument();
+
+    // The explicit click is the recovery path and must still work.
+    writeText.mockResolvedValue(undefined);
+    fireEvent.click(button);
+    await waitFor(() => expect(button).toHaveTextContent("Copied ✓"));
+  });
+
+  it("never carries a stale 'Copied ✓' across a re-mint", async () => {
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+    render(<PairToSync />);
+
+    await open();
+    expect(screen.getByTestId("pairsync-copy")).toHaveTextContent("Copied ✓");
+
+    // Close and reopen: the second mint ROTATES the first code away, so the
+    // success state from the first must not survive into it.
+    fireEvent.click(screen.getByTestId("pair-to-sync"));
+    let resolveMint: (value: unknown) => void = () => {};
+    mintPairingCode.mockReturnValue(new Promise((resolve) => (resolveMint = resolve)));
+    fireEvent.click(screen.getByTestId("pair-to-sync"));
+
+    expect(screen.getByTestId("pairsync-copy")).toHaveTextContent("Minting…");
+    // Any pending "Copied ✓" reset timer from the first mint is cleared, so it
+    // cannot fire mid-flight and desync the label either.
+    act(() => vi.advanceTimersByTime(5_000));
+    expect(screen.getByTestId("pairsync-copy")).toHaveTextContent("Minting…");
+
+    await act(async () => {
+      resolveMint({ code: "second-code", expires_in: 900 });
+    });
+    await waitFor(() => expect(writeText).toHaveBeenLastCalledWith("second-code"));
+  });
+
+  it("never renders the code into the DOM", async () => {
+    const { container } = render(<PairToSync />);
+
+    await open();
+
+    expect(container.innerHTML).not.toContain(CODE);
+  });
+
+  it("ends the pairing session on close and on unmount while open", async () => {
+    const { unmount } = render(<PairToSync />);
+
+    await open();
+    fireEvent.click(screen.getByText("Done"));
+    expect(endPairing).toHaveBeenCalledTimes(1);
+
+    await open();
+    unmount();
+    expect(endPairing).toHaveBeenCalledTimes(2);
+  });
+});

--- a/frontend/src/components/PairToSync.tsx
+++ b/frontend/src/components/PairToSync.tsx
@@ -2,10 +2,18 @@
 // Settings once the service has been adopted.
 //
 // Mints a fresh pairing code (origin="resync") through the same lifecycle and
-// operator-auth gate as the awaiting-adoption page, and offers a Copy button.
-// The code value is held only in a ref and is NEVER rendered into the DOM
-// (FR-015/FR-016); opening mints, closing (or unmounting, e.g. leaving Settings)
-// ends the session best-effort (the idle TTL is the backstop).
+// operator-auth gate as the awaiting-adoption page. The code value is held only
+// in a ref and is NEVER rendered into the DOM (FR-015/FR-016); opening mints,
+// closing (or unmounting, e.g. leaving Settings) ends the session best-effort
+// (the idle TTL is the backstop).
+//
+// The clipboard is written as soon as the code is minted (#159). Every open
+// mints a code that ROTATES the previous one, so a mint the operator didn't
+// follow with a Copy click left a dead code in their clipboard — invisible,
+// because the code is never displayed, and unrecoverable by reopening the page
+// (that rotates again). Opening is a user gesture, so the write is normally
+// permitted; if it is refused the Copy button becomes a loud, non-expiring
+// "(required)" affordance instead of a quiet fallback.
 
 import { useCallback, useEffect, useRef, useState } from "react";
 import { ApiError, endPairing, mintPairingCode } from "../api/client";
@@ -32,14 +40,33 @@ export function PairToSync(): JSX.Element {
     endPairing();
   }, []);
 
+  const copyCode = useCallback(async () => {
+    clearTimeout(copyResetHandle.current);
+    const code = codeRef.current;
+    if (!code) {
+      setCopyState("failed");
+      return;
+    }
+    const ok = await copyText(code);
+    setCopyState(ok ? "copied" : "failed");
+    // Only the success state auto-clears. "Copy required" must stay on screen
+    // until the operator acts on it — this is the state where the clipboard
+    // does NOT hold a usable code.
+    if (ok) copyResetHandle.current = setTimeout(() => setCopyState("idle"), 2_000);
+  }, []);
+
   const openAndMint = useCallback(() => {
     setOpen(true);
     setMintState("minting");
+    // Clear any pending "Copied ✓" reset so it can never outlive the code it
+    // referred to: this mint rotates that code away.
+    clearTimeout(copyResetHandle.current);
     setCopyState("idle");
     void mintPairingCode("resync")
       .then((res) => {
         codeRef.current = res.code;
         setMintState("ready");
+        void copyCode();
       })
       .catch((err) => {
         codeRef.current = null;
@@ -47,7 +74,7 @@ export function PairToSync(): JSX.Element {
           err instanceof ApiError && err.code === "forbidden" ? "unauthorized" : "error",
         );
       });
-  }, []);
+  }, [copyCode]);
 
   useEffect(() => () => clearTimeout(copyResetHandle.current), []);
   // End the pairing session if Settings is closed with a code still live.
@@ -55,19 +82,6 @@ export function PairToSync(): JSX.Element {
     if (openRef.current) {
       endPairing();
     }
-  }, []);
-
-  const onCopy = useCallback(() => {
-    const code = codeRef.current;
-    if (!code) {
-      setCopyState("failed");
-      return;
-    }
-    void copyText(code).then((ok) => {
-      setCopyState(ok ? "copied" : "failed");
-      clearTimeout(copyResetHandle.current);
-      copyResetHandle.current = setTimeout(() => setCopyState("idle"), 2_000);
-    });
   }, []);
 
   return (
@@ -86,7 +100,10 @@ export function PairToSync(): JSX.Element {
         <div className="pairsync-popover" role="dialog" aria-label="Pair CLI to sync">
           <p className="pairsync-body">
             Run <code>remo web push &lt;url&gt;</code> on your workstation and paste this code when
-            prompted. The code is copied to your clipboard — it is never shown.
+            prompted. The code is never shown — it goes straight to your clipboard.
+            {copyState === "copied" && " It is on your clipboard now."}
+            {copyState === "failed" &&
+              " This browser refused the automatic copy, so you must click Copy below before pasting."}
           </p>
 
           {mintState === "unauthorized" ? (
@@ -98,15 +115,17 @@ export function PairToSync(): JSX.Element {
           ) : (
             <button
               type="button"
-              className="pairsync-btn"
-              onClick={onCopy}
+              className={
+                copyState === "failed" ? "pairsync-btn pairsync-btn-attention" : "pairsync-btn"
+              }
+              onClick={() => void copyCode()}
               disabled={mintState !== "ready"}
               data-testid="pairsync-copy"
             >
               {mintState !== "ready" && "Minting…"}
               {mintState === "ready" && copyState === "idle" && "Copy pairing code"}
               {mintState === "ready" && copyState === "copied" && "Copied ✓"}
-              {mintState === "ready" && copyState === "failed" && "Copy failed"}
+              {mintState === "ready" && copyState === "failed" && "Copy pairing code (required)"}
             </button>
           )}
 

--- a/specs/012-web-adopt-pairing/contracts/pairing-api.md
+++ b/specs/012-web-adopt-pairing/contracts/pairing-api.md
@@ -53,6 +53,11 @@ capability.
 The idle TTL remains the authoritative backstop; the service never depends on
 this call for correctness (FR-004).
 
+**Browser-only.** The CLI never calls any `/api/v1/pairing/*` route: it has no
+Origin header, and only `/api/v1/setup/*` is exempt from the Origin allowlist,
+so a CLI call here would be refused. The CLI ends its session through
+`POST /api/v1/setup/end` instead (see `setup-api.md`).
+
 ---
 
 ## Operator-auth configuration (mint gating)

--- a/specs/012-web-adopt-pairing/contracts/setup-api.md
+++ b/specs/012-web-adopt-pairing/contracts/setup-api.md
@@ -23,13 +23,22 @@ Notes:
 - Dormancy is **the default state**: the surface exists only while an operator
   is on the adopt page / re-sync affordance (a live session). SC-001: with no
   session live, 100% of setup requests return the dormant `404`.
-- Completing the flow **ends the session** (FR-007): because the CLI runs
-  `status → identity → PUT /registry → POST /verify` on one code, the session is
-  ended by the **`POST /verify`** handler (the terminal authenticated step), not
-  by the `PUT` — ending on the `PUT` would sever the in-flight `verify` call.
-  The surface returns to dormant immediately after the flow (US2 scenario 3, US4
-  scenario 2); a client that skips `verify` falls back to the idle-TTL / page-hide
-  backstop.
+- Completing the flow **ends the session** (FR-007) via an explicit
+  **`POST /setup/end`** (pairing-code-gated like every other setup route, and
+  inside the Origin-exempt `/api/v1/setup/*` prefix an Origin-less CLI request
+  needs). The CLI calls it once its flow has succeeded; a failed or aborted flow
+  deliberately leaves the session live so a retry can reuse the same code.
+  `POST /verify` does **not** end the session and may be called more than once:
+  the push flow's self-heal pass re-PUTs the mirror and re-verifies *after* the
+  first verify, and ending there made both of those calls hit the dormant `404`,
+  stranding the repair and the workstation's push cache (#158). The surface
+  returns to dormant immediately after `/setup/end` (US2 scenario 3, US4
+  scenario 2); a client that never calls it falls back to the idle-TTL /
+  page-hide backstop.
+- `POST /setup/end` -> `200 {"ended": true}`. Idempotent in effect, though a
+  second call from the same client sees the dormant `404` (its code is no longer
+  live) — the CLI treats that, and a `404` from a service predating the route,
+  as success.
 - The presented code is **never logged** (FR-016); an auth failure is logged
   with route/method context only, exactly as 011 logged its failures minus the
   credential.

--- a/specs/012-web-adopt-pairing/data-model.md
+++ b/specs/012-web-adopt-pairing/data-model.md
@@ -27,7 +27,7 @@ One live record for a single adoption/push handoff. At most one exists at a time
 LIVE   --successful setup call (touch)--> LIVE  (last_activity reset)
 LIVE   --mint() again (rotation)--> LIVE (new code; prior code invalid)   [FR-003]
 LIVE   --idle > ttl_s--> (none)  (lazy expiry on is_live/authenticate)     [FR-002]
-LIVE   --successful adoption/push apply--> (none)  (end)                   [FR-007]
+LIVE   --client POST /setup/end (flow succeeded)--> (none)  (end)          [FR-007]
 LIVE   --pagehide sendBeacon /pairing/end--> (none)  (best-effort)         [FR-004]
 LIVE   --process restart--> (none)  (never persisted)                      [FR-008]
 ```

--- a/specs/012-web-adopt-pairing/spec.md
+++ b/specs/012-web-adopt-pairing/spec.md
@@ -281,9 +281,11 @@ after the affordance closes.
   expired/rotated session MUST receive the same dormant `404`, never a
   distinguishable `401` that would reveal a session exists. (Rationale: a dormant
   surface must be indistinguishable from an absent one, mirroring 011 FR-021.)
-- **FR-007**: Successful adoption/push (a registry apply that transitions or
-  refreshes configured state) MUST end the pairing session so the surface returns
-  to dormant.
+- **FR-007**: A successful adoption/push MUST end the pairing session so the
+  surface returns to dormant. The client ends it explicitly (`POST /setup/end`)
+  once the whole flow has succeeded; no other setup route may end it as a side
+  effect — in particular `POST /verify` MUST remain repeatable, since the push
+  flow re-PUTs and re-verifies after a self-heal (#158).
 - **FR-008**: Pairing sessions and codes MUST NOT be persisted to disk; a process
   restart MUST drop all sessions.
 

--- a/specs/012-web-adopt-pairing/tasks.md
+++ b/specs/012-web-adopt-pairing/tasks.md
@@ -67,7 +67,7 @@ instances, and confirm the dashboard shows all instances with working terminals.
 
 ### Tests for User Story 1
 
-- [X] T009 [P] [US1] Integration coverage in `tests/integration/test_web_adopt_e2e.py` (migrated from 011): boots a live `remo web serve` in the network-restricted posture, mints a code via `POST /pairing/mint`, runs the adopt orchestration, and asserts identity→registry→verify all succeed with the code as bearer and the session ends on the terminal verify (FR-007).
+- [X] T009 [P] [US1] Integration coverage in `tests/integration/test_web_adopt_e2e.py` (migrated from 011): boots a live `remo web serve` in the network-restricted posture, mints a code via `POST /pairing/mint`, runs the adopt orchestration, and asserts identity→registry→verify all succeed with the code as bearer and the session ends when the CLI calls `POST /setup/end` (FR-007; verify itself is repeatable and no longer ends it — #158).
 - [X] T010 [P] [US1] Unit test `tests/unit/core/test_web_adopt_code.py`: adopt sends the pasted code as `Authorization: Bearer`, and a dormant `404` from a setup call maps to the "reopen the adopt page for a fresh code" message (FR-020).
 
 ### Implementation for User Story 1

--- a/src/remo_cli/core/web_adopt.py
+++ b/src/remo_cli/core/web_adopt.py
@@ -244,6 +244,16 @@ class SetupApiClient:
     def post_verify(self) -> dict[str, Any]:
         return self._request("POST", "/api/v1/setup/verify", timeout=self.verify_timeout)
 
+    def post_end(self) -> dict[str, Any]:
+        """End the pairing session, returning the setup surface to dormant.
+
+        Called once the flow has succeeded (#158). Verify used to end the
+        session itself, which severed the self-heal pass that runs after it —
+        so the close is now an explicit step. An older service without this
+        route answers 404, which the caller treats as "already ended".
+        """
+        return self._request("POST", "/api/v1/setup/end")
+
     # -- internals ----------------------------------------------------------
 
     def _request(
@@ -1638,6 +1648,22 @@ def render_verification(
         print_warning("Some service-side checks failed (see above).")
 
 
+def _end_session_best_effort(client: SetupApiClient) -> None:
+    """Return the service's setup surface to dormant (#158, FR-007).
+
+    Best effort by design: the flow has already succeeded and the mirror is
+    applied, so a failure to close cannot be allowed to fail the push. Only
+    `SetupApiError` is swallowed — a 404 from a service that predates
+    `/setup/end` (or one that already ended the session on verify) is the
+    expected skew case. The idle TTL and the page-hide beacon remain the
+    backstop either way.
+    """
+    try:
+        client.post_end()
+    except SetupApiError:
+        pass
+
+
 def _run_flow_maybe_tunneled(
     url: str,
     token: str,
@@ -1647,12 +1673,21 @@ def _run_flow_maybe_tunneled(
 ) -> AdoptResult:
     """Run *flow* against a `SetupApiClient`, optionally through a `--via` SSH
     tunnel. A 400/403 seen through the tunnel is remapped to Host-allowlist
-    guidance (FR-018); *verb* ("adopting"/"pushing") tailors that message."""
+    guidance (FR-018); *verb* ("adopting"/"pushing") tailors that message.
+
+    On success — and only on success — the pairing session is ended. A failed
+    or aborted flow deliberately leaves it live so the operator can retry with
+    the same code instead of minting (and rotating to) a new one.
+    """
     if via:
         print_info(f"Opening SSH tunnel via {via}...")
         with open_via_tunnel(via, url) as tunneled_url:
+            client = SetupApiClient(tunneled_url, token)
             try:
-                return flow(SetupApiClient(tunneled_url, token))
+                result = flow(client)
+                # Inside the `with`: the tunnel must still be up for the call.
+                _end_session_best_effort(client)
+                return result
             except SetupApiError as e:
                 if e.status in (400, 403):
                     raise AdoptError(
@@ -1662,7 +1697,10 @@ def _run_flow_maybe_tunneled(
                         "127.0.0.1."
                     ) from e
                 raise
-    return flow(SetupApiClient(url, token))
+    client = SetupApiClient(url, token)
+    result = flow(client)
+    _end_session_best_effort(client)
+    return result
 
 
 # ---------------------------------------------------------------------------
@@ -1865,15 +1903,39 @@ def _push_flow(
     # the instances the fast path skipped, then re-PUT (a repaired instance may
     # carry rescanned host-key lines) and re-verify so the report reflects the
     # repaired state rather than the state that triggered it.
+    #
+    # Everything from here on is best-effort: the mirror is already applied, so
+    # a failure in the repair round must not abort the run before step 7 writes
+    # the cache. Losing that write is what turned #158 into a phantom
+    # "another workstation" flap on the following push.
     repaired = _repair_auth_failures(
         outcomes, verify, host_keys, interactive=interactive, public_key=public_key
     )
+    repair_put_failed = False
     if repaired:
         payload = build_adoption_payload(hosts, host_keys, allow_empty=True)
         payload["workstation"] = _workstation_label()
-        applied = client.put_registry(payload, allow_empty=allow_empty)
-        print_info("Re-running service-side verification after repair...")
-        verify = client.post_verify()
+        try:
+            # `applied` is reassigned ONLY on success: the service bumps the
+            # mirror generation on every PUT, so caching a generation from a
+            # failed call would mis-arm the next push's flap detection.
+            applied = client.put_registry(payload, allow_empty=allow_empty)
+        except SetupApiError as e:
+            repair_put_failed = True
+            print_warning(
+                f"Could not re-push the mirror after repair: {e}. The repaired "
+                "instances will be re-scanned and re-authorized in full on the "
+                "next `remo web push`."
+            )
+        else:
+            print_info("Re-running service-side verification after repair...")
+            try:
+                verify = client.post_verify()
+            except SetupApiError as e:
+                print_warning(
+                    f"Could not re-run service-side verification after repair: {e}. "
+                    "The report below predates the repair."
+                )
 
     # Step 7: only after a successful PUT, rewrite the delta cache for this
     # deployment (removed instances drop out; skipped/flagged instances get no
@@ -1895,6 +1957,14 @@ def _push_flow(
         still_failing = auth_failed_labels(verify)
         for outcome in outcomes:
             if outcome.label in still_failing:
+                cache_entries.pop(outcome.host.name, None)
+            elif repair_put_failed and outcome.outcome == OUTCOME_REPAIRED:
+                # The service never received this instance's rescanned host-key
+                # lines, so it is not really in sync. Caching it would re-arm
+                # the `unchanged` fast path that hid the breakage in the first
+                # place. (When only the re-verify failed, the stale report's
+                # own auth_failed labels prune these above — conservative on
+                # purpose: an instance we cannot confirm is never cached.)
                 cache_entries.pop(outcome.host.name, None)
         _update_push_cache(deployment_id, cache_entries, new_generation)
 

--- a/src/remo_cli/core/web_adopt.py
+++ b/src/remo_cli/core/web_adopt.py
@@ -535,11 +535,17 @@ def _persist_confirmed_host_keys(lines: list[str], trusted_store: Path) -> str |
 
     Deliberately pure Python file I/O — no ``ssh-keygen``/``ssh-keyscan``
     subprocess — so the write cannot fail on a workstation without those tools.
+
+    The warning strings name the store only through the ``OSError``, which
+    already carries the offending path, rather than interpolating
+    *trusted_store* directly: CodeQL's clear-text-logging heuristic reads a
+    "trusted"-named value flowing into output as a leaked secret, and the caller
+    has just printed the store's path anyway.
     """
     try:
         existing = trusted_store.read_text() if trusted_store.exists() else ""
     except OSError as e:
-        return f"could not read {trusted_store} to record the confirmed host key: {e}"
+        return f"could not read the known_hosts file to record the confirmed host key: {e}"
 
     already = {line.strip() for line in existing.splitlines() if line.strip()}
     # Verbatim comparison: a record may already exist for *other* key types
@@ -561,7 +567,7 @@ def _persist_confirmed_host_keys(lines: list[str], trusted_store: Path) -> str |
             fh.write(payload)
     except OSError as e:
         return (
-            f"could not record the confirmed host key in {trusted_store}: {e}. "
+            f"could not record the confirmed host key in known_hosts: {e}. "
             "Authorizing the service key over ssh will likely fail until this "
             "host is trusted locally."
         )

--- a/src/remo_cli/core/web_adopt.py
+++ b/src/remo_cli/core/web_adopt.py
@@ -312,18 +312,21 @@ class SetupApiClient:
 
         if status == 401:
             return SetupAuthError(
-                "the service returned HTTP 401. Reopen the adopt page (or the "
-                "dashboard's re-sync affordance) to mint a fresh pairing code, "
-                "then retry.",
+                "the service returned HTTP 401 — this pairing code was not "
+                "accepted. Codes rotate on every mint, so make sure you clicked "
+                "'Copy pairing code' after the most recent mint, and paste that "
+                "code. If in doubt, mint a fresh code and copy it before retrying.",
                 status=401,
             )
         if status == 404:
             return SetupNotFoundError(
                 f"the pairing code is no longer valid — the setup surface at "
-                f"{self.base_url} is dormant (HTTP 404). The code may have expired "
-                "or been rotated by a page reopen (or the URL is wrong). Reopen "
-                "the adopt page (or the dashboard's re-sync affordance) to mint a "
-                "fresh code, then retry.",
+                f"{self.base_url} is dormant (HTTP 404). Every mint rotates the "
+                "previous code, so the usual cause is a code copied before a "
+                "later mint: click 'Copy pairing code' after the most recent "
+                "mint and paste that one. The code may also have expired, or "
+                "the URL may be wrong. If the page is no longer open, reopen it "
+                "for a fresh code — and copy it before retrying.",
                 status=404,
             )
         if status == 409:

--- a/src/remo_cli/core/web_adopt.py
+++ b/src/remo_cli/core/web_adopt.py
@@ -506,6 +506,55 @@ def _render_fingerprints(lines: list[str]) -> str:
             pass
 
 
+def _persist_confirmed_host_keys(lines: list[str], trusted_store: Path) -> str | None:
+    """Append interactively-confirmed *lines* to the workstation's known_hosts.
+
+    Issue #157: confirming a fingerprint used to affect only the *push payload*
+    (the service's known_hosts). The workstation's own store was left untouched,
+    so the very next step — :func:`authorize_service_key`, which runs ssh with
+    ``BatchMode=yes`` — died with "Host key verification failed" and the instance
+    was reported unreachable. The operator had just said "yes, I trust this key";
+    recording that answer locally is what makes the rest of the push work.
+
+    Returns ``None`` on success (including the no-op case) or a warning string
+    the caller should print. A write failure is never fatal: the scanned lines
+    are still valid for the payload, so trust is reported either way.
+
+    Deliberately pure Python file I/O — no ``ssh-keygen``/``ssh-keyscan``
+    subprocess — so the write cannot fail on a workstation without those tools.
+    """
+    try:
+        existing = trusted_store.read_text() if trusted_store.exists() else ""
+    except OSError as e:
+        return f"could not read {trusted_store} to record the confirmed host key: {e}"
+
+    already = {line.strip() for line in existing.splitlines() if line.strip()}
+    # Verbatim comparison: a record may already exist for *other* key types
+    # (the fall-through above), in which case only the missing lines are added.
+    missing = [line for line in lines if line.strip() not in already]
+    if not missing:
+        return None
+
+    payload = "".join(f"{line}\n" for line in missing)
+    if existing and not existing.endswith("\n"):
+        payload = "\n" + payload
+
+    try:
+        trusted_store.parent.mkdir(mode=0o700, parents=True, exist_ok=True)
+        # os.open with mode 0600 so a *newly created* known_hosts is never
+        # briefly world-readable (a create-then-chmod would race).
+        fd = os.open(trusted_store, os.O_WRONLY | os.O_APPEND | os.O_CREAT, 0o600)
+        with os.fdopen(fd, "a") as fh:
+            fh.write(payload)
+    except OSError as e:
+        return (
+            f"could not record the confirmed host key in {trusted_store}: {e}. "
+            "Authorizing the service key over ssh will likely fail until this "
+            "host is trusted locally."
+        )
+    return None
+
+
 def scan_and_verify_host_key(
     hostname: str,
     *,
@@ -535,6 +584,11 @@ def scan_and_verify_host_key(
         interactive TTY           -> SHA256 fingerprint confirmation
                                      (accept -> ``trusted``, decline -> ``no_trust``)
         non-interactive           -> ``no_trust``
+
+    Side effect, confirmation branch only: an accepted fingerprint is also
+    appended to *known_hosts_file* (see :func:`_persist_confirmed_host_keys`).
+    Nothing else here writes to the workstation's trust store — a match needs no
+    write, and mismatch/decline/non-interactive must not create one.
     """
     trusted_store = known_hosts_file or (Path.home() / ".ssh" / "known_hosts")
     if confirm_fn is None:
@@ -616,6 +670,11 @@ def scan_and_verify_host_key(
     print("Scanned key fingerprints:")
     print(_render_fingerprints(scanned_lines))
     if confirm_fn(f"Trust these keys for {lookup_key} and include them in the push?"):
+        # Record the answer locally too (#157) — the authorize step that follows
+        # runs ssh with BatchMode=yes and fails outright on an untrusted host.
+        warning = _persist_confirmed_host_keys(scanned_lines, trusted_store)
+        if warning:
+            print_warning(warning)
         return HostKeyScan(
             "trusted", lines=scanned_lines, detail="fingerprint confirmed interactively"
         )
@@ -1151,14 +1210,26 @@ def _process_instance(
 
         ok, error = authorize_service_key(host, public_key)
         if not ok:
+            if "Host key verification failed" in (error or ""):
+                # Name the real cause instead of sending the operator to check a
+                # host that is demonstrably reachable (#157).
+                lookup_key = known_hosts_lookup_key(host.host, host.ssh_port)
+                remediation = (
+                    f"There is no trusted host key for {lookup_key} in this "
+                    "workstation's ~/.ssh/known_hosts, so ssh refused to connect. "
+                    f"Connect once (e.g. `remo shell {host.name}`) to trust it, "
+                    "then re-run `remo web push`."
+                )
+            else:
+                remediation = (
+                    f"Check you can `ssh {host.user}@{host.host}` from this "
+                    "workstation, then re-run `remo web push`."
+                )
             return InstanceOutcome(
                 host,
                 OUTCOME_SKIPPED_UNREACHABLE,
                 detail=f"host key verified, but authorizing the service key failed: {error}",
-                remediation=(
-                    f"Check you can `ssh {host.user}@{host.host}` from this "
-                    "workstation, then re-run `remo web push`."
-                ),
+                remediation=remediation,
             )
 
         host_keys[host.name] = scan.lines

--- a/src/remo_cli/providers/added.py
+++ b/src/remo_cli/providers/added.py
@@ -200,6 +200,8 @@ def verify_reachable(host: KnownHost, timeout: int = 10) -> tuple[bool, str | No
     key verification failed" — wrongly reporting a reachable, never-before-seen
     host as unreachable. It deliberately does not pre-seed ``~/.ssh/known_hosts``
     (the first real ``remo shell`` still follows normal host-key behavior).
+    Contrast ``core/web_adopt.py``'s fingerprint-confirmation branch, which
+    *does* write known_hosts — there the operator explicitly approved the key.
     """
     from remo_cli.core.ssh import build_ssh_opts
 

--- a/src/remo_cli/web/api/setup.py
+++ b/src/remo_cli/web/api/setup.py
@@ -35,6 +35,10 @@ T011/T012/T013), all inheriting the router-level token dependency:
 - ``POST /verify`` -- JSON wrapper around `web.check.run_checks()` with
   instance checks included (sync route: FastAPI runs it in a threadpool, so
   the ~5s-per-unreachable-instance round-trips never block the event loop).
+  Repeatable: a flow may verify, repair, re-PUT and verify again.
+- ``POST /end`` -- end the pairing session, returning the surface to dormant
+  (FR-007). Explicit rather than a side effect of ``/verify``, which broke the
+  push flow's self-heal re-PUT + re-verify (#158).
 """
 
 from __future__ import annotations
@@ -203,6 +207,12 @@ class VerifyCheckOut(BaseModel):
 class VerifyResponse(BaseModel):
     results: list[VerifyCheckOut]
     all_passed: bool
+
+
+class SetupEndResponse(BaseModel):
+    #: Always true — ending is idempotent, so "there was nothing to end" and
+    #: "a live session was ended" are the same successful outcome.
+    ended: bool = True
 
 
 # ---------------------------------------------------------------------------
@@ -579,17 +589,16 @@ def post_verify(request: Request) -> VerifyResponse:
     the check module, never duplicates it), instance round-trips included.
     Deliberately a sync route: FastAPI executes it in a threadpool, so the
     up-to-~5s-per-unreachable-instance runtime never blocks the event loop.
+
+    Verify is repeatable and does NOT end the pairing session. It used to
+    (it was the flow's last authenticated step), but the push flow's
+    self-heal pass re-PUTs the mirror and re-verifies *after* that first
+    verify, and both calls hit the now-dormant surface as a 404 — the repair
+    never landed and the local push cache was never written (#158). Ending is
+    now the client's explicit call: `POST /setup/end`.
     """
     settings = _get_settings(request)
     results = web_check.run_checks(settings, include_instances=True)
-
-    # The verification pass is the terminal authenticated step of both the
-    # adopt and push flows (status -> identity -> registry -> verify). Ending
-    # the session here returns the setup surface to dormant once the flow
-    # completes (FR-007) without severing the in-flight verify call that ending
-    # on the registry PUT would have broken. If a client skips verify, the idle
-    # TTL / page-hide beacon remain the backstop.
-    request.app.state.pairing_manager.end()
 
     return VerifyResponse(
         results=[
@@ -603,3 +612,26 @@ def post_verify(request: Request) -> VerifyResponse:
         ],
         all_passed=web_check.all_passed(results),
     )
+
+
+@router.post("/end", response_model=SetupEndResponse)
+def post_end(request: Request) -> SetupEndResponse:
+    """`POST /api/v1/setup/end` -- end the pairing session (FR-007).
+
+    The explicit close the CLI calls once its flow has succeeded, returning the
+    setup surface to dormant. Previously `POST /verify` ended the session as a
+    side effect, which broke the push flow's self-heal re-PUT + re-verify
+    (#158); ending is now a step of its own, so any number of setup calls may
+    precede it.
+
+    Idempotent: ending an already-ended session is a no-op — though a second
+    call from the *same* client sees the dormant 404 from the router gate, since
+    its code is no longer live. The CLI treats that as success.
+
+    This lives on the setup router (not the browser-only `/api/v1/pairing/*`
+    control plane) deliberately: it is pairing-code-authenticated like the rest
+    of the flow, and only `/api/v1/setup/*` is exempt from the Origin allowlist,
+    which every Origin-less CLI request needs.
+    """
+    request.app.state.pairing_manager.end()
+    return SetupEndResponse(ended=True)

--- a/tests/integration/test_web_adopt_e2e.py
+++ b/tests/integration/test_web_adopt_e2e.py
@@ -12,9 +12,9 @@ therefore see genuinely different registries/homes, exactly like a real
 workstation adopting a real container.
 
 Each adopt/push obtains a FRESH pairing code (minted via
-`POST /api/v1/pairing/mint`); the code authenticates the whole flow and the
-service ends the session on the terminal `POST /setup/verify` (FR-007), so a
-subsequent probe re-mints.
+`POST /api/v1/pairing/mint`); the code authenticates the whole flow and the CLI
+ends the session with an explicit `POST /setup/end` once the flow succeeds
+(FR-007; verify no longer ends it — #158), so a subsequent probe re-mints.
 
 No real SSH instances exist here, so the workstation-side per-instance SSH
 work is selectively substituted (see `adoption_ssh_mocks`):
@@ -516,8 +516,8 @@ def test_registry_put_preserves_established_sessions(
     the service-side registry (standing in for an established session's held
     resources) and a live keep-alive HTTP connection spanning the PUT.
     """
-    # One minted code drives every call here: the flow never calls /verify, so
-    # the session stays live across both PUTs (it would end only on verify).
+    # One minted code drives every call here: nothing calls /setup/end, so the
+    # session stays live across both PUTs.
     code = service.mint()
     client = web_adopt.SetupApiClient(service.url, code)
 

--- a/tests/integration/test_web_adopt_e2e.py
+++ b/tests/integration/test_web_adopt_e2e.py
@@ -702,14 +702,14 @@ def test_push_after_adopt_processes_only_the_new_instance(
 
 
 @requires_live_web
-def test_push_with_dormant_code_fails_with_reopen_guidance(
+def test_push_with_dormant_code_fails_with_stale_code_guidance(
     service: LiveService,
     workstation: Path,
     adoption_ssh_mocks: dict,
 ):
     """A stale/dormant code (never minted, or already used) makes every setup
-    call return the dormant 404, which the CLI maps to reopen-the-page guidance
-    -- before any per-instance work or registry PUT."""
+    call return the dormant 404, which the CLI maps to "copy the code from the
+    most recent mint" guidance -- before any per-instance work or registry PUT."""
     # Adopt once so there is a registry to (not) disturb.
     web_adopt.run_adopt(service.url, service.mint(), interactive=False)
     adoption_ssh_mocks["scanned"].clear()
@@ -722,7 +722,8 @@ def test_push_with_dormant_code_fails_with_reopen_guidance(
 
     message = str(excinfo.value)
     assert "dormant" in message
-    assert "fresh code" in message  # reopen-the-page remediation
+    assert "fresh code" in message
+    assert "most recent" in message.lower()  # #159: rotation is the usual cause
 
     # Failed at the first setup call: no instance touched, no PUT.
     assert adoption_ssh_mocks["scanned"] == []

--- a/tests/unit/cli/test_web_adopt_cmd.py
+++ b/tests/unit/cli/test_web_adopt_cmd.py
@@ -197,11 +197,11 @@ class TestExitCodes:
         assert "read-only mounts" in result.output
         assert "adoption does not apply" in result.output
 
-    def test_dormant_surface_exits_one_with_reopen_message(self, runner, mock_run_push):
+    def test_dormant_surface_exits_one_with_stale_code_message(self, runner, mock_run_push):
         mock_run_push.side_effect = SetupNotFoundError(
             "the pairing code is no longer valid — the setup surface at "
-            "http://svc:8080 is dormant (HTTP 404). Reopen the adopt page to mint "
-            "a fresh code, then retry.",
+            "http://svc:8080 is dormant (HTTP 404). Click 'Copy pairing code' "
+            "after the most recent mint and paste that one, or mint a fresh code.",
             status=404,
         )
 

--- a/tests/unit/core/test_web_adopt_code.py
+++ b/tests/unit/core/test_web_adopt_code.py
@@ -39,7 +39,7 @@ def test_bearer_header_carries_the_pairing_code(mocker):
     assert captured["auth"] == "Bearer the-pairing-code"
 
 
-def test_dormant_404_maps_to_reopen_message(mocker):
+def test_dormant_404_leads_with_code_rotation(mocker):
     client = SetupApiClient("http://svc:8080", "stale-code")
 
     def raise_404(request, timeout=None):
@@ -53,4 +53,8 @@ def test_dormant_404_maps_to_reopen_message(mocker):
     message = str(excinfo.value)
     assert "dormant" in message
     assert "fresh code" in message
-    assert "reopen the adopt page" in message.lower()
+    # #159: the leading advice is "copy the code from the MOST RECENT mint",
+    # not "reopen the page" — reopening mints again, rotating away whatever the
+    # operator just copied, which is how the trap compounds.
+    assert "most recent" in message.lower()
+    assert message.lower().index("most recent") < message.lower().index("reopen")

--- a/tests/unit/core/test_web_adopt_trust.py
+++ b/tests/unit/core/test_web_adopt_trust.py
@@ -261,10 +261,16 @@ class TestNoTrustedRecord:
         assert result.detail == "fingerprint confirmed interactively"
         assert len(prompts) == 1
         assert HOST in prompts[0]
+        # #157: the confirmation is recorded locally too, without disturbing
+        # the unrelated entry that was already there.
+        assert known_hosts.read_text() == (
+            "other.example.com ssh-ed25519 AAAAunrelated\n" f"{HOST} {ED25519_KEY}\n"
+        )
 
-    def test_interactive_decline_is_no_trust(self, mocker, known_hosts):
+    def test_interactive_decline_is_no_trust(self, mocker, known_hosts, tmp_path):
         dispatcher = self._dispatcher_not_found()
         _patch_run(mocker, dispatcher)
+        before = known_hosts.read_text()
 
         result = scan_and_verify_host_key(
             HOST,
@@ -276,6 +282,8 @@ class TestNoTrustedRecord:
         assert result.decision == "no_trust"
         assert result.lines == []
         assert result.detail == "fingerprint confirmation declined"
+        # A declined fingerprint must never be trusted locally either (#157).
+        assert known_hosts.read_text() == before
 
     def test_non_interactive_is_no_trust_without_prompting(self, mocker, known_hosts):
         dispatcher = self._dispatcher_not_found()
@@ -294,19 +302,213 @@ class TestNoTrustedRecord:
         assert "non-interactive" in result.detail
         # The fingerprint-rendering path must not run either.
         assert dispatcher.lf_file_contents == []
+        # Nothing was confirmed, so nothing may be trusted locally (#157).
+        assert known_hosts.read_text() == f"{HOST} {ED25519_KEY}\n"
 
     def test_missing_known_hosts_file_skips_keygen_f(self, mocker, tmp_path):
         dispatcher = RunDispatcher(
             keyscan=_cp(["ssh-keyscan"], stdout=_keyscan_stdout(ED25519_KEY)),
         )
         _patch_run(mocker, dispatcher)
+        missing = tmp_path / "does-not-exist"
 
         result = scan_and_verify_host_key(
-            HOST, known_hosts_file=tmp_path / "does-not-exist", interactive=False
+            HOST, known_hosts_file=missing, interactive=False
         )
 
         assert result.decision == "no_trust"
         assert dispatcher.commands() == ["ssh-keyscan"]
+        # A non-interactive run must not create a trust store either (#157).
+        assert not missing.exists()
+
+
+# ---------------------------------------------------------------------------
+# Confirmed fingerprints are persisted to the workstation's known_hosts (#157)
+# ---------------------------------------------------------------------------
+
+
+class TestConfirmPersistsTrust:
+    """Issue #157: confirming a fingerprint used to update only the push
+    payload, so the authorize step that immediately follows (ssh with
+    BatchMode=yes) died with "Host key verification failed"."""
+
+    def _dispatcher(self, *keys: str, found: str | None = None) -> RunDispatcher:
+        return RunDispatcher(
+            keyscan=_cp(["ssh-keyscan"], stdout=_keyscan_stdout(*keys)),
+            keygen_f=(
+                _cp(["ssh-keygen"], stdout=_keygen_f_stdout(found))
+                if found
+                else _cp(["ssh-keygen"], rc=1)
+            ),
+            keygen_lf=_cp(["ssh-keygen"], stdout="256 SHA256:zZz fingerprint\n"),
+        )
+
+    def test_creates_store_with_tight_permissions(self, mocker, tmp_path):
+        _patch_run(mocker, self._dispatcher(ED25519_KEY))
+        store = tmp_path / "ssh" / "known_hosts"
+
+        result = scan_and_verify_host_key(
+            HOST,
+            known_hosts_file=store,
+            interactive=True,
+            confirm_fn=lambda _prompt: True,
+        )
+
+        assert result.decision == "trusted"
+        assert store.read_text() == f"{HOST} {ED25519_KEY}\n"
+        assert store.stat().st_mode & 0o777 == 0o600
+        assert store.parent.stat().st_mode & 0o777 == 0o700
+
+    def test_appends_all_scanned_key_types(self, mocker, tmp_path):
+        _patch_run(mocker, self._dispatcher(ED25519_KEY, RSA_KEY))
+        store = tmp_path / "known_hosts"
+
+        result = scan_and_verify_host_key(
+            HOST,
+            known_hosts_file=store,
+            interactive=True,
+            confirm_fn=lambda _prompt: True,
+        )
+
+        assert result.lines == [f"{HOST} {ED25519_KEY}", f"{HOST} {RSA_KEY}"]
+        assert store.read_text() == f"{HOST} {ED25519_KEY}\n{HOST} {RSA_KEY}\n"
+
+    def test_appends_only_the_missing_line(self, mocker, tmp_path):
+        """Never duplicate a line the store already holds verbatim — the
+        lookup can come back empty for a line that is physically present (an
+        unusable `ssh-keygen`, a record `-F` could not parse), and a second
+        confirmed run must still leave one copy."""
+        _patch_run(mocker, self._dispatcher(ED25519_KEY, RSA_KEY))
+        store = tmp_path / "known_hosts"
+        store.write_text(f"{HOST} {RSA_KEY}\n")
+
+        result = scan_and_verify_host_key(
+            HOST,
+            known_hosts_file=store,
+            interactive=True,
+            confirm_fn=lambda _prompt: True,
+        )
+
+        assert result.decision == "trusted"
+        assert store.read_text() == f"{HOST} {RSA_KEY}\n{HOST} {ED25519_KEY}\n"
+
+    def test_unterminated_existing_file_gets_a_separator(self, mocker, tmp_path):
+        _patch_run(mocker, self._dispatcher(ED25519_KEY))
+        store = tmp_path / "known_hosts"
+        store.write_text("other.example.com ssh-ed25519 AAAAunrelated")  # no newline
+
+        scan_and_verify_host_key(
+            HOST,
+            known_hosts_file=store,
+            interactive=True,
+            confirm_fn=lambda _prompt: True,
+        )
+
+        assert store.read_text() == (
+            "other.example.com ssh-ed25519 AAAAunrelated\n" f"{HOST} {ED25519_KEY}\n"
+        )
+
+    def test_non_default_port_is_recorded_in_bracketed_form(self, mocker, tmp_path):
+        """`ssh-keyscan -p` emits the `[host]:port` line form; it is stored
+        verbatim, which is exactly what `ssh -p 2222` later looks up."""
+        line = f"[{HOST}]:2222 {ED25519_KEY}"
+        _patch_run(
+            mocker,
+            RunDispatcher(
+                keyscan=_cp(["ssh-keyscan"], stdout=line + "\n"),
+                keygen_f=_cp(["ssh-keygen"], rc=1),
+                keygen_lf=_cp(["ssh-keygen"], stdout="256 SHA256:zZz fingerprint\n"),
+            ),
+        )
+        store = tmp_path / "known_hosts"
+
+        result = scan_and_verify_host_key(
+            HOST,
+            port=2222,
+            known_hosts_file=store,
+            interactive=True,
+            confirm_fn=lambda _prompt: True,
+        )
+
+        assert result.decision == "trusted"
+        assert store.read_text() == line + "\n"
+
+    def test_mismatch_never_writes(self, mocker, known_hosts):
+        _patch_run(mocker, self._dispatcher(ED25519_OTHER, found=ED25519_KEY))
+        before = known_hosts.read_text()
+
+        result = scan_and_verify_host_key(
+            HOST,
+            known_hosts_file=known_hosts,
+            interactive=True,
+            confirm_fn=lambda _prompt: pytest.fail("must not prompt on mismatch"),
+        )
+
+        assert result.decision == "mismatch"
+        assert known_hosts.read_text() == before
+
+    def test_second_run_takes_the_trusted_path_without_prompting(
+        self, mocker, tmp_path, real_pubkeys
+    ):
+        """Round-trip against the REAL ssh-keygen: what the first (confirmed)
+        run wrote is what the second run's `-F` lookup must find, so the
+        operator is asked exactly once (Principle VII — the write is a no-op
+        the second time)."""
+        key_a, _key_b = real_pubkeys
+        store = tmp_path / "known_hosts"
+
+        def dispatch(cmd: list[str], **kwargs: object):
+            if cmd[0] == "ssh-keyscan":
+                return _cp(cmd, stdout=_keyscan_stdout(key_a))
+            return _REAL_RUN(cmd, **kwargs)  # type: ignore[arg-type]
+
+        mocker.patch("remo_cli.core.web_adopt.subprocess.run", side_effect=dispatch)
+
+        first = scan_and_verify_host_key(
+            HOST,
+            known_hosts_file=store,
+            interactive=True,
+            confirm_fn=lambda _prompt: True,
+        )
+        after_first = store.read_text()
+
+        second = scan_and_verify_host_key(
+            HOST,
+            known_hosts_file=store,
+            interactive=True,
+            confirm_fn=lambda _prompt: pytest.fail("already trusted; must not prompt"),
+        )
+
+        assert first.decision == "trusted"
+        assert first.detail == "fingerprint confirmed interactively"
+        assert second.decision == "trusted"
+        assert second.detail == "matches trusted known_hosts entry"
+        assert store.read_text() == after_first
+
+    def test_write_failure_warns_but_still_trusts(self, mocker, tmp_path, capsys):
+        """The scanned lines are still valid for the payload, so a failed local
+        write must not turn a confirmed key into a skipped instance."""
+        _patch_run(mocker, self._dispatcher(ED25519_KEY))
+        parent = tmp_path / "readonly"
+        parent.mkdir()
+        store = parent / "known_hosts"
+        parent.chmod(0o500)
+        try:
+            result = scan_and_verify_host_key(
+                HOST,
+                known_hosts_file=store,
+                interactive=True,
+                confirm_fn=lambda _prompt: True,
+            )
+        finally:
+            parent.chmod(0o700)
+
+        assert result.decision == "trusted"
+        assert result.lines == [f"{HOST} {ED25519_KEY}"]
+        assert result.detail == "fingerprint confirmed interactively"
+        out = capsys.readouterr().out
+        assert str(store) in out
+        assert not store.exists()
 
 
 # ---------------------------------------------------------------------------
@@ -504,6 +706,10 @@ class TestMultipleKeyTypes:
 
         assert result.decision == "trusted"
         assert result.lines == [f"{HOST} {ED25519_KEY}"]
+        # The fixture store already holds this exact line (the `-F` lookup here
+        # is mocked to report only an rsa record), so the confirmed write
+        # dedupes to a no-op rather than duplicating it.
+        assert known_hosts.read_text() == f"{HOST} {ED25519_KEY}\n"
 
 
 # ---------------------------------------------------------------------------
@@ -707,3 +913,53 @@ class TestPushThreadsThePort:
         _process_instance(host, "ssh-ed25519 AAAA", interactive=False, host_keys={})
 
         assert scan.call_args.kwargs["port"] == 22
+
+
+class TestAuthorizeFailureRemediation:
+    """#157: an authorize failure caused by an untrusted host key used to point
+    the operator at a host that was demonstrably reachable."""
+
+    def _run(self, mocker, error: str, *, port: int = 22) -> str:
+        mocker.patch(
+            "remo_cli.core.web_adopt.scan_and_verify_host_key",
+            return_value=HostKeyScan("trusted", lines=[f"{HOST} {ED25519_KEY}"]),
+        )
+        mocker.patch(
+            "remo_cli.core.web_adopt.authorize_service_key",
+            return_value=(False, error),
+        )
+        host = KnownHost(
+            type="ssh",
+            name="mbp",
+            host=HOST,
+            user="remo",
+            instance_id=str(port),
+            access_mode="direct",
+        )
+        outcome = _process_instance(
+            host, "ssh-ed25519 AAAA", interactive=False, host_keys={}
+        )
+        assert outcome.outcome == "skipped_unreachable"
+        assert error in outcome.detail
+        return outcome.remediation or ""
+
+    def test_host_key_verification_failure_names_the_real_cause(self, mocker):
+        remediation = self._run(
+            mocker, "Host key verification failed.\r\nlost connection"
+        )
+
+        assert "known_hosts" in remediation
+        assert HOST in remediation
+        assert "remo shell mbp" in remediation
+        assert "ssh remo@" not in remediation
+
+    def test_custom_port_remediation_names_the_bracketed_record(self, mocker):
+        remediation = self._run(mocker, "Host key verification failed.", port=2222)
+
+        assert f"[{HOST}]:2222" in remediation
+
+    def test_other_failures_keep_the_generic_ssh_hint(self, mocker):
+        remediation = self._run(mocker, "Permission denied (publickey).")
+
+        assert f"ssh remo@{HOST}" in remediation
+        assert "known_hosts" not in remediation

--- a/tests/unit/core/test_web_adopt_trust.py
+++ b/tests/unit/core/test_web_adopt_trust.py
@@ -507,6 +507,9 @@ class TestConfirmPersistsTrust:
         assert result.lines == [f"{HOST} {ED25519_KEY}"]
         assert result.detail == "fingerprint confirmed interactively"
         out = capsys.readouterr().out
+        # The path reaches the operator through the OSError rather than being
+        # interpolated from `trusted_store` (CodeQL reads that flow as a leaked
+        # secret) — it still has to be there, whichever way it arrives.
         assert str(store) in out
         assert not store.exists()
 

--- a/tests/unit/core/test_web_push_self_heal.py
+++ b/tests/unit/core/test_web_push_self_heal.py
@@ -35,6 +35,10 @@ from remo_cli.core.web_adopt import (
     InstanceOutcome,
     auth_failed_labels,
     instance_fingerprint,
+    PayloadRejectedError,
+    SetupApiError,
+    SetupConnectionError,
+    SetupNotFoundError,
     load_push_cache,
     run_push,
     save_push_cache,
@@ -417,3 +421,183 @@ class TestRemediationNamesTheCommand:
         run_push(URL, CODE, assume_yes=True)
 
         assert "--force" not in capsys.readouterr().out
+
+
+class TestSessionIsEndedExplicitly:
+    """#158: `POST /setup/verify` used to end the pairing session as a side
+    effect, so the self-heal pass above — a re-PUT and re-verify that run
+    *after* it — hit a dormant 404 and aborted the push before the cache write.
+    Ending is now the CLI's own call, made once the flow has succeeded."""
+
+    def test_successful_push_ends_the_session(
+        self, tmp_config_dir, api_client, registry, mocker
+    ):
+        registry.return_value = [_host()]
+        api_client.post_verify.return_value = {"all_passed": True, "results": []}
+        _patch_process(mocker)
+
+        run_push(URL, CODE, assume_yes=True)
+
+        assert api_client.post_end.call_count == 1
+
+    def test_session_is_ended_after_the_self_heal_pass(
+        self, tmp_config_dir, api_client, registry, mocker
+    ):
+        """Ordering is the whole point: the close must come last, never before
+        the repair's re-PUT + re-verify."""
+        host = _host()
+        registry.return_value = [host]
+        _seed_cache(host)
+        _patch_process(mocker)
+        order: list[str] = []
+        verifies = [
+            {
+                "all_passed": False,
+                "results": [
+                    _instance_check("incus/node1/dev", passed=False, detail="auth_failed")
+                ],
+            },
+            {"all_passed": True, "results": [_instance_check("incus/node1/dev", passed=True)]},
+        ]
+        applied = {"registry_instances": 1, "host_key_instances": 1, "mirror_generation": 2}
+        api_client.put_registry.side_effect = _recording(order, "put_registry", [applied] * 2)
+        api_client.post_verify.side_effect = _recording(order, "post_verify", verifies)
+        api_client.post_end.side_effect = _recording(order, "post_end", [{"ended": True}])
+
+        run_push(URL, CODE, assume_yes=True)
+
+        assert order == ["put_registry", "post_verify", "put_registry", "post_verify", "post_end"]
+
+    def test_end_failure_never_fails_the_push(
+        self, tmp_config_dir, api_client, registry, mocker
+    ):
+        """An older service without /setup/end (or one that already ended the
+        session on verify) answers 404. The mirror is applied either way."""
+        registry.return_value = [_host()]
+        api_client.post_verify.return_value = {"all_passed": True, "results": []}
+        api_client.post_end.side_effect = SetupNotFoundError("dormant", status=404)
+        _patch_process(mocker)
+
+        result = run_push(URL, CODE, assume_yes=True)
+
+        assert result.all_verified
+
+    def test_failed_push_leaves_the_session_live(
+        self, tmp_config_dir, api_client, registry, mocker
+    ):
+        """A retry should be able to reuse the same code — minting another one
+        would rotate this one away (#159)."""
+        registry.return_value = [_host()]
+        api_client.put_registry.side_effect = PayloadRejectedError(
+            "rejected", reason="invalid_payload"
+        )
+        _patch_process(mocker)
+
+        with pytest.raises(SetupApiError):
+            run_push(URL, CODE, assume_yes=True)
+
+        api_client.post_end.assert_not_called()
+
+
+def _recording(order, name, responses):
+    """A side_effect returning *responses* in turn and logging the call order."""
+    pending = list(responses)
+
+    def call(*_args, **_kwargs):
+        order.append(name)
+        return pending.pop(0)
+
+    return call
+
+
+class TestRepairFailuresStillWriteTheCache:
+    """Everything after the first successful PUT is best-effort: the mirror is
+    already applied, so a failure in the repair round must not strand the local
+    cache — that lost write is what turned #158 into a phantom flap warning on
+    the following push."""
+
+    @pytest.fixture
+    def _failing_first_verify(self, api_client):
+        api_client.post_verify.side_effect = [
+            {
+                "all_passed": False,
+                "results": [
+                    _instance_check("incus/node1/dev", passed=False, detail="auth_failed")
+                ],
+            },
+            {"all_passed": True, "results": [_instance_check("incus/node1/dev", passed=True)]},
+        ]
+
+    def test_repair_put_failure_still_caches_the_generation(
+        self, tmp_config_dir, api_client, registry, mocker, _failing_first_verify, capsys
+    ):
+        host = _host()
+        registry.return_value = [host]
+        _seed_cache(host)
+        api_client.put_registry.side_effect = [
+            {"registry_instances": 1, "host_key_instances": 1, "mirror_generation": 2},
+            SetupNotFoundError("dormant", status=404),
+        ]
+        _patch_process(mocker)
+
+        result = run_push(URL, CODE, assume_yes=True)
+
+        cache = load_push_cache()[DEPLOYMENT_ID]
+        # The generation must come from the last SUCCESSFUL PUT — the service
+        # bumps it on every PUT, so a failed call's generation would be wrong.
+        assert cache.mirror_generation == 2
+        # The service never received the rescanned host keys, so caching this
+        # instance would re-arm the very `unchanged` fast path #122 fixed.
+        assert cache.instances == {}
+        assert result.outcomes[0].outcome == OUTCOME_REPAIRED
+        assert "re-push the mirror after repair" in capsys.readouterr().out
+
+    def test_repair_put_failure_skips_the_re_verify(
+        self, tmp_config_dir, api_client, registry, mocker, _failing_first_verify
+    ):
+        host = _host()
+        registry.return_value = [host]
+        _seed_cache(host)
+        api_client.put_registry.side_effect = [
+            {"registry_instances": 1, "host_key_instances": 1, "mirror_generation": 2},
+            SetupNotFoundError("dormant", status=404),
+        ]
+        _patch_process(mocker)
+
+        result = run_push(URL, CODE, assume_yes=True)
+
+        assert api_client.post_verify.call_count == 1
+        assert not result.all_verified, "the pre-repair report is the only one we have"
+
+    def test_re_verify_failure_still_caches_the_new_generation(
+        self, tmp_config_dir, api_client, registry, mocker, capsys
+    ):
+        """The re-PUT succeeded, so the service DID advance a generation — the
+        cache has to record it or the next push reads a flap."""
+        host = _host()
+        registry.return_value = [host]
+        _seed_cache(host)
+        api_client.put_registry.side_effect = [
+            {"registry_instances": 1, "host_key_instances": 1, "mirror_generation": 2},
+            {"registry_instances": 1, "host_key_instances": 1, "mirror_generation": 3},
+        ]
+        api_client.post_verify.side_effect = [
+            {
+                "all_passed": False,
+                "results": [
+                    _instance_check("incus/node1/dev", passed=False, detail="auth_failed")
+                ],
+            },
+            SetupConnectionError("connection reset"),
+        ]
+        _patch_process(mocker)
+
+        result = run_push(URL, CODE, assume_yes=True)
+
+        cache = load_push_cache()[DEPLOYMENT_ID]
+        assert cache.mirror_generation == 3
+        # Conservative on purpose: the stale report still says auth_failed, and
+        # an instance we cannot confirm is never cached.
+        assert cache.instances == {}
+        assert result.verify["all_passed"] is False
+        assert "report below predates the repair" in capsys.readouterr().out

--- a/tests/unit/web/test_setup_api.py
+++ b/tests/unit/web/test_setup_api.py
@@ -296,7 +296,7 @@ def test_put_registry_happy_path_applies_mirror_and_flips_to_adopted(state_dir):
         assert doc["hosts"] == _EXPECTED_V2_HOSTS
         assert not state_dir.registry_path.exists()  # legacy mirror never written
 
-        # The PUT does not end the session (verify is the terminal step, FR-007).
+        # The PUT does not end the session (the CLI's POST /setup/end does, FR-007).
         status = client.get("/api/v1/setup/status", headers=_AUTH).json()
     assert status["state"] == "adopted"
     assert status["registry_instances"] == 2

--- a/tests/unit/web/test_setup_dormancy.py
+++ b/tests/unit/web/test_setup_dormancy.py
@@ -19,6 +19,7 @@ _SETUP_ROUTES = [
     ("GET", "/api/v1/setup/identity"),
     ("PUT", "/api/v1/setup/registry"),
     ("POST", "/api/v1/setup/verify"),
+    ("POST", "/api/v1/setup/end"),
 ]
 
 
@@ -65,28 +66,69 @@ def test_idle_expiry_returns_to_dormant(state_dir):
     assert resp.status_code == 404
 
 
+_PAYLOAD = {
+    "version": 1,
+    "registry": [{"type": "incus", "name": "dev", "host": "10.0.0.5", "user": "remo"}],
+    "host_keys": {},
+}
+
+
 def test_adoption_completion_ends_session(state_dir):
     state_dir.adopted()
     client = make_client(state_dir)
     code = mint(client)
-    payload = {
-        "version": 1,
-        "registry": [{"type": "incus", "name": "dev", "host": "10.0.0.5", "user": "remo"}],
-        "host_keys": {},
-    }
     applied = client.put(
-        "/api/v1/setup/registry", headers={**bearer(code), "Origin": ORIGIN}, json=payload
+        "/api/v1/setup/registry", headers={**bearer(code), "Origin": ORIGIN}, json=_PAYLOAD
     )
     assert applied.status_code == 200
-    # The PUT alone does NOT end the session — verify is the terminal step of the
-    # adopt/push flow and must still run with the same code.
+    # The PUT does NOT end the session — the flow continues with the same code.
     assert client.get("/api/v1/setup/status", headers=bearer(code)).status_code == 200
 
     verified = client.post("/api/v1/setup/verify", headers={**bearer(code), "Origin": ORIGIN})
     assert verified.status_code == 200
-    # FR-007: completing the flow (verify) ends the session -> dormant again.
-    after = client.get("/api/v1/setup/status", headers=bearer(code))
-    assert after.status_code == 404
+    # Nor does verify (#158): it used to end the session here, which severed the
+    # push flow's self-heal re-PUT + re-verify.
+    assert client.get("/api/v1/setup/status", headers=bearer(code)).status_code == 200
+
+    # FR-007: the client's explicit close ends it -> dormant again.
+    ended = client.post("/api/v1/setup/end", headers={**bearer(code), "Origin": ORIGIN})
+    assert ended.status_code == 200
+    assert ended.json() == {"ended": True}
+    assert client.get("/api/v1/setup/status", headers=bearer(code)).status_code == 404
+    # And the close itself is now behind the dormant gate, like every setup route.
+    assert (
+        client.post("/api/v1/setup/end", headers={**bearer(code), "Origin": ORIGIN}).status_code
+        == 404
+    )
+
+
+def test_self_heal_sequence_survives_on_one_code(state_dir):
+    """#158 regression: the exact push sequence, including the self-heal pass
+    that runs AFTER the first verify. Every step must stay authenticated by the
+    single minted code until the CLI ends the session itself."""
+    state_dir.adopted()
+    client = make_client(state_dir)
+    code = mint(client)
+    auth = {**bearer(code), "Origin": ORIGIN}
+
+    assert client.get("/api/v1/setup/status", headers=bearer(code)).status_code == 200
+    assert client.get("/api/v1/setup/identity", headers=bearer(code)).status_code == 200
+
+    first = client.put("/api/v1/setup/registry", headers=auth, json=_PAYLOAD)
+    assert first.status_code == 200
+    assert client.post("/api/v1/setup/verify", headers=auth).status_code == 200
+
+    # The self-heal re-PUT + re-verify — both used to hit a dormant 404.
+    second = client.put("/api/v1/setup/registry", headers=auth, json=_PAYLOAD)
+    assert second.status_code == 200
+    assert client.post("/api/v1/setup/verify", headers=auth).status_code == 200
+
+    # The generation advances per successful PUT, which is what the workstation
+    # caches for flap detection — so it must come from the LAST successful one.
+    assert second.json()["mirror_generation"] == first.json()["mirror_generation"] + 1
+
+    assert client.post("/api/v1/setup/end", headers=auth).status_code == 200
+    assert client.get("/api/v1/setup/status", headers=bearer(code)).status_code == 404
 
 
 def _health_ready(client):


### PR DESCRIPTION
One real session — registering a rebuilt OrbStack VM with `remo add`/`remo configure`, then `remo web push` — surfaced three collaborating defects. Each is a commit here; they share files (`core/web_adopt.py`, the pairing components, `docs/web-session-interface.md`), so they ship together.

### #157 — a confirmed fingerprint was never recorded locally

`remo web push` shows a new host's SHA256 fingerprints and asks you to trust them, but the confirmed lines only rode in the push payload, for the *service's* known_hosts. The workstation's own store was left untouched, so the very next step (`authorize_service_key`, ssh with `BatchMode=yes`) died with "Host key verification failed" and the instance was reported `skipped_unreachable` — with a remediation telling you to check a host that had just answered a keyscan. **Every first push to a genuinely-new host failed deterministically.**

Confirming now also appends the scanned lines to `~/.ssh/known_hosts`: pure Python I/O (no `ssh-keygen` subprocess), `O_APPEND|O_CREAT` at 0600 so a new store is never briefly world-readable, verbatim dedup so a re-run appends nothing. Only the confirmation branch writes. A write failure warns and still reports `trusted` — the lines are still valid for the payload. The authorize-failure remediation now names the real cause when ssh reports a host-key failure.

### #158 — verify ended the pairing session, severing the self-heal

`POST /setup/verify` ended the session as a side effect (it was the flow's last authenticated step when written). The #122 self-heal (#123) then added a re-PUT + re-verify *after* it — both now hit the dormant 404, so push aborted after the service applied the mirror but before the push cache was written. The repair never landed, and the next push read the service's advanced generation as "another workstation pushed" and warned about a flap that never happened.

Verify is now repeatable. Ending is an explicit `POST /api/v1/setup/end` → `200 {"ended": true}`, on the same pairing-gated router and inside the Origin-exempt `/api/v1/setup/*` prefix an Origin-less CLI request needs (which is why the CLI cannot use the browser-only `/api/v1/pairing/end`). The CLI calls it only on success — a failed push leaves the session live so a retry can reuse the same code. Version skew is safe both directions.

Hardened the whole post-first-PUT stretch while here: the self-heal re-PUT and re-verify are individually wrapped, `applied` is reassigned only on a *successful* PUT (the service bumps the generation on every PUT), step 7 always runs, and a failed re-PUT drops the repaired instances from the cache so they cannot re-arm the `unchanged` fast path.

### #159 — a mint without a click left a dead code on the clipboard

The code is never displayed, so the clipboard is its only channel — but the clipboard was written only by an explicit Copy click, while every page open *mints and rotates*. A mint without a click left a dead code there invisibly, and the CLI's dormant-404 message advised reopening the page, which rotates again. Both components now copy on mint; when the browser refuses (normal on the adopt page, where load is not a user gesture) the button becomes a non-expiring "Copy pairing code (required)". The CLI's 401/404 messages lead with rotation and demote the reopen advice.

## Verification

- `uv run pytest` — 2161 passed, 19 skipped (incl. the live-service `test_web_adopt_e2e.py`)
- `uv run mypy src/remo_cli`, `uv run ruff check src/remo_cli` — clean
- `npm run lint && npm run test && npm run build` — 231 tests across 17 files (2 new suites)
- Artifacts regenerated and checked in: `openapi.json` + `schema.d.ts` (the new route); `terminal-frames.*` unchanged. Both drift gates and `test_docs_structure.py` pass.

Specs (`012-web-adopt-pairing`: `setup-api.md`, `pairing-api.md`, `spec.md` FR-007, `data-model.md`, `tasks.md`), `docs/web-session-interface.md` and the CLAUDE.md structure diagram are updated in the same commits.

Fixes #157, fixes #158, fixes #159

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RcgFXhhdqGGzhk5Ardf9rk