### PR TITLE
fix(web): re-assert the terminal size so a dropped resize self-heals

### DIFF
--- a/frontend/src/components/TerminalCard.test.tsx
+++ b/frontend/src/components/TerminalCard.test.tsx
@@ -40,6 +40,8 @@ vi.mock("../terminal/defaultRenderer", () => ({
   }),
 }));
 
+const connections: Array<{ reassertSize: ReturnType<typeof vi.fn> }> = [];
+
 vi.mock("../terminal/TerminalConnection", () => ({
   TerminalConnection: class {
     needsManualReconnect = false;
@@ -47,6 +49,10 @@ vi.mock("../terminal/TerminalConnection", () => ({
     close = vi.fn().mockResolvedValue(undefined);
     sendInput = vi.fn();
     sendResize = vi.fn();
+    reassertSize = vi.fn();
+    constructor() {
+      connections.push(this as unknown as { reassertSize: ReturnType<typeof vi.fn> });
+    }
   },
 }));
 
@@ -71,6 +77,7 @@ async function mount(): Promise<{
 }> {
   vi.resetModules();
   adapters.length = 0;
+  connections.length = 0;
   window.localStorage.clear();
   const settings = await import("../state/settings");
   const card = await import("./TerminalCard");
@@ -251,5 +258,76 @@ describe("themeMenuPosition", () => {
     const pos = themeMenuPosition({ top: 0, bottom: 0, right: 0 }, { width: 0, height: 0 });
     expect(pos.style.maxHeight as number).toBeGreaterThan(0);
     expect(pos.style.left as number).toBeGreaterThanOrEqual(0);
+  });
+});
+
+
+// ---------------------------------------------------------------------------
+// Remote size repair on show.
+//
+// A hidden card measures 0x0, so scheduleFit skips every fit while it is away.
+// On return, a fit landing on the SAME cols/rows sends nothing — correct for
+// the local emulator, but it leaves no way to repair a remote that missed the
+// SIGWINCH for this size, and nothing else will ever re-send it. That is what
+// stranded `stty size` at 67 rows against a panel with room for 59.
+// ---------------------------------------------------------------------------
+describe("TerminalCard remote size repair", () => {
+  function renderWithVisibility(
+    TerminalCard: typeof import("./TerminalCard").TerminalCard,
+    isVisible: boolean,
+  ) {
+    return render(
+      <DndContext>
+        <TerminalCard
+          target={target}
+          mode="single"
+          isVisible={isVisible}
+          isFocused
+          viewState="normal"
+          onClose={() => {}}
+          onNormal={() => {}}
+          onToggleFullscreen={() => {}}
+        />
+      </DndContext>,
+    );
+  }
+
+  it("re-asserts the remote size when a hidden card is shown again", async () => {
+    const { card } = await mount();
+    const { rerender } = renderWithVisibility(card.TerminalCard, false);
+
+    expect(connections).toHaveLength(1);
+    const connection = connections[0];
+    // Hidden on mount: nothing to repair, and a hidden card must not touch the
+    // remote at all.
+    expect(connection.reassertSize).not.toHaveBeenCalled();
+
+    rerender(
+      <DndContext>
+        <card.TerminalCard
+          target={target}
+          mode="single"
+          isVisible
+          isFocused
+          viewState="normal"
+          onClose={() => {}}
+          onNormal={() => {}}
+          onToggleFullscreen={() => {}}
+        />
+      </DndContext>,
+    );
+
+    expect(connection.reassertSize).toHaveBeenCalledTimes(1);
+  });
+
+  it("re-asserts on mount when the card starts visible", async () => {
+    const { card } = await mount();
+    renderWithVisibility(card.TerminalCard, true);
+
+    expect(connections).toHaveLength(1);
+    // Harmless before the socket is open — sendControl drops it, and the
+    // `ready` handler re-sends the same dims — but it is the right shape: the
+    // card asserts its size whenever it is on screen.
+    expect(connections[0].reassertSize).toHaveBeenCalledTimes(1);
   });
 });

--- a/frontend/src/components/TerminalCard.tsx
+++ b/frontend/src/components/TerminalCard.tsx
@@ -483,6 +483,21 @@ export function TerminalCard({
     }
   }, [isFocused, isVisible]);
 
+  // Re-assert the remote window size whenever this card is shown.
+  //
+  // A hidden card measures 0x0, so scheduleFit skips every fit while it is
+  // away; when it comes back, a fit that lands on the SAME cols/rows sends
+  // nothing (the grid genuinely did not change). That is correct for the local
+  // emulator but leaves no way to repair a remote that missed the SIGWINCH for
+  // this size — and nothing else will ever re-send it. Showing the card is the
+  // cheapest moment to fix that: the operator is looking at this terminal, so
+  // the redraw an already-correct remote performs is free and invisible.
+  useEffect(() => {
+    if (isVisible) {
+      connectionRef.current?.reassertSize();
+    }
+  }, [isVisible]);
+
   // Measure the popup's placement before paint, and keep it anchored while it
   // is open. A grid tile can be far smaller than the list, so the menu is
   // positioned against the VIEWPORT (see ThemeMenuPosition) rather than the

--- a/frontend/src/components/WorkspacePane.test.tsx
+++ b/frontend/src/components/WorkspacePane.test.tsx
@@ -44,6 +44,9 @@ vi.mock("../terminal/TerminalConnection", () => ({
     close = vi.fn().mockResolvedValue(undefined);
     sendInput = vi.fn();
     sendResize = vi.fn();
+    // TerminalCard re-asserts the remote size whenever a card is shown, so a
+    // double that omits this throws on every render of a visible tile.
+    reassertSize = vi.fn();
   },
 }));
 

