### PR TITLE
fix(web): rename trusted_store so CodeQL stops reading a path as a secret

### DIFF
--- a/src/remo_cli/core/web_adopt.py
+++ b/src/remo_cli/core/web_adopt.py
@@ -519,7 +519,7 @@ def _render_fingerprints(lines: list[str]) -> str:
             pass
 
 
-def _persist_confirmed_host_keys(lines: list[str], trusted_store: Path) -> str | None:
+def _persist_confirmed_host_keys(lines: list[str], known_hosts_path: Path) -> str | None:
     """Append interactively-confirmed *lines* to the workstation's known_hosts.
 
     Issue #157: confirming a fingerprint used to affect only the *push payload*
@@ -536,14 +536,12 @@ def _persist_confirmed_host_keys(lines: list[str], trusted_store: Path) -> str |
     Deliberately pure Python file I/O — no ``ssh-keygen``/``ssh-keyscan``
     subprocess — so the write cannot fail on a workstation without those tools.
 
-    The warning strings name the store only through the ``OSError``, which
-    already carries the offending path, rather than interpolating
-    *trusted_store* directly: CodeQL's clear-text-logging heuristic reads a
-    "trusted"-named value flowing into output as a leaked secret, and the caller
-    has just printed the store's path anyway.
+    The warning strings name the file only through the ``OSError``, which
+    already carries the offending path — repeating it would just be noise, and
+    the caller has printed it one line earlier anyway.
     """
     try:
-        existing = trusted_store.read_text() if trusted_store.exists() else ""
+        existing = known_hosts_path.read_text() if known_hosts_path.exists() else ""
     except OSError as e:
         return f"could not read the known_hosts file to record the confirmed host key: {e}"
 
@@ -559,10 +557,10 @@ def _persist_confirmed_host_keys(lines: list[str], trusted_store: Path) -> str |
         payload = "\n" + payload
 
     try:
-        trusted_store.parent.mkdir(mode=0o700, parents=True, exist_ok=True)
+        known_hosts_path.parent.mkdir(mode=0o700, parents=True, exist_ok=True)
         # os.open with mode 0600 so a *newly created* known_hosts is never
         # briefly world-readable (a create-then-chmod would race).
-        fd = os.open(trusted_store, os.O_WRONLY | os.O_APPEND | os.O_CREAT, 0o600)
+        fd = os.open(known_hosts_path, os.O_WRONLY | os.O_APPEND | os.O_CREAT, 0o600)
         with os.fdopen(fd, "a") as fh:
             fh.write(payload)
     except OSError as e:
