### PR TITLE
chore(deps): force js-yaml >= 4.3.1 through the openapi-typescript chain

### DIFF
--- a/docs/maintaining-generated-types.md
+++ b/docs/maintaining-generated-types.md
@@ -100,6 +100,18 @@ If none of these checks fail because of a change you made, check whether `fastap
 alter the emitted bytes (formatting, ordering, added metadata) with zero first-party
 source change. The fix is identical either way: regenerate and commit.
 
+### The `js-yaml` override
+
+`frontend/package.json` carries one `overrides` entry, `"js-yaml": "^4.3.1"`. It exists
+only because of this toolchain: `openapi-typescript` depends on `@redocly/openapi-core`,
+which pins `js-yaml` to an exact version. When that pin last landed on a version with an
+open advisory (GHSA / CVE-2026-59870, quadratic CPU consumption in `!!omap` resolution)
+there was no upgrade path — `@redocly/openapi-core@1.x` is the tip of its line and
+`openapi-typescript` won't accept `2.x` — so the transitive resolution is forced here
+instead. Re-evaluate the entry whenever `openapi-typescript` is bumped: once the
+dependency chain resolves to a patched version on its own, the override is dead weight
+and should be deleted rather than carried forward.
+
 ## Not an external contract
 
 All four artifacts are an **internal build input** for this repository's own console —

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1668,9 +1668,9 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
-      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.1.tgz",
+      "integrity": "sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==",
       "dev": true,
       "funding": [
         {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -45,5 +45,8 @@
     "typescript": "^5",
     "vite": "^8",
     "vitest": "^4"
+  },
+  "overrides": {
+    "js-yaml": "^4.3.1"
   }
 }


### PR DESCRIPTION
Closes Dependabot alert [23](https://github.com/get2knowio/remo/security/dependabot/23) (**high**): `js-yaml` quadratic CPU consumption in `!!omap` resolution (CVE-2026-59870), fixed in `4.3.1` and never backported further down the 4.x line.

## Why an override rather than a bump

`js-yaml` is a transitive **dev** dependency with no upgrade path:

```
remo-web-frontend
`-- openapi-typescript@7.13.0        <- latest release
  `-- @redocly/openapi-core@1.34.18  <- tip of the 1.x line
    `-- js-yaml@4.3.0                <- pinned exactly by redocly
```

Redocly pins `"js-yaml": "4.3.0"` exactly. Only `@redocly/openapi-core@2.x` moved to `js-yaml ^5`, and `openapi-typescript@7.13.0` — itself the latest release — accepts only `^1.34.6`. Nothing in the chain can be bumped into a patched resolution, so `frontend/package.json` forces it:

```json
"overrides": { "js-yaml": "^4.3.1" }
```

## Risk and blast radius

Exposure was low in practice: the generator parses this repo's own `openapi.json` (JSON, not attacker-supplied YAML), and the package is dev-only — it is not in the runtime bundle or the container image. The override costs nothing either way: `4.3.1` is a patch of `4.3.0`, and `npm ci` reproduces it (`js-yaml@4.3.1 overridden`).

## Verification

- `npm ci` → clean, `npm audit` → **0 vulnerabilities** (was 1 high)
- `npm run generate:types` → both `schema.d.ts` and `terminal-frames.d.ts` come back **byte-identical**; `npm run check:types-fresh` passes (Principle IV)
- `npm run lint` clean, `npm run test` 231 passed (17 files), `npm run build` clean

Documented in `docs/maintaining-generated-types.md` next to the toolchain that caused it, including the condition for deleting the entry: once the chain resolves to a patched version on its own, the override is dead weight and should go rather than be carried forward.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RcgFXhhdqGGzhk5Ardf9rk