--- a/frontend/src/terminal/TerminalConnection.test.ts
+++ b/frontend/src/terminal/TerminalConnection.test.ts
@@ -145,3 +145,136 @@ describe("TerminalConnection", () => {
     expect(socket.sent.some((f) => typeof f === "string" && f.includes('"ping"'))).toBe(true);
   });
 });
+
+// ---------------------------------------------------------------------------
+// Resize re-assertion.
+//
+// A resize reaches the remote as exactly ONE SIGWINCH, and the chain below the
+// service PTY (ssh -> remote PTY -> Zellij -> the `docker exec` TTY under
+// `devcontainer exec`) has to be listening at that instant. Miss it and nothing
+// regenerates it: TerminalCard sends a given grid only once, so the remote stays
+// pinned at the stale size until the operator forces a different one by hand.
+// These pin the bounded re-assert that makes such a loss self-heal.
+// ---------------------------------------------------------------------------
+
+/** Every `resize` control frame sent on *socket*, oldest first. */
+const resizeFrames = (
+  socket: { sent: unknown[] },
+): Array<{ cols: number; rows: number }> =>
+  socket.sent
+    .filter((f): f is string => typeof f === "string")
+    .map((f) => JSON.parse(f) as { type: string; cols: number; rows: number })
+    .filter((f) => f.type === "resize")
+    .map(({ cols, rows }) => ({ cols, rows }));
+
+describe("TerminalConnection resize re-assertion", () => {
+  it("re-asserts the same dims after a resize, then stops", async () => {
+    conn = new TerminalConnection("s1", 80, 24);
+    await conn.connect();
+    last().ready();
+    const socket = last();
+    const before = resizeFrames(socket).length; // the `ready` handler's re-send
+
+    conn.sendResize(100, 40);
+    expect(resizeFrames(socket).length).toBe(before + 1);
+
+    // Three bounded re-asserts, each carrying the SAME dims: an unchanged size
+    // still makes the service signal SIGWINCH, which is the whole repair.
+    await vi.advanceTimersByTimeAsync(400);
+    await vi.advanceTimersByTimeAsync(800); // 1200 total
+    await vi.advanceTimersByTimeAsync(1800); // 3000 total
+    const afterBurst = resizeFrames(socket);
+    expect(afterBurst.length).toBe(before + 4);
+    expect(afterBurst.slice(-4)).toEqual([
+      { cols: 100, rows: 40 },
+      { cols: 100, rows: 40 },
+      { cols: 100, rows: 40 },
+      { cols: 100, rows: 40 },
+    ]);
+
+    // Bounded: no steady-state churn once the burst is spent. Every re-assert
+    // costs a remote redraw, so an unbounded loop would be a real cost.
+    await vi.advanceTimersByTimeAsync(60_000);
+    expect(resizeFrames(socket).length).toBe(before + 4);
+  });
+
+  it("a newer resize replaces the pending burst instead of stacking", async () => {
+    conn = new TerminalConnection("s1", 80, 24);
+    await conn.connect();
+    last().ready();
+    const socket = last();
+
+    // A window drag: many resizes in quick succession. Only the final size
+    // deserves a burst — stacking one per intermediate size would fire dozens
+    // of SIGWINCHes at the remote for sizes it should never see again.
+    conn.sendResize(100, 40);
+    await vi.advanceTimersByTimeAsync(100);
+    conn.sendResize(101, 41);
+    await vi.advanceTimersByTimeAsync(100);
+    conn.sendResize(102, 42);
+
+    await vi.advanceTimersByTimeAsync(5000);
+    const frames = resizeFrames(socket);
+    // The three drag frames, then exactly three re-asserts of the LAST size.
+    expect(frames.slice(-4)).toEqual([
+      { cols: 102, rows: 42 },
+      { cols: 102, rows: 42 },
+      { cols: 102, rows: 42 },
+      { cols: 102, rows: 42 },
+    ]);
+    expect(frames.filter((f) => f.cols === 100).length).toBe(1);
+    expect(frames.filter((f) => f.cols === 101).length).toBe(1);
+  });
+
+  it("reassertSize() re-sends the current dims without re-arming the burst", async () => {
+    conn = new TerminalConnection("s1", 80, 24);
+    await conn.connect();
+    last().ready();
+    const socket = last();
+
+    conn.sendResize(90, 30);
+    await vi.advanceTimersByTimeAsync(5000); // let the burst finish
+    const settled = resizeFrames(socket).length;
+
+    conn.reassertSize();
+    expect(resizeFrames(socket).length).toBe(settled + 1);
+
+    // Routing reassertSize through sendResize would re-arm the timers and the
+    // burst would never terminate.
+    await vi.advanceTimersByTimeAsync(60_000);
+    expect(resizeFrames(socket).length).toBe(settled + 1);
+    expect(resizeFrames(socket).at(-1)).toEqual({ cols: 90, rows: 30 });
+  });
+
+  it("cancels pending re-asserts when the terminal is closed", async () => {
+    conn = new TerminalConnection("s1", 80, 24);
+    await conn.connect();
+    last().ready();
+    const socket = last();
+
+    conn.sendResize(120, 50);
+    const atClose = resizeFrames(socket).length;
+    await conn.close();
+    conn = null;
+
+    await vi.advanceTimersByTimeAsync(60_000);
+    expect(resizeFrames(socket).length).toBe(atClose);
+  });
+
+  it("re-asserts the dims the remote missed while the socket was down", async () => {
+    conn = new TerminalConnection("s1", 80, 24);
+    await conn.connect();
+    last().ready();
+
+    // Resize while disconnected: sendControl drops the frame, but cols/rows are
+    // still recorded, so the reconnect's `ready` re-send carries the real size
+    // rather than the 80x24 the PTY was spawned at.
+    last().drop(1006);
+    conn.sendResize(140, 60);
+    await vi.advanceTimersByTimeAsync(500);
+    const reconnected = last();
+    reconnected.ready();
+
+    expect(resizeFrames(reconnected)[0]).toEqual({ cols: 140, rows: 60 });
+  });
+});