@@ -608,8 +606,15 @@ def scan_and_verify_host_key(
     appended to *known_hosts_file* (see :func:`_persist_confirmed_host_keys`).
     Nothing else here writes to the workstation's trust store — a match needs no
     write, and mismatch/decline/non-interactive must not create one.
+
+    The local name is *known_hosts_path*, matching :func:`_lookup_trusted_keys`'
+    parameter, and not something like ``trusted_store``: CodeQL's
+    ``py/clear-text-logging-sensitive-data`` heuristic classifies any
+    "trusted"-named value as a secret, so the plain path below flowing into
+    :func:`print_warning` raised a high-severity alert on a value that is only
+    ever ``~/.ssh/known_hosts``.
     """
-    trusted_store = known_hosts_file or (Path.home() / ".ssh" / "known_hosts")
+    known_hosts_path = known_hosts_file or (Path.home() / ".ssh" / "known_hosts")
     if confirm_fn is None:
         confirm_fn = confirm
     lookup_key = known_hosts_lookup_key(hostname, port)
@@ -652,7 +657,7 @@ def scan_and_verify_host_key(
         detail = stderr_lines[-1].strip() if stderr_lines else "no host keys returned by ssh-keyscan"
         return HostKeyScan("unreachable", detail=detail)
 
-    trusted_pairs = _lookup_trusted_keys(lookup_key, trusted_store)
+    trusted_pairs = _lookup_trusted_keys(lookup_key, known_hosts_path)
     if trusted_pairs is not None:
         trusted_by_type: dict[str, set[str]] = {}
         for key_type, key in trusted_pairs:
@@ -665,7 +670,7 @@ def scan_and_verify_host_key(
                         "mismatch",
                         detail=(
                             f"scanned {key_type} host key does not match the trusted "
-                            f"entry in {trusted_store}"
+                            f"entry in {known_hosts_path}"
                         ),
                     )
             return HostKeyScan(
@@ -680,18 +685,18 @@ def scan_and_verify_host_key(
         return HostKeyScan(
             "no_trust",
             detail=(
-                f"no trusted host key for {lookup_key} in {trusted_store} "
+                f"no trusted host key for {lookup_key} in {known_hosts_path} "
                 "(non-interactive run; fingerprint confirmation skipped)"
             ),
         )
 
-    print_warning(f"No trusted host key for {lookup_key} in {trusted_store}.")
+    print_warning(f"No trusted host key for {lookup_key} in {known_hosts_path}.")
     print("Scanned key fingerprints:")
     print(_render_fingerprints(scanned_lines))
     if confirm_fn(f"Trust these keys for {lookup_key} and include them in the push?"):
         # Record the answer locally too (#157) — the authorize step that follows
         # runs ssh with BatchMode=yes and fails outright on an untrusted host.
-        warning = _persist_confirmed_host_keys(scanned_lines, trusted_store)
+        warning = _persist_confirmed_host_keys(scanned_lines, known_hosts_path)
         if warning:
             print_warning(warning)
         return HostKeyScan(

--- a/tests/unit/core/test_web_adopt_trust.py
+++ b/tests/unit/core/test_web_adopt_trust.py
@@ -508,8 +508,8 @@ class TestConfirmPersistsTrust:
         assert result.detail == "fingerprint confirmed interactively"
         out = capsys.readouterr().out
         # The path reaches the operator through the OSError rather than being
-        # interpolated from `trusted_store` (CodeQL reads that flow as a leaked
-        # secret) — it still has to be there, whichever way it arrives.
+        # interpolated a second time into the warning body — it still has to be
+        # there, whichever way it arrives.
         assert str(store) in out
         assert not store.exists()
 


### PR DESCRIPTION
Closes CodeQL alert [#2](https://github.com/get2knowio/remo/security/code-scanning/2) (`py/clear-text-logging-sensitive-data`, **high**), open on `main` against `src/remo_cli/core/output.py:41`.

## The alert

The sink is `print_warning`. The flow is `scan_and_verify_host_key`'s

```
No trusted host key for <host> in <path>.
```

and the value CodeQL classifies as a secret is the local `trusted_store` — which only ever holds `~/.ssh/known_hosts`, or a `tmp_path` override in tests. The query's sensitive-data heuristic treats any *"trusted"*-named value as a secret, so this is a naming artifact end to end: there is no secret in the flow, and the path is precisely what the operator needs in order to fix an untrusted host.

## The fix

Rename the local to `known_hosts_path` — which is what `_lookup_trusted_keys` already calls the same value in its own signature, so the module stops using two names for one thing. **No behavior change**: every message keeps its wording, and the path still reaches the operator through exactly the same lines.

The narrower workaround PR #166 added for this heuristic in `_persist_confirmed_host_keys` (naming the file only through the `OSError`, which already carries it) stays as-is — repeating the path in the warning body would just be noise. Its docstring no longer explains itself in terms of CodeQL, since the rename is now the reason the alert is gone.

The remaining "trusted"-named values in the module (`_lookup_trusted_keys`, `trusted_pairs`) hold public SSH host keys and never reach an output sink, so they are left alone.

## Verification

- `uv run pytest` — 2161 passed, 19 skipped
- `uv run mypy src/remo_cli` — clean; `uv run ruff check src/remo_cli` — clean

The alert should close on the next `main` analysis after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RcgFXhhdqGGzhk5Ardf9rk