### PR TITLE
chore(ci): resolve the two remaining CodeQL alerts (#1 scope, #3 false positive)

### DIFF
--- a/.github/codeql/codeql-config.yml
+++ b/.github/codeql/codeql-config.yml
@@ -1,0 +1,21 @@
+name: "remo CodeQL config"
+
+# Scope the scan to code this repository actually ships.
+#
+# `docs/remo-web.html` is an 881 KB single-file design mockup produced by a
+# page bundler, checked in as the visual reference the console's design was
+# adopted from (cited by `frontend/src/theme/tokens.css` and
+# `frontend/src/state/workspace.ts`). It is not served by anything: no Pages
+# workflow publishes `docs/`, nothing links to it, and it is absent from both
+# the wheel and the container image. You open it from disk.
+#
+# Scanning it produced one alert (js/xss-through-dom) whose "DOM text" source
+# is the file's OWN embedded `<script type="__bundler/template">` literal,
+# read back at line 86 and handed to `DOMParser.parseFromString`. That is how
+# every self-unpacking bundle works; there is no external input anywhere in
+# the flow, and no origin to be cross-site against.
+#
+# Only the one file is excluded, not `docs/` -- `docs/examples/` holds real
+# cloud-init YAML, and anything executable added there later should be scanned.
+paths-ignore:
+  - docs/remo-web.html

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -37,6 +37,7 @@ jobs:
         with:
           languages: ${{ matrix.language }}
           build-mode: ${{ matrix.build-mode }}
+          config-file: .github/codeql/codeql-config.yml
 
       - name: Perform CodeQL Analysis
         uses: github/codeql-action/analyze@5595ccaf912efad79be6eef63a5619ff05969be3 # v4.37.6

--- a/src/remo_cli/web/api/setup.py
+++ b/src/remo_cli/web/api/setup.py
@@ -291,6 +291,31 @@ def _mount_configured_response() -> JSONResponse:
 
 
 def _invalid_payload(detail: str) -> JSONResponse:
+    """422 with an actionable *detail* (contracts/setup-api.md).
+
+    The detail is deliberately specific -- the CLI surfaces it verbatim as
+    ``PayloadRejectedError``, and it is the only thing telling the operator
+    which entry of their own registry the service refused.
+
+    CodeQL flags this as ``py/stack-trace-exposure`` because two of the four
+    call sites derive *detail* from a caught exception. That reading fails on
+    both prongs, so the alert is dismissed rather than coded around:
+
+    * It is not a stack trace. The ``ValidationError`` branch joins only
+      ``loc`` and ``msg`` from :meth:`pydantic.ValidationError.errors` -- never
+      ``input``, ``__traceback__``, or ``repr`` -- and
+      ``RegistryValidationError`` carries a hand-written message. Both describe
+      the caller's own submitted fields ("control characters", "fewer than 3
+      fields"); neither can reach a path or any service-side internal.
+    * There is no external user. Every route on this router sits behind
+      ``Depends(require_pairing_code)``; without a live code the whole surface
+      is a uniform 404, so reaching this response already requires the
+      operator's own single-use pairing secret.
+
+    Degrading the message to satisfy the query would cost the operator the one
+    diagnostic that makes a rejected push fixable. ``test_setup_api.py``'s
+    ``test_put_registry_invalid_payload_writes_nothing`` pins the shape.
+    """
     return JSONResponse(
         status_code=422, content={"reason": "invalid_payload", "detail": detail}
     )


### PR DESCRIPTION
Resolves the last two open CodeQL alerts. They fail for different reasons, so they get different treatment: one is a **scan-scope** fix, one is a **documented dismissal**. Neither changes runtime behavior.

---

## Alert [#1](https://github.com/get2knowio/remo/security/code-scanning/1) — `js/xss-through-dom` (high), `docs/remo-web.html:178` → excluded from the scan

`docs/remo-web.html` is an 881 KB single-file design mockup emitted by a page bundler, checked in as the visual reference the console's design was adopted from (cited by `frontend/src/theme/tokens.css:1` and `frontend/src/state/workspace.ts:5`).

**Nothing serves it.** No Pages workflow publishes `docs/`, nothing links to it, and it's in neither the wheel nor the container image. You open it from disk.

What the alert traces:

```js
// line 78
const templateEl = document.querySelector('script[type="__bundler/template"]');
// line 86
let template = JSON.parse(templateEl.textContent);   // <- the "DOM text" source
// line 178
const doc = new DOMParser().parseFromString(template, 'text/html');  // <- the sink
```

The "DOM text" is the file's **own embedded `<script type="__bundler/template">` literal**, sitting at line 219 of the same static file. That's how every self-unpacking bundle works: no external input anywhere in the flow, and no origin to be cross-site against.

So the finding isn't wrong about the *pattern* — it's wrong about the *file being in scope*. New `.github/codeql/codeql-config.yml`, wired into the `init` step via `config-file`, excludes **the single file**, not `docs/` — `docs/examples/` holds real cloud-init YAML, and anything executable added there later should still be scanned.

---

## Alert [#3](https://github.com/get2knowio/remo/security/code-scanning/3) — `py/stack-trace-exposure` (medium), `setup.py:295` → dismissed as a false positive

Flagged because two of `_invalid_payload`'s four call sites derive the detail from a caught exception. The reading fails on both prongs:

- **It is not a stack trace.** The `ValidationError` branch joins only `loc` and `msg` from `pydantic`'s `.errors()` — never `input`, `__traceback__`, or `repr` — and `RegistryValidationError` carries a hand-written message. Both describe the caller's own submitted fields (`"control characters"`, `"fewer than 3 fields"`); neither can reach a path or any service-side internal.
- **There is no external user.** Every route on this router sits behind `Depends(require_pairing_code)` (`setup.py:116`). Without a live code the whole surface is a uniform 404, so reaching this response already requires the operator's own single-use pairing secret.

The detail is also the *point*: the CLI surfaces it verbatim as `PayloadRejectedError`, and it's the only thing telling the operator which entry of their own registry was refused. Degrading it to satisfy the query would make a rejected push undiagnosable — so this commit documents the reasoning at `_invalid_payload` instead, and the alert is dismissed via the API with the same justification.

`test_setup_api.py::test_put_registry_invalid_payload_writes_nothing` pins the response shape either way.

---

## Verification

- `uv run pytest tests/unit/web/` — 320 passed, 2 skipped
- `uv run mypy src/remo_cli` clean; `uv run ruff check src/remo_cli` clean

Alert #1 should close on the next `main` analysis after merge. With #2 already fixed by #168, that leaves **zero open CodeQL alerts** and zero open Dependabot alerts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RcgFXhhdqGGzhk5Ardf9rk