--- a/frontend/src/terminal/TerminalConnection.ts
+++ b/frontend/src/terminal/TerminalConnection.ts
@@ -40,6 +40,29 @@ const MAX_AUTO_RECONNECT_ATTEMPTS = 3;
 const RECONNECT_BACKOFF_MS = [500, 1500, 3500];
 /** How often to ping the WS to measure round-trip latency (also a keepalive). */
 const PING_INTERVAL_MS = 4000;
+/**
+ * Delays (ms) at which a just-sent resize is re-asserted.
+ *
+ * A resize reaches the remote as exactly ONE SIGWINCH: the service applies the
+ * winsize to its PTY and signals the child unconditionally (web/terminal.py
+ * `TerminalSession.resize`), and `ssh` only forwards a window-change when it
+ * catches that signal. Everything below — ssh, the remote PTY, Zellij, and the
+ * `docker exec` TTY that `devcontainer exec` runs Claude Code on — has to be
+ * listening at that instant. If any of them is mid-startup or busy, the signal
+ * is lost, and NOTHING regenerates it: `TerminalCard` sends a given grid only
+ * once (it skips a fit whose cols/rows are unchanged), so the remote stays
+ * pinned at the stale size until the operator forces a *different* one by hand.
+ * That is the "maximize and restore to bring the prompt back" workaround —
+ * observed as `stty size` reporting 67 rows against a panel with room for 59.
+ *
+ * Re-asserting is safe and idempotent in both directions: the service signals
+ * on every resize frame regardless of whether the size changed, so an unchanged
+ * size still produces the SIGWINCH a dropped one never will, while a remote
+ * that is already correct simply redraws to identical output. Bounded on
+ * purpose — each re-assert costs a remote redraw, so this buys convergence
+ * after a resize without any steady-state churn.
+ */
+const RESIZE_REASSERT_DELAYS_MS = [400, 1200, 3000];
 
 export interface TerminalConnectionCallbacks {
   onData?: (data: Uint8Array) => void;
@@ -79,6 +102,8 @@ export class TerminalConnection {
   private pingTimer: ReturnType<typeof setInterval> | undefined;
   /** performance.now() when the outstanding ping was sent (null if none). */
   private pingSentAt: number | null = null;
+  /** Pending re-asserts of the last-sent size (RESIZE_REASSERT_DELAYS_MS). */
+  private resizeReassertTimers: Array<ReturnType<typeof setTimeout>> = [];
 
   constructor(
     sessionTargetId: string,
@@ -121,11 +146,46 @@ export class TerminalConnection {
     this.socket.send(typeof data === "string" ? new TextEncoder().encode(data) : data);
   }
 
-  /** Sends a `resize` control frame; server clamps to safe bounds (FR-060). */
+  /** Sends a `resize` control frame; server clamps to safe bounds (FR-060).
+   *
+   * Also schedules the bounded re-assert burst (RESIZE_REASSERT_DELAYS_MS), so
+   * a SIGWINCH dropped by a busy or still-starting remote chain gets further
+   * chances instead of leaving the remote pinned at the stale size forever.
+   */
   sendResize(cols: number, rows: number): void {
     this.cols = cols;
     this.rows = rows;
     this.sendControl({ v: 1, type: "resize", cols, rows });
+    this.scheduleResizeReasserts();
+  }
+
+  /**
+   * Re-send the current dims without scheduling another burst.
+   *
+   * Deliberately NOT routed through `sendResize`: that would re-arm the timers
+   * and the burst would never terminate.
+   */
+  reassertSize(): void {
+    if (this.cols <= 0 || this.rows <= 0) {
+      return;
+    }
+    this.sendControl({ v: 1, type: "resize", cols: this.cols, rows: this.rows });
+  }
+
+  private scheduleResizeReasserts(): void {
+    // A window drag calls this many times; only the final size deserves a
+    // burst, so each call replaces the pending one rather than stacking.
+    this.clearResizeReasserts();
+    this.resizeReassertTimers = RESIZE_REASSERT_DELAYS_MS.map((delay) =>
+      setTimeout(() => this.reassertSize(), delay),
+    );
+  }
+
+  private clearResizeReasserts(): void {
+    for (const timer of this.resizeReassertTimers) {
+      clearTimeout(timer);
+    }
+    this.resizeReassertTimers = [];
   }
 
   /** Sends a `ping` control frame (keepalive / liveness probe). */
@@ -139,6 +199,7 @@ export class TerminalConnection {
     this.removeWakeListeners();
     this.stopPinging();
     this.clearReconnectTimer();
+    this.clearResizeReasserts();
     const socket = this.socket;
     const terminalId = this.terminalId;
     this.socket = null;

--- a/tests/unit/web/test_terminal_resize.py
+++ b/tests/unit/web/test_terminal_resize.py
@@ -131,3 +131,69 @@ async def test_session_resize_delivers_sigwinch_to_child():
         assert await _drain_until(b"WINCH"), "child did not receive SIGWINCH on resize"
     finally:
         await session.close()
+
+
+@pytest.mark.asyncio
+async def test_session_resize_signals_even_when_the_size_is_unchanged():
+    """Re-sending the SAME dims must still deliver SIGWINCH.
+
+    A resize reaches the remote as exactly one SIGWINCH, and everything below
+    this PTY -- ssh, the remote PTY, Zellij, and the ``docker exec`` TTY that
+    ``devcontainer exec`` runs a TUI on -- has to be listening at that instant.
+    Miss it and nothing regenerates it, so the remote stays pinned at the stale
+    size while the browser shows the correct one: observed in the field as
+    ``stty size`` reporting 67 rows against a panel with room for 59, curable
+    only by forcing a *different* size by hand (maximize, then restore).
+
+    The browser therefore re-asserts its current dims after every resize
+    (``RESIZE_REASSERT_DELAYS_MS`` in frontend/src/terminal/TerminalConnection.ts)
+    and whenever a hidden card is shown again. That repair rests entirely on
+    this property: the kernel suppresses a same-size ``TIOCSWINSZ``, so an
+    unchanged resize raises no signal of its own, and :meth:`TerminalSession.
+    resize` signalling unconditionally is the only reason a re-assert is worth
+    anything. Gate that here -- "skip the signal when nothing changed" looks
+    like a safe optimisation and would silently restore the bug.
+    """
+    child = (
+        "import signal,sys,time\n"
+        "signal.signal(signal.SIGWINCH, lambda *a: (sys.stdout.write('WINCH\\n'), sys.stdout.flush()))\n"
+        "sys.stdout.write('READY\\n'); sys.stdout.flush()\n"
+        "time.sleep(5)\n"
+    )
+    session = TerminalSession([sys.executable, "-u", "-c", child], cols=80, rows=24)
+    await session.start()
+
+    async def _drain_until(marker: bytes, timeout: float = 3.0) -> bool:
+        acc = bytearray()
+
+        async def _pump() -> bool:
+            while True:
+                chunk = await session.read_output()
+                if not chunk:
+                    return False
+                acc.extend(chunk)
+                if marker in acc:
+                    return True
+
+        try:
+            return await asyncio.wait_for(_pump(), timeout)
+        except (TimeoutError, asyncio.TimeoutError):
+            return False
+
+    try:
+        assert await _drain_until(b"READY"), "child never started"
+
+        session.resize(120, 40)
+        assert await _drain_until(b"WINCH"), "no SIGWINCH on the initial resize"
+        assert _read_winsize(session._master_fd) == (120, 40)  # noqa: SLF001
+
+        # The re-assert: identical dims, nothing for the kernel to change.
+        session.resize(120, 40)
+        assert await _drain_until(b"WINCH"), (
+            "re-asserting the same size delivered no SIGWINCH — a remote that "
+            "missed the first one can no longer be repaired without the "
+            "operator forcing a different size by hand"
+        )
+        assert _read_winsize(session._master_fd) == (120, 40)  # noqa: SLF001
+    finally:
+        await session.close()


### PR DESCRIPTION
Closes the hole that made "maximize and restore to bring the prompt back into
view" a necessary workaround.

## What was actually wrong

A resize reaches the remote as exactly **one** SIGWINCH. The service applies the
winsize to its PTY and signals the child unconditionally — the child `ssh` runs
in its own session without the slave PTY as its controlling terminal, so a
master-side `TIOCSWINSZ` raises nothing on its own — and `ssh` only forwards a
window-change when it *catches* that signal. Everything below (ssh → remote PTY
→ Zellij → the `docker exec` TTY that `devcontainer exec` runs Claude Code on)
has to be listening at that instant.

Miss it and **nothing regenerates it**. `TerminalCard` sends a given grid once:
a fit whose cols/rows are unchanged is correctly read as "the local emulator
needs nothing", and that silently doubles as "the remote already knows" — which
it may not. The remote stays pinned at the stale size until the operator forces
a *different* one by hand.

Reported symptom: `stty size` showing **67 rows against a panel with room for
59**, Claude Code's input box drawn below the visible area.

## This is not a fit bug — the client was measured clean first

Before changing anything, I ran the real `XtermRenderer` and the real
`TerminalCard.css`/`WorkspacePane.css` box chain in headless Chromium and
measured every hypothesis:

| Hypothesis | Result |
|---|---|
| Emulator taller than its `overflow:hidden` box | never — `rows` always equalled what fits |
| Header show/hide, maximize/restore leaving a stale fit | clean |
| Viewport drifting off the bottom (incl. wrapping content, reflow) | `viewportY == baseY` throughout |
| Bottom-anchored UI redrawing after each resize | bottom row always inside the viewport |
| DPR change (zoom / different-DPI display) | no effect |
| Card hidden across a resize, then reshown | clean |
| `FitAddon` silently bailing out | never observed |

The reported `cols` was **identical** across the failure (217 both times), which
independently rules out the font path — a font-size change always moves `cols`
too (measured: 111 → 74 → 66 → 95).

## The fix

Two repairs, both bounded:

- **After each resize**, re-assert the same dims at 400/1200/3000 ms. A new
  resize *replaces* the pending burst rather than stacking, so a window drag
  fires one burst for the final size, not one per intermediate size. Bounded on
  purpose — every re-assert costs a remote redraw, so an unbounded loop would be
  real churn across up to 32 terminals.
- **Whenever a card is shown.** A hidden card measures 0x0 and skips every fit
  while away; on return, a fit landing on the same grid sends nothing. This is
  the one moment a stale remote can be repaired, and the operator is looking at
  that terminal — so an already-correct remote's redraw is free and invisible.

`reassertSize()` deliberately does **not** route through `sendResize`; that
would re-arm the timers and the burst would never terminate.

## The property it all rests on

Re-asserting only works because the service signals SIGWINCH **even when the
size did not change** — the kernel suppresses a same-size `TIOCSWINSZ`, so
otherwise every re-assert would be a silent no-op.

That was load-bearing and untested. `test_session_resize_signals_even_when_the_size_is_unchanged`
now pins it, and I mutation-checked it: adding a `"nothing changed, nothing to
do"` early return to `TerminalSession.resize` fails the test with a message
naming the consequence. That optimisation looks safe and would silently restore
this bug.

## Notes

- Both `TerminalConnection` test doubles gained `reassertSize`; the one in
  `WorkspacePane.test.tsx` threw on every visible tile without it — optional
  chaining guards a null connection, not a missing method.
- No service behaviour change, no schema change, no new dependency.

## Verification

```
uv run pytest                  # 2188 passed, 19 skipped
uv run ruff check src/remo_cli # clean
uv run mypy src/remo_cli       # clean
npm run lint && npm run test   # 238 passed
npm run build                  # ok
npm run check:types-fresh      # no drift
```

**Not verified against the live failure** — it needs the real ssh → Zellij →
devcontainer chain. The check is that the stale state stops recurring, and that
`stty size` inside a panel matches the panel without maximize/restore.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RcgFXhhdqGGzhk5Ardf9